### PR TITLE
chore: add OCI standard labels to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,19 @@ RUN apk add --no-cache ca-certificates tzdata setpriv \
 COPY --from=builder --chmod=555 /out/maintenant /app/maintenant
 COPY --chmod=555 docker-entrypoint.sh /docker-entrypoint.sh
 
+ARG VERSION=dev
+ARG COMMIT=unknown
+ARG BUILD_DATE=unknown
+LABEL org.opencontainers.image.title="maintenant" \
+      org.opencontainers.image.description="Monitor everything. Manage nothing." \
+      org.opencontainers.image.url="https://github.com/kOlapsis/maintenant" \
+      org.opencontainers.image.source="https://github.com/kOlapsis/maintenant" \
+      org.opencontainers.image.vendor="kOlapsis" \
+      org.opencontainers.image.licenses="AGPL-3.0-or-later" \
+      org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.revision="${COMMIT}" \
+      org.opencontainers.image.created="${BUILD_DATE}"
+
 EXPOSE 8080
 VOLUME /data
 


### PR DESCRIPTION
## Context

Add [OCI (Open Container Initiative)](https://github.com/opencontainers/image-spec/blob/main/annotations.md) standard labels to the final stage of the Dockerfile for better image metadata and container registry compatibility.

## Type

Improvement — metadata only, no functional changes.

## Labels Added

| Label | Value | Source |
|-------|-------|--------|
| `org.opencontainers.image.title` | `maintenant` | Static |
| `org.opencontainers.image.description` | `Monitor everything. Manage nothing.` | Static |
| `org.opencontainers.image.url` | `https://github.com/kOlapsis/maintenant` | Static |
| `org.opencontainers.image.source` | `https://github.com/kOlapsis/maintenant` | Static |
| `org.opencontainers.image.vendor` | `kOlapsis` | Static |
| `org.opencontainers.image.licenses` | `AGPL-3.0-or-later` | Static |
| `org.opencontainers.image.version` | `${VERSION}` | Build arg (already passed by CI) |
| `org.opencontainers.image.revision` | `${COMMIT}` | Build arg (already passed by CI) |
| `org.opencontainers.image.created` | `${BUILD_DATE}` | Build arg (already passed by CI) |

## Implementation Note

The workflow uses a multi-platform "build by digest + merge manifest" pattern. `docker/metadata-action` runs in the `merge` job, but `imagetools create` creates a manifest list from pre-built image digests and cannot retroactively embed labels into image configs — labels must be set at build time.

This PR embeds labels directly in the Dockerfile's final stage (`alpine:3.21`). The three dynamic labels reuse the existing `VERSION`, `COMMIT`, and `BUILD_DATE` build args that are already passed to `docker/build-push-action` in the `build` job — no CI changes needed.

## Benefits

- **Registry compatibility**: GHCR displays title, description, license, and source link in the package UI
- **Dependency bot changelogs**: Renovate and Dependabot use `org.opencontainers.image.source` to link release notes in update PRs
- **Image provenance**: `revision` (git SHA) and `created` (build timestamp) enable precise build auditing
- **Standardization**: follows OCI Image Spec best practices for container metadata

## Changes

- `Dockerfile`: added `ARG` re-declarations and `LABEL` block to the final `alpine:3.21` stage (after `COPY`, before `EXPOSE`) — 13 lines added, no existing instructions modified

## Verification

After merge and CI rebuild:
```sh
docker pull ghcr.io/kolapsis/maintenant:latest
docker inspect ghcr.io/kolapsis/maintenant:latest --format '{{ json .Config.Labels }}' | jq
```

## References

- [OCI Image Spec — Annotations](https://github.com/opencontainers/image-spec/blob/main/annotations.md)
- [Renovate Docker datasource](https://docs.renovatebot.com/modules/datasource/docker/)
- [Docker — Manage tags and labels](https://docs.docker.com/build/ci/github-actions/manage-tags-labels/)