### PR TITLE
feat(certificates): trust an internal CA, and report untrusted hosts …

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,3 +48,8 @@ MAINTENANT_DB=./maintenant.db
 # MAINTENANT_SMTP_USERNAME=alerts@example.com
 # MAINTENANT_SMTP_PASSWORD=secret
 # MAINTENANT_SMTP_FROM=maintenant@example.com
+
+# Extra root CA to trust, for hosts signed by an internal PKI (step-ca, AD CS...).
+# Added to the system roots, never replacing them. Mount it readable by uid 65534.
+# Prefer this over SSL_CERT_FILE, which replaces the whole bundle and fails silently.
+# MAINTENANT_CA_CERT=/etc/maintenant/ca.pem

--- a/cmd/maintenant/main.go
+++ b/cmd/maintenant/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/kolapsis/maintenant/internal/agent"
 	"github.com/kolapsis/maintenant/internal/app"
 	_ "github.com/kolapsis/maintenant/internal/kubernetes"
+	"github.com/kolapsis/maintenant/internal/trust"
 )
 
 var (
@@ -45,6 +46,7 @@ func main() {
 	fTLSCert := flag.String("grpc-tls-cert", "", "TLS certificate file (server mode)")
 	fTLSKey := flag.String("grpc-tls-key", "", "TLS key file (server mode)")
 	fInsecureSkip := flag.Bool("grpc-insecure-skip-tls-verify", false, "disable TLS verification (debug only)")
+	fCACert := flag.String("ca-cert", "", "PEM bundle of extra root CAs to trust, added to the system store")
 	fEmbeddedAgent := flag.Bool("embedded-agent", false, "also run a local agent (server mode, Pro)")
 
 	// flag.Parse handles --foo and -foo; ignore unknown flags for --mcp-stdio compat.
@@ -72,6 +74,20 @@ func main() {
 	cfg.BuildDate = buildDate
 	cfg.PublicKeyB64 = publicKeyB64
 	cfg.Mode = *fMode
+
+	if *fCACert != "" {
+		cfg.CACertFile = *fCACert
+	}
+	// Loaded before anything can probe: both server and agent modes run from
+	// here, and a bad path must stop the process rather than turn every TLS
+	// check into a misleading "unknown authority".
+	if err := trust.Load(cfg.CACertFile); err != nil {
+		logger.Error("failed to load extra CA bundle", "error", err)
+		os.Exit(1)
+	}
+	if cfg.CACertFile != "" {
+		logger.Info("extra CA bundle trusted", "path", cfg.CACertFile)
+	}
 
 	// CLI overrides for MultiHost config
 	if *fGRPCListen != "" {

--- a/docs/features/certificates.md
+++ b/docs/features/certificates.md
@@ -52,6 +52,41 @@ If any certificate in the chain is invalid, expired, or missing, maintenant fire
 
 ---
 
+## Trusting an internal CA
+
+If you run your own PKI — step-ca, Smallstep, an internal Active Directory CA — point maintenant at your root certificate:
+
+```yaml
+services:
+  maintenant:
+    environment:
+      MAINTENANT_CA_CERT: /etc/maintenant/ca.pem
+    volumes:
+      - ./ca.pem:/etc/maintenant/ca.pem:ro
+```
+
+The bundle is **added** to the system roots, so public CAs keep working. It applies to endpoint probes, certificate monitoring, webhooks and SMTP alike. A CLI equivalent exists for one-off runs: `--ca-cert /path/to/ca.pem`.
+
+Three things to watch out for:
+
+- **The file must be readable by uid 65534.** The container drops to an unprivileged user, and a root-owned `0600` file — the default output of most CA tooling — will not be readable. `chmod 644` the copy you mount.
+- **Provide it to whichever process performs the check.** An endpoint attached to an agent is probed by that agent, on its own host. Setting the variable on the server changes nothing for it.
+- **Do not use `SSL_CERT_FILE` for this.** Go treats it as a *replacement* for the system bundle, not an addition, so every public CA disappears the moment you set it. Worse, if the file cannot be read, Go returns an empty trust store with no error at all and every HTTPS check starts failing with "unknown authority" and nothing in the logs. `MAINTENANT_CA_CERT` refuses to start instead.
+
+A bad path, an unreadable file, or a PEM with no certificate in it all stop the process with an explicit message rather than silently degrading every check.
+
+---
+
+## Untrusted certificates are degraded, not down
+
+A host that answers normally but presents a certificate maintenant cannot validate is reported as **degraded** (orange), not **down** (red). The host is not the problem — its chain of trust is. It keeps counting as available in uptime, and raises a `certificate_untrusted` alert at *warning* severity instead of a critical outage.
+
+The certificate is still collected in this state, so expiry monitoring keeps working on internal-PKI hosts even before you configure the CA.
+
+A host that is genuinely unreachable — timeout, DNS failure, connection refused — remains **down**.
+
+---
+
 ## Alert Events
 
 | Event | Description | Severity |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -95,3 +95,22 @@ volumes:
 ```
 
 Replace `1000` with the UID of the user running the rootless daemon (`id -u` on the host). The `group_add` configuration is not required in rootless mode — the socket is owned by the user, not by a `docker` group.
+
+## An HTTPS host shows as down (or degraded) with "unknown authority"
+
+The host is answering; maintenant just refuses to trust the certificate it presents. Since it is reachable, it is reported as **degraded** rather than down.
+
+If the certificate comes from your own PKI, trust the root instead of disabling verification:
+
+```yaml
+environment:
+  MAINTENANT_CA_CERT: /etc/maintenant/ca.pem
+volumes:
+  - ./ca.pem:/etc/maintenant/ca.pem:ro
+```
+
+Make sure the mounted file is readable by uid **65534** — the container runs unprivileged, and a root-owned `0600` file will not be read. If the endpoint is attached to an agent, set this on the **agent**: it is the one performing the probe.
+
+Do not reach for `SSL_CERT_FILE`. Go treats it as a replacement for the whole system bundle rather than an addition, so setting it drops every public CA, and an unreadable file yields an empty trust store with no error reported.
+
+As a last resort you can turn verification off for a single container endpoint with the label `maintenant.endpoint.http.tls-verify=false`, but that also stops expiry and hostname checks for it.

--- a/frontend/src/components/EndpointCard.vue
+++ b/frontend/src/components/EndpointCard.vue
@@ -162,7 +162,7 @@ function formatResponseTime(ms: number | undefined): string {
     </div>
 
     <div
-      v-if="endpoint.last_error && endpoint.status === 'down'"
+      v-if="endpoint.last_error && (endpoint.status === 'down' || endpoint.status === 'degraded')"
       class="mt-2 truncate rounded px-2 py-1 text-xs"
       :style="{
         backgroundColor: 'var(--mnt-status-down-bg)',

--- a/frontend/src/components/EndpointDetail.vue
+++ b/frontend/src/components/EndpointDetail.vue
@@ -226,7 +226,7 @@ watch(() => props.endpointId, () => {
 
       <!-- Last error -->
       <div
-        v-if="endpoint.last_error && endpoint.status === 'down'"
+        v-if="endpoint.last_error && (endpoint.status === 'down' || endpoint.status === 'degraded')"
         class="mb-6 break-words rounded-lg px-3 py-2 text-xs"
         :style="{ backgroundColor: 'var(--mnt-status-down-bg)', color: 'var(--mnt-status-down)' }"
       >

--- a/frontend/src/components/EndpointEventTimeline.vue
+++ b/frontend/src/components/EndpointEventTimeline.vue
@@ -15,7 +15,7 @@
 import { computed, ref } from 'vue'
 import type { CheckResult } from '@/services/endpointApi'
 
-type EpStatus = 'up' | 'down' | 'unknown'
+type EpStatus = 'up' | 'down' | 'degraded' | 'unknown'
 
 const props = withDefaults(defineProps<{
   checks: CheckResult[]
@@ -36,6 +36,7 @@ const tooltip = ref<{ visible: boolean; x: number; y: number; status: EpStatus; 
 const statusColors: Record<EpStatus, string> = {
   up: 'var(--mnt-status-ok)',
   down: 'var(--mnt-status-down)',
+  degraded: 'var(--mnt-status-warn)',
   unknown: 'var(--mnt-sev-unknown)',
 }
 
@@ -50,7 +51,10 @@ function statusOpacity(status: EpStatus): string {
 }
 
 function statusLabel(status: EpStatus): string {
-  return status === 'up' ? 'Up' : status === 'down' ? 'Down' : 'No data'
+  if (status === 'up') return 'Up'
+  if (status === 'down') return 'Down'
+  if (status === 'degraded') return 'Degraded'
+  return 'No data'
 }
 
 const timeWindow = computed(() => {

--- a/frontend/src/components/EndpointStatusBadge.vue
+++ b/frontend/src/components/EndpointStatusBadge.vue
@@ -9,12 +9,14 @@ import StatusBadge from '@/components/ui/StatusBadge.vue'
 import type { Severity } from '@/composables/useSeverity'
 
 const props = defineProps<{
-  status: 'up' | 'down' | 'unknown'
+  status: 'up' | 'down' | 'degraded' | 'unknown'
 }>()
 
-const map: Record<'up' | 'down' | 'unknown', { severity: Severity; label: string }> = {
+const map: Record<'up' | 'down' | 'degraded' | 'unknown', { severity: Severity; label: string }> = {
   up: { severity: 'ok', label: 'Up' },
   down: { severity: 'incident', label: 'Down' },
+  // Reachable, but over a certificate we do not trust — a warning, not an outage.
+  degraded: { severity: 'warning', label: 'Degraded' },
   unknown: { severity: 'unknown', label: 'Unknown' },
 }
 const cfg = computed(() => map[props.status])

--- a/frontend/src/pages/EndpointsPage.vue
+++ b/frontend/src/pages/EndpointsPage.vue
@@ -341,6 +341,12 @@ onUnmounted(() => {
       <span class="rounded-full bg-mnt-status-down text-mnt-status-down px-3 py-1 font-medium">
         {{ store.statusCounts.down }} down
       </span>
+      <span
+        v-if="store.statusCounts.degraded > 0"
+        class="rounded-full bg-mnt-status-warn text-mnt-status-warn px-3 py-1 font-medium"
+      >
+        {{ store.statusCounts.degraded }} degraded
+      </span>
       <span class="rounded-full bg-mnt-sev-unknown text-mnt-sev-unknown px-3 py-1 font-medium">
         {{ store.statusCounts.unknown }} unknown
       </span>
@@ -356,6 +362,7 @@ onUnmounted(() => {
         <option value="">All statuses</option>
         <option value="up">Up</option>
         <option value="down">Down</option>
+        <option value="degraded">Degraded</option>
         <option value="unknown">Unknown</option>
       </select>
 

--- a/frontend/src/services/endpointApi.ts
+++ b/frontend/src/services/endpointApi.ts
@@ -37,7 +37,7 @@ export interface Endpoint {
   agent_offline?: boolean
   target: string
   label_key: string
-  status: 'up' | 'down' | 'unknown'
+  status: 'up' | 'down' | 'degraded' | 'unknown'
   alert_state: 'normal' | 'alerting'
   consecutive_failures: number
   consecutive_successes: number

--- a/frontend/src/stores/dashboard.ts
+++ b/frontend/src/stores/dashboard.ts
@@ -66,6 +66,8 @@ function endpointStatus(e: Endpoint): { status: UnifiedStatus; label: string } {
   if (e.stale) return { status: 'unknown', label: 'Agent offline' }
   if (e.status === 'up') return { status: 'ok', label: 'Up' }
   if (e.status === 'down') return { status: 'down', label: 'Down' }
+  // Reachable, but its certificate is not trusted.
+  if (e.status === 'degraded') return { status: 'warning', label: 'Degraded' }
   return { status: 'unknown', label: 'Unknown' }
 }
 

--- a/frontend/src/stores/endpoints.ts
+++ b/frontend/src/stores/endpoints.ts
@@ -59,7 +59,7 @@ export const useEndpointsStore = defineStore('endpoints', () => {
   })
 
   const statusCounts = computed(() => {
-    const counts = { up: 0, down: 0, unknown: 0 }
+    const counts = { up: 0, down: 0, degraded: 0, unknown: 0 }
     for (const ep of endpoints.value) {
       if (ep.status in counts) {
         counts[ep.status as keyof typeof counts]++

--- a/internal/agent/prober.go
+++ b/internal/agent/prober.go
@@ -159,7 +159,10 @@ func scanCertsOnce(ctx context.Context, agentID string, ld labeledDiscoverer, se
 // carried in url so the server can resolve the monitor by (agent_id, target).
 func endpointEvent(agentID, target string, r endpoint.CheckResult) *agentpb.AgentEvent {
 	status := agentpb.EndpointStatus_ENDPOINT_STATUS_DOWN
-	if r.Success {
+	switch {
+	case r.Success && r.Degraded:
+		status = agentpb.EndpointStatus_ENDPOINT_STATUS_DEGRADED
+	case r.Success:
 		status = agentpb.EndpointStatus_ENDPOINT_STATUS_UP
 	}
 	var code uint32

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -39,6 +39,10 @@ type Config struct {
 	CORSOrigins string
 	MaxBodySize int64
 
+	// CACertFile is a PEM bundle appended to the system roots, so endpoints and
+	// certificates signed by an internal PKI validate without disabling checks.
+	CACertFile string
+
 	// Branding
 	OrgName string
 
@@ -132,6 +136,7 @@ func ConfigFromEnv() Config {
 
 		CORSOrigins: os.Getenv("MAINTENANT_CORS_ORIGINS"),
 		MaxBodySize: 1048576,
+		CACertFile:  os.Getenv("MAINTENANT_CA_CERT"),
 
 		OrgName:   envOr("MAINTENANT_ORGANISATION_NAME", "Maintenant"),
 		StatusURL: os.Getenv("MAINTENANT_STATUS_URL"),

--- a/internal/app/status.go
+++ b/internal/app/status.go
@@ -44,6 +44,9 @@ func EndpointStatus(ep *endpoint.Endpoint) string {
 		return status.StatusOperational
 	case endpoint.StatusDown:
 		return status.StatusMajorOutage
+	case endpoint.StatusDegraded:
+		// Serving, but over a certificate we do not trust: not an outage.
+		return status.StatusDegraded
 	default:
 		return status.StatusOperational
 	}

--- a/internal/app/wiring.go
+++ b/internal/app/wiring.go
@@ -129,6 +129,45 @@ func (a *App) wireAlertCallbacks(alertDetector *alert.EndpointAlertDetector) {
 	a.endpointSvc.SetAlertCallback(func(ep *endpoint.Endpoint, result endpoint.CheckResult) (string, any) {
 		a.statusSvc.NotifyMonitorChanged(ctx, "endpoint", ep.ID)
 
+		epName := ep.ContainerName
+		if epName == "" {
+			epName = ep.Name
+		}
+
+		// Certificate trust is independent of the failure thresholds: a degraded
+		// host is answering, so it never trips them. Raise it as its own warning
+		// and clear it once the chain verifies. Both directions are idempotent —
+		// the engine dedups the alert and ignores a recovery with nothing active.
+		switch {
+		case result.Degraded:
+			sendAlert(alert.Event{
+				Source:     alert.SourceEndpoint,
+				AlertType:  "certificate_untrusted",
+				Severity:   alert.SeverityWarning,
+				Message:    fmt.Sprintf("Endpoint %s is reachable but its certificate is not trusted: %s", ep.Target, result.DegradedReason),
+				EntityType: "endpoint",
+				EntityID:   ep.ID,
+				EntityName: epName,
+				Details: map[string]any{
+					"target": ep.Target,
+					"reason": result.DegradedReason,
+				},
+				Timestamp: result.Timestamp,
+			})
+		case result.Success:
+			sendAlert(alert.Event{
+				Source:     alert.SourceEndpoint,
+				AlertType:  "certificate_untrusted",
+				Severity:   alert.SeverityInfo,
+				IsRecover:  true,
+				Message:    fmt.Sprintf("Endpoint %s now presents a trusted certificate", ep.Target),
+				EntityType: "endpoint",
+				EntityID:   ep.ID,
+				EntityName: epName,
+				Timestamp:  result.Timestamp,
+			})
+		}
+
 		al := alertDetector.EvaluateCheckResult(ep, result)
 		if al == nil {
 			return "", nil

--- a/internal/certificate/checker.go
+++ b/internal/certificate/checker.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"golang.org/x/crypto/ocsp"
+
+	"github.com/kolapsis/maintenant/internal/trust"
 )
 
 // CheckCertificateResult holds the raw result of a TLS certificate check.
@@ -195,7 +197,10 @@ func validateChain(leaf *x509.Certificate, intermediates []*x509.Certificate, ho
 	opts := x509.VerifyOptions{
 		DNSName:       hostname,
 		Intermediates: pool,
-		// Roots: nil uses system CA pool
+		// nil falls back to the system pool. Without this the endpoint probe
+		// would go green on an internal CA while the monitor kept reporting an
+		// untrusted root.
+		Roots: trust.Pool(),
 	}
 
 	_, err := leaf.Verify(opts)

--- a/internal/endpoint/agent_event.go
+++ b/internal/endpoint/agent_event.go
@@ -36,9 +36,14 @@ func (s *Service) HandleAgentEvent(ctx context.Context, agentID string, ev *agen
 	}
 
 	statusCode := int(ev.GetStatusCode())
+	// Degraded is a success: the agent reached the host, only its certificate
+	// is untrusted. Collapsing it into the boolean would report it as down.
+	degraded := ev.GetStatus() == agentpb.EndpointStatus_ENDPOINT_STATUS_DEGRADED
 	result := CheckResult{
 		EndpointID:     ep.ID,
-		Success:        ev.GetStatus() == agentpb.EndpointStatus_ENDPOINT_STATUS_UP,
+		Success:        ev.GetStatus() == agentpb.EndpointStatus_ENDPOINT_STATUS_UP || degraded,
+		Degraded:       degraded,
+		DegradedReason: ev.GetErrorMessage(),
 		ResponseTimeMs: int64(ev.GetLatencyMs()), // #nosec G115 -- probe latency in ms, never approaches int64
 		HTTPStatus:     &statusCode,
 		ErrorMessage:   ev.GetErrorMessage(),

--- a/internal/endpoint/checker_http.go
+++ b/internal/endpoint/checker_http.go
@@ -3,6 +3,8 @@ package endpoint
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -10,6 +12,8 @@ import (
 	"net/url"
 	"sync"
 	"time"
+
+	"github.com/kolapsis/maintenant/internal/trust"
 )
 
 // warnedLinkLocal tracks endpoints for which a link-local warning has been emitted.
@@ -32,58 +36,70 @@ func CheckHTTP(ctx context.Context, ep *Endpoint, logger interface{ Warn(string,
 	// Check for link-local addresses (T009)
 	warnLinkLocal(ep, logger)
 
-	transport := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: !cfg.TLSVerify, // #nosec G402 -- per-endpoint opt-out configured by the user.
-			MinVersion:         tls.VersionTLS12,
-		},
-		DialContext: (&net.Dialer{
-			Timeout: timeout,
-		}).DialContext,
-		ResponseHeaderTimeout: timeout,
-	}
-
-	maxRedirects := cfg.MaxRedirects
-	if maxRedirects < 0 {
-		maxRedirects = 0
-	}
-
-	client := &http.Client{
-		Transport: transport,
-		Timeout:   timeout,
-		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			if len(via) >= maxRedirects {
-				return http.ErrUseLastResponse
-			}
-			return nil
-		},
-	}
-	defer client.CloseIdleConnections()
-
 	method := cfg.Method
 	if method == "" {
 		method = "GET"
 	}
 
-	req, err := http.NewRequestWithContext(ctx, method, ep.Target, nil)
+	newRequest := func() (*http.Request, error) {
+		req, err := http.NewRequestWithContext(ctx, method, ep.Target, nil)
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("User-Agent", "maintenant/1.0")
+		for k, v := range cfg.Headers {
+			req.Header.Set(k, v)
+		}
+		return req, nil
+	}
+
+	client := newHTTPClient(cfg, timeout, !cfg.TLSVerify)
+	defer client.CloseIdleConnections()
+
+	req, err := newRequest()
 	if err != nil {
 		result.ResponseTimeMs = time.Since(start).Milliseconds()
 		result.ErrorMessage = fmt.Sprintf("create request: %v", err)
 		return result
 	}
 
-	req.Header.Set("User-Agent", "maintenant/1.0")
-	for k, v := range cfg.Headers {
-		req.Header.Set(k, v)
-	}
-
 	resp, err := client.Do(req)
-	result.ResponseTimeMs = time.Since(start).Milliseconds()
 
 	if err != nil {
-		result.ErrorMessage = fmt.Sprintf("request failed: %v", err)
-		return result
+		reason, isTrustFailure := trustFailureReason(err)
+		if !isTrustFailure {
+			result.ResponseTimeMs = time.Since(start).Milliseconds()
+			result.ErrorMessage = fmt.Sprintf("request failed: %v", err)
+			return result
+		}
+
+		// The certificate was rejected, but that says nothing about whether the
+		// host is serving. Retry once without verification purely to find out:
+		// a host behind an internal PKI that answers is degraded, not down. The
+		// retry never yields "up" — it only tells the two apart, and it hands
+		// back the chain so expiry monitoring keeps working on these hosts.
+		insecure := newHTTPClient(cfg, timeout, true)
+		defer insecure.CloseIdleConnections()
+
+		retryReq, reqErr := newRequest()
+		if reqErr != nil {
+			result.ResponseTimeMs = time.Since(start).Milliseconds()
+			result.ErrorMessage = fmt.Sprintf("create request: %v", reqErr)
+			return result
+		}
+
+		resp, err = insecure.Do(retryReq)
+		if err != nil {
+			result.ResponseTimeMs = time.Since(start).Milliseconds()
+			result.ErrorMessage = fmt.Sprintf("request failed: %v", err)
+			return result
+		}
+
+		result.Degraded = true
+		result.DegradedReason = reason
 	}
+
+	result.ResponseTimeMs = time.Since(start).Milliseconds()
 	defer func(Body io.ReadCloser) {
 		_ = Body.Close()
 	}(resp.Body)
@@ -103,7 +119,77 @@ func CheckHTTP(ctx context.Context, ep *Endpoint, logger interface{ Warn(string,
 		result.ErrorMessage = fmt.Sprintf("unexpected status %d", statusCode)
 	}
 
+	// Surface the trust problem either way: on its own when the host is
+	// otherwise healthy, appended when it is also returning a bad status.
+	if result.Degraded {
+		if result.ErrorMessage == "" {
+			result.ErrorMessage = result.DegradedReason
+		} else {
+			result.ErrorMessage += "; " + result.DegradedReason
+		}
+	}
+
 	return result
+}
+
+// newHTTPClient builds the probe client. skipVerify is used both for the
+// per-endpoint opt-out and for the diagnostic retry after a rejected certificate.
+func newHTTPClient(cfg EndpointConfig, timeout time.Duration, skipVerify bool) *http.Client {
+	maxRedirects := cfg.MaxRedirects
+	if maxRedirects < 0 {
+		maxRedirects = 0
+	}
+
+	return &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: skipVerify, // #nosec G402 -- per-endpoint opt-out, or the diagnostic retry that classifies a rejected certificate.
+				MinVersion:         tls.VersionTLS12,
+				RootCAs:            trust.Pool(), // nil unless an extra CA was configured: system store
+			},
+			DialContext:           (&net.Dialer{Timeout: timeout}).DialContext,
+			ResponseHeaderTimeout: timeout,
+		},
+		Timeout: timeout,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= maxRedirects {
+				return http.ErrUseLastResponse
+			}
+			return nil
+		},
+	}
+}
+
+// trustFailureReason reports whether err is the peer's certificate being
+// rejected — as opposed to the host being unreachable — and describes it in
+// terms an operator can act on.
+func trustFailureReason(err error) (string, bool) {
+	var unknownAuthority x509.UnknownAuthorityError
+	if errors.As(err, &unknownAuthority) {
+		return "certificate signed by an unknown authority", true
+	}
+
+	var hostname x509.HostnameError
+	if errors.As(err, &hostname) {
+		return "certificate is not valid for this hostname", true
+	}
+
+	var invalid x509.CertificateInvalidError
+	if errors.As(err, &invalid) {
+		if invalid.Reason == x509.Expired {
+			return "certificate has expired", true
+		}
+		return fmt.Sprintf("certificate is not valid: %v", invalid), true
+	}
+
+	// Go wraps verification failures in this type; the cases above unwrap
+	// through it, so reaching here means a kind we have not named yet.
+	var verification *tls.CertificateVerificationError
+	if errors.As(err, &verification) {
+		return "certificate verification failed", true
+	}
+
+	return "", false
 }
 
 // warnLinkLocal logs a warning (once per endpoint) if the target resolves to a link-local or loopback address.

--- a/internal/endpoint/checker_http_tls_test.go
+++ b/internal/endpoint/checker_http_tls_test.go
@@ -1,0 +1,174 @@
+// Copyright 2026 Benjamin Touchard (Kolapsis)
+//
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+// or a commercial license. You may not use this file except in compliance
+// with one of these licenses.
+//
+// AGPL-3.0: https://www.gnu.org/licenses/agpl-3.0.html
+// Commercial: See COMMERCIAL-LICENSE.md
+//
+// Source: https://github.com/kolapsis/maintenant
+
+package endpoint
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kolapsis/maintenant/internal/trust"
+)
+
+func httpEndpoint(target string) *Endpoint {
+	return &Endpoint{
+		ID:           "ep-tls",
+		EndpointType: TypeHTTP,
+		Target:       target,
+		Config:       DefaultConfig(),
+	}
+}
+
+// Issue #36: a host answering over a certificate signed by an unknown authority
+// is not down. It must report as degraded, keep counting as a success, and still
+// surrender its certificate chain so expiry monitoring keeps working.
+func TestCheckHTTP_UntrustedCertificateIsDegradedNotDown(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	// httptest's certificate is signed by an authority nothing trusts, which is
+	// exactly the reporter's internal-PKI situation.
+	result := CheckHTTP(context.Background(), httpEndpoint(srv.URL), nil)
+
+	assert.True(t, result.Success, "a reachable host must not count as a failure")
+	assert.True(t, result.Degraded, "an untrusted certificate must mark the check degraded")
+	assert.Contains(t, result.DegradedReason, "unknown authority")
+	assert.Contains(t, result.ErrorMessage, "unknown authority",
+		"the reason must reach the UI through last_error")
+	require.NotNil(t, result.HTTPStatus)
+	assert.Equal(t, http.StatusOK, *result.HTTPStatus)
+	assert.NotEmpty(t, result.TLSPeerCertificates,
+		"the chain must still be captured, or expiry monitoring silently stops for these hosts")
+}
+
+// The same host, trusted: no retry, no degradation.
+func TestCheckHTTP_TrustedCertificateIsUp(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	// Trust the test server's own certificate the way an operator would: through
+	// MAINTENANT_CA_CERT, exercising the real load path.
+	caPath := filepath.Join(t.TempDir(), "ca.pem")
+	require.NoError(t, os.WriteFile(caPath,
+		pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: srv.Certificate().Raw}), 0o600))
+	require.NoError(t, trust.Load(caPath))
+	t.Cleanup(func() { _ = trust.Load("") })
+
+	result := CheckHTTP(context.Background(), httpEndpoint(srv.URL), nil)
+
+	assert.True(t, result.Success)
+	assert.False(t, result.Degraded, "a trusted chain must not be reported as degraded")
+	assert.Empty(t, result.ErrorMessage)
+}
+
+// A genuinely unreachable host stays down — the retry must not paper over it.
+func TestCheckHTTP_UnreachableHostStaysDown(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
+	target := srv.URL
+	srv.Close() // nothing is listening any more
+
+	result := CheckHTTP(context.Background(), httpEndpoint(target), nil)
+
+	assert.False(t, result.Success)
+	assert.False(t, result.Degraded, "a connection failure is not a trust problem")
+	assert.Contains(t, result.ErrorMessage, "request failed")
+}
+
+// An untrusted certificate on a host that also answers badly is still down: the
+// status check governs, and the trust problem is reported alongside it.
+func TestCheckHTTP_UntrustedAndBadStatusIsDown(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	result := CheckHTTP(context.Background(), httpEndpoint(srv.URL), nil)
+
+	assert.False(t, result.Success, "a 500 is a failure regardless of the certificate")
+	assert.Contains(t, result.ErrorMessage, "unexpected status 500")
+	assert.Contains(t, result.ErrorMessage, "unknown authority",
+		"both problems must be visible, not just the first")
+}
+
+// With verification switched off per endpoint, nothing is degraded.
+func TestCheckHTTP_TLSVerifyDisabledIsPlainUp(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	ep := httpEndpoint(srv.URL)
+	ep.Config.TLSVerify = false
+
+	result := CheckHTTP(context.Background(), ep, nil)
+
+	assert.True(t, result.Success)
+	assert.False(t, result.Degraded)
+}
+
+func TestTrustFailureReason(t *testing.T) {
+	reason, ok := trustFailureReason(x509.UnknownAuthorityError{})
+	assert.True(t, ok)
+	assert.Contains(t, reason, "unknown authority")
+
+	reason, ok = trustFailureReason(x509.HostnameError{Host: "wrong.example.com"})
+	assert.True(t, ok)
+	assert.Contains(t, reason, "hostname")
+
+	reason, ok = trustFailureReason(x509.CertificateInvalidError{Reason: x509.Expired})
+	assert.True(t, ok)
+	assert.Contains(t, reason, "expired")
+
+	// Wrapped the way crypto/tls and net/http actually deliver it.
+	wrapped := &tls.CertificateVerificationError{Err: x509.UnknownAuthorityError{}}
+	reason, ok = trustFailureReason(wrapped)
+	assert.True(t, ok)
+	assert.Contains(t, reason, "unknown authority", "must unwrap to the specific cause")
+
+	_, ok = trustFailureReason(errors.New("connection refused"))
+	assert.False(t, ok, "a transport error is not a trust failure")
+
+	_, ok = trustFailureReason(nil)
+	assert.False(t, ok)
+}
+
+func TestCheckHTTP_DegradedResolvesToDegradedStatus(t *testing.T) {
+	// Guards the classification itself, independently of the probe.
+	cases := []struct {
+		name     string
+		result   CheckResult
+		expected EndpointStatus
+	}{
+		{"reachable and trusted", CheckResult{Success: true}, StatusUp},
+		{"reachable but untrusted", CheckResult{Success: true, Degraded: true}, StatusDegraded},
+		{"unreachable", CheckResult{}, StatusDown},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, statusForResult(tc.result))
+		})
+	}
+}

--- a/internal/endpoint/model.go
+++ b/internal/endpoint/model.go
@@ -59,9 +59,12 @@ const (
 type EndpointStatus string
 
 const (
-	StatusUp      EndpointStatus = "up"
-	StatusDown    EndpointStatus = "down"
-	StatusUnknown EndpointStatus = "unknown"
+	StatusUp   EndpointStatus = "up"
+	StatusDown EndpointStatus = "down"
+	// StatusDegraded is reachable and serving, but its certificate is not
+	// trusted. Distinct from down: the host is not the problem, its chain is.
+	StatusDegraded EndpointStatus = "degraded"
+	StatusUnknown  EndpointStatus = "unknown"
 )
 
 // AlertState represents the current alert state of an endpoint.
@@ -107,13 +110,18 @@ func (e *Endpoint) ConfigJSON() string {
 
 // CheckResult represents a single probe result for an endpoint.
 type CheckResult struct {
-	ID                  string              `json:"id"`
-	EndpointID          string              `json:"endpoint_id"`
-	Success             bool                `json:"success"`
-	ResponseTimeMs      int64               `json:"response_time_ms"`
-	HTTPStatus          *int                `json:"http_status,omitempty"`
-	ErrorMessage        string              `json:"error_message,omitempty"`
-	Timestamp           time.Time           `json:"timestamp"`
+	ID             string    `json:"id"`
+	EndpointID     string    `json:"endpoint_id"`
+	Success        bool      `json:"success"`
+	ResponseTimeMs int64     `json:"response_time_ms"`
+	HTTPStatus     *int      `json:"http_status,omitempty"`
+	ErrorMessage   string    `json:"error_message,omitempty"`
+	Timestamp      time.Time `json:"timestamp"`
+	// Degraded marks a host that answered but whose certificate we refuse to
+	// trust. Success stays true — it is reachable and serving — so uptime is
+	// unaffected and only the status and alert severity change.
+	Degraded            bool                `json:"degraded,omitempty"`
+	DegradedReason      string              `json:"degraded_reason,omitempty"`
 	TLSPeerCertificates []*x509.Certificate `json:"-"`
 	TLSOCSPResponse     []byte              `json:"-"`
 	AgentID             string              `json:"agent_id"`

--- a/internal/endpoint/service.go
+++ b/internal/endpoint/service.go
@@ -304,6 +304,21 @@ func (s *Service) SyncAgentEndpoints(ctx context.Context, agentID, containerName
 	}
 }
 
+// statusForResult maps a probe outcome to the endpoint's reported status. A
+// degraded host is reachable and serving, so it stays a success everywhere that
+// matters — uptime, consecutive counters, outage alerting — and differs only in
+// the status it shows.
+func statusForResult(result CheckResult) EndpointStatus {
+	switch {
+	case result.Success && result.Degraded:
+		return StatusDegraded
+	case result.Success:
+		return StatusUp
+	default:
+		return StatusDown
+	}
+}
+
 // ProcessCheckResult handles a check result: updates the endpoint state and persists the result.
 func (s *Service) ProcessCheckResult(ctx context.Context, endpointID string, result CheckResult) {
 	ep, err := s.store.GetEndpointByID(ctx, endpointID)
@@ -314,13 +329,11 @@ func (s *Service) ProcessCheckResult(ctx context.Context, endpointID string, res
 
 	previousStatus := ep.Status
 
-	var newStatus EndpointStatus
+	newStatus := statusForResult(result)
 	if result.Success {
-		newStatus = StatusUp
 		ep.ConsecutiveSuccesses++
 		ep.ConsecutiveFailures = 0
 	} else {
-		newStatus = StatusDown
 		ep.ConsecutiveFailures++
 		ep.ConsecutiveSuccesses = 0
 	}

--- a/internal/store/sqlite/endpoints_degraded_test.go
+++ b/internal/store/sqlite/endpoints_degraded_test.go
@@ -1,0 +1,102 @@
+// Copyright 2026 Benjamin Touchard (Kolapsis)
+//
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+// or a commercial license. You may not use this file except in compliance
+// with one of these licenses.
+//
+// AGPL-3.0: https://www.gnu.org/licenses/agpl-3.0.html
+// Commercial: See COMMERCIAL-LICENSE.md
+//
+// Source: https://github.com/kolapsis/maintenant
+
+package sqlite
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// downgradeEndpointsStatusCheck restores the pre-degraded CHECK, standing in for
+// a database converted before the state existed.
+const downgradeEndpointsStatusCheck = `
+DROP TABLE endpoints;
+CREATE TABLE endpoints (
+    id              TEXT PRIMARY KEY NOT NULL,
+    agent_id        TEXT NOT NULL DEFAULT '00000000-0000-0000-0000-000000000000' REFERENCES agents(id) ON DELETE CASCADE,
+    container_name  TEXT NOT NULL,
+    label_key       TEXT NOT NULL,
+    external_id     TEXT NOT NULL,
+    endpoint_type   TEXT NOT NULL CHECK(endpoint_type IN ('http','tcp')),
+    target          TEXT NOT NULL,
+    status          TEXT NOT NULL DEFAULT 'unknown' CHECK(status IN ('up','down','unknown')),
+    alert_state     TEXT NOT NULL DEFAULT 'normal' CHECK(alert_state IN ('normal','alerting')),
+    consecutive_failures  INTEGER NOT NULL DEFAULT 0,
+    consecutive_successes INTEGER NOT NULL DEFAULT 0,
+    last_check_at         BIGINT,
+    last_response_time_ms BIGINT,
+    last_http_status      INTEGER,
+    last_error      TEXT,
+    config_json     TEXT NOT NULL DEFAULT '{}',
+    active          INTEGER NOT NULL DEFAULT 1,
+    first_seen_at   BIGINT NOT NULL,
+    last_seen_at    BIGINT NOT NULL,
+    source          TEXT NOT NULL DEFAULT 'label' CHECK(source IN ('label','standalone')),
+    name            TEXT NOT NULL DEFAULT '',
+    UNIQUE(agent_id, container_name, label_key)
+);
+INSERT INTO endpoints (id, container_name, label_key, external_id, endpoint_type, target,
+                       status, first_seen_at, last_seen_at)
+VALUES ('legacy-ep', 'web', 'http', 'ext-1', 'http', 'https://legacy.example.com',
+        'up', 1700000000, 1700000000);
+`
+
+func TestRebuildEndpointsForDegraded(t *testing.T) {
+	db := openTestDB(t)
+	rw := db.ReadDB()
+	ctx := context.Background()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	_, err := rw.ExecContext(ctx, downgradeEndpointsStatusCheck)
+	require.NoError(t, err)
+
+	// Before the rebuild the state is rejected outright — this is what an
+	// upgraded install would hit on the first degraded check.
+	_, err = rw.ExecContext(ctx, `UPDATE endpoints SET status='degraded' WHERE id='legacy-ep'`)
+	require.Error(t, err, "the old CHECK must reject 'degraded'")
+
+	require.NoError(t, rebuildEndpointsForDegraded(ctx, rw, logger))
+
+	ddl := scanString(t, rw, `SELECT sql FROM sqlite_master WHERE type='table' AND name='endpoints'`)
+	require.Contains(t, ddl, endpointStatusConstraint)
+
+	// The row survived, and the state now persists.
+	require.Equal(t, "legacy-ep", scanString(t, rw, `SELECT id FROM endpoints`))
+	_, err = rw.ExecContext(ctx, `UPDATE endpoints SET status='degraded' WHERE id='legacy-ep'`)
+	require.NoError(t, err)
+	require.Equal(t, "degraded", scanString(t, rw, `SELECT status FROM endpoints`))
+
+	// Indexes were recreated after the DROP TABLE.
+	var indexes int
+	require.NoError(t, rw.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND tbl_name='endpoints' AND name LIKE 'idx_%'`).Scan(&indexes))
+	require.Equal(t, 5, indexes)
+
+	// Second run is a no-op.
+	require.NoError(t, rebuildEndpointsForDegraded(ctx, rw, logger))
+	require.Equal(t, ddl, scanString(t, rw, `SELECT sql FROM sqlite_master WHERE type='table' AND name='endpoints'`))
+	require.Equal(t, "degraded", scanString(t, rw, `SELECT status FROM endpoints`))
+}
+
+// The rebuild's CREATE TABLE must embed the exact constraint string the
+// idempotency guard looks for, or fresh installs would be rebuilt on every boot.
+func TestEndpointStatusConstraint_MatchesSchema(t *testing.T) {
+	schema, err := os.ReadFile("uuid_schema.sql")
+	require.NoError(t, err)
+	require.True(t, strings.Contains(string(schema), endpointStatusConstraint),
+		"uuid_schema.sql must contain %q verbatim — the rebuild guard depends on it", endpointStatusConstraint)
+}

--- a/internal/store/sqlite/migrations.go
+++ b/internal/store/sqlite/migrations.go
@@ -98,6 +98,12 @@ func Migrate(db *sql.DB, logger *slog.Logger) error {
 		return fmt.Errorf("cert sni rebuild: %w", err)
 	}
 
+	// One-time rebuild widening the endpoint status CHECK to accept 'degraded',
+	// for databases converted before that state existed.
+	if err := rebuildEndpointsForDegraded(context.Background(), db, logger); err != nil {
+		return fmt.Errorf("endpoint degraded rebuild: %w", err)
+	}
+
 	return nil
 }
 

--- a/internal/store/sqlite/transform_endpoint_degraded.go
+++ b/internal/store/sqlite/transform_endpoint_degraded.go
@@ -1,0 +1,147 @@
+// Copyright 2026 Benjamin Touchard (Kolapsis)
+//
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+// or a commercial license. You may not use this file except in compliance
+// with one of these licenses.
+//
+// AGPL-3.0: https://www.gnu.org/licenses/agpl-3.0.html
+// Commercial: See COMMERCIAL-LICENSE.md
+//
+// Source: https://github.com/kolapsis/maintenant
+
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+)
+
+// endpointStatusConstraint is the status CHECK allowing the degraded state. It
+// must stay byte-identical to the endpoints DDL in uuid_schema.sql — SQLite
+// stores the CREATE TABLE text verbatim and the idempotency guard matches on it.
+const endpointStatusConstraint = "CHECK(status IN ('up','down','degraded','unknown'))"
+
+// rebuildEndpointsForDegraded widens the endpoint status CHECK to accept
+// 'degraded' on databases converted to the UUID schema before that state
+// existed. SQLite cannot alter a CHECK constraint, so the table is rebuilt once;
+// fresh installs and databases converted by this release get it straight from
+// uuid_schema.sql and skip the rebuild.
+//
+// This runs after convertToUUID rather than as a numbered migration on purpose:
+// migrations execute against the legacy integer schema, where the endpoints
+// table does not have agent_id yet, so one SQL file cannot serve both shapes.
+func rebuildEndpointsForDegraded(ctx context.Context, db *sql.DB, logger *slog.Logger) error {
+	var ddl string
+	err := db.QueryRowContext(ctx,
+		`SELECT sql FROM sqlite_master WHERE type='table' AND name='endpoints'`).Scan(&ddl)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("endpoint degraded rebuild: probe ddl: %w", err)
+	}
+	if strings.Contains(ddl, endpointStatusConstraint) {
+		return nil
+	}
+
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("endpoint degraded rebuild: acquire conn: %w", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	if _, err := conn.ExecContext(ctx, "PRAGMA foreign_keys=OFF"); err != nil {
+		return fmt.Errorf("endpoint degraded rebuild: fk off: %w", err)
+	}
+
+	logger.Info("endpoint degraded-status rebuild starting")
+
+	if err := runEndpointDegradedRebuild(ctx, conn); err != nil {
+		return err
+	}
+
+	if err := foreignKeyCheck(ctx, conn); err != nil {
+		return err
+	}
+	if _, err := conn.ExecContext(ctx, "PRAGMA foreign_keys=ON"); err != nil {
+		return fmt.Errorf("endpoint degraded rebuild: fk on: %w", err)
+	}
+
+	logger.Info("endpoint degraded-status rebuild complete")
+	return nil
+}
+
+// runEndpointDegradedRebuild performs the table rebuild inside one transaction.
+func runEndpointDegradedRebuild(ctx context.Context, conn *sql.Conn) error {
+	tx, err := conn.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("endpoint degraded rebuild: begin: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	stmts := []stmt{
+		// Keep this CREATE TABLE byte-identical to uuid_schema.sql.
+		{"create table", `CREATE TABLE endpoints_new (
+    id              TEXT PRIMARY KEY NOT NULL,              -- uid.EndpointLabel(agent,container,label) or minted (standalone)
+    agent_id        TEXT NOT NULL DEFAULT '00000000-0000-0000-0000-000000000000' REFERENCES agents(id) ON DELETE CASCADE,
+    container_name  TEXT NOT NULL,
+    label_key       TEXT NOT NULL,
+    external_id     TEXT NOT NULL,
+    endpoint_type   TEXT NOT NULL CHECK(endpoint_type IN ('http','tcp')),
+    target          TEXT NOT NULL,
+    status          TEXT NOT NULL DEFAULT 'unknown' ` + endpointStatusConstraint + `,
+    alert_state     TEXT NOT NULL DEFAULT 'normal' CHECK(alert_state IN ('normal','alerting')),
+    consecutive_failures  INTEGER NOT NULL DEFAULT 0,
+    consecutive_successes INTEGER NOT NULL DEFAULT 0,
+    last_check_at         BIGINT,
+    last_response_time_ms BIGINT,
+    last_http_status      INTEGER,
+    last_error      TEXT,
+    config_json     TEXT NOT NULL DEFAULT '{}',
+    active          INTEGER NOT NULL DEFAULT 1,
+    first_seen_at   BIGINT NOT NULL,
+    last_seen_at    BIGINT NOT NULL,
+    source          TEXT NOT NULL DEFAULT 'label' CHECK(source IN ('label','standalone')),
+    name            TEXT NOT NULL DEFAULT '',
+    UNIQUE(agent_id, container_name, label_key)
+)`},
+		{"copy rows", `INSERT INTO endpoints_new
+			(id, agent_id, container_name, label_key, external_id, endpoint_type, target,
+			 status, alert_state, consecutive_failures, consecutive_successes, last_check_at,
+			 last_response_time_ms, last_http_status, last_error, config_json, active,
+			 first_seen_at, last_seen_at, source, name)
+			SELECT id, agent_id, container_name, label_key, external_id, endpoint_type, target,
+			 status, alert_state, consecutive_failures, consecutive_successes, last_check_at,
+			 last_response_time_ms, last_http_status, last_error, config_json, active,
+			 first_seen_at, last_seen_at, source, name
+			FROM endpoints`},
+		{"drop old table", `DROP TABLE endpoints`},
+		{"rename", `ALTER TABLE endpoints_new RENAME TO endpoints`},
+		// DROP TABLE removed the old table's indexes — recreate them all.
+		{"index external_id", `CREATE INDEX idx_endpoint_external_id ON endpoints(external_id)`},
+		{"index status", `CREATE INDEX idx_endpoint_status ON endpoints(status) WHERE active=1`},
+		{"index active", `CREATE INDEX idx_endpoint_active ON endpoints(active, last_seen_at DESC)`},
+		{"index source", `CREATE INDEX idx_endpoint_source ON endpoints(source) WHERE active=1`},
+		{"index agent_id", `CREATE INDEX idx_endpoints_agent_id ON endpoints(agent_id)`},
+	}
+	for _, s := range stmts {
+		if _, err := tx.ExecContext(ctx, s.sql); err != nil {
+			return fmt.Errorf("endpoint degraded rebuild: %s: %w", s.desc, err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("endpoint degraded rebuild: commit: %w", err)
+	}
+	committed = true
+	return nil
+}

--- a/internal/store/sqlite/uuid_schema.sql
+++ b/internal/store/sqlite/uuid_schema.sql
@@ -167,7 +167,7 @@ CREATE TABLE endpoints (
     external_id     TEXT NOT NULL,
     endpoint_type   TEXT NOT NULL CHECK(endpoint_type IN ('http','tcp')),
     target          TEXT NOT NULL,
-    status          TEXT NOT NULL DEFAULT 'unknown' CHECK(status IN ('up','down','unknown')),
+    status          TEXT NOT NULL DEFAULT 'unknown' CHECK(status IN ('up','down','degraded','unknown')),
     alert_state     TEXT NOT NULL DEFAULT 'normal' CHECK(alert_state IN ('normal','alerting')),
     consecutive_failures  INTEGER NOT NULL DEFAULT 0,
     consecutive_successes INTEGER NOT NULL DEFAULT 0,

--- a/internal/trust/trust.go
+++ b/internal/trust/trust.go
@@ -1,0 +1,69 @@
+// Copyright 2026 Benjamin Touchard (Kolapsis)
+//
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+// or a commercial license. You may not use this file except in compliance
+// with one of these licenses.
+//
+// AGPL-3.0: https://www.gnu.org/licenses/agpl-3.0.html
+// Commercial: See COMMERCIAL-LICENSE.md
+//
+// Source: https://github.com/kolapsis/maintenant
+
+// Package trust holds the root certificates used to validate the TLS endpoints
+// and certificates we monitor.
+//
+// It exists because Go's own escape hatch is a trap for this use case:
+// SSL_CERT_FILE *replaces* the system bundle rather than extending it, so
+// pointing it at an internal root silently drops every public CA — and when the
+// file cannot be read, crypto/x509 returns an empty pool with a nil error, so
+// every check fails as "unknown authority" with nothing in the logs. Operators
+// running an internal PKI need to add a root, not swap the whole store.
+package trust
+
+import (
+	"crypto/x509"
+	"fmt"
+	"os"
+	"sync/atomic"
+)
+
+// pool is written once at startup, before any check runs, and only read
+// afterwards. atomic.Pointer keeps that contract explicit and race-free.
+var pool atomic.Pointer[x509.CertPool]
+
+// Load reads a PEM bundle and appends it to the system roots. Any failure is
+// returned rather than swallowed: a misconfigured CA path must stop the process,
+// not degrade every TLS check into a confusing "unknown authority".
+func Load(path string) error {
+	// An empty path clears any previously loaded bundle, so Load fully describes
+	// the desired state rather than only ever adding to it.
+	if path == "" {
+		pool.Store(nil)
+		return nil
+	}
+
+	pem, err := os.ReadFile(path) // #nosec G304 -- operator-supplied CA bundle path, read once at startup.
+	if err != nil {
+		return fmt.Errorf("read CA bundle %s: %w", path, err)
+	}
+
+	roots, err := x509.SystemCertPool()
+	if err != nil {
+		return fmt.Errorf("load system CA pool: %w", err)
+	}
+
+	if !roots.AppendCertsFromPEM(pem) {
+		return fmt.Errorf("CA bundle %s contains no valid PEM certificate", path)
+	}
+
+	pool.Store(roots)
+	return nil
+}
+
+// Pool returns the roots to validate against, or nil when no extra CA was
+// loaded. Nil is meaningful: both tls.Config.RootCAs and x509.VerifyOptions.Roots
+// read it as "use the system store", so an install without a custom CA keeps
+// exactly the behaviour it had before this package existed.
+func Pool() *x509.CertPool {
+	return pool.Load()
+}

--- a/internal/trust/trust_test.go
+++ b/internal/trust/trust_test.go
@@ -1,0 +1,133 @@
+// Copyright 2026 Benjamin Touchard (Kolapsis)
+//
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+// or a commercial license. You may not use this file except in compliance
+// with one of these licenses.
+//
+// AGPL-3.0: https://www.gnu.org/licenses/agpl-3.0.html
+// Commercial: See COMMERCIAL-LICENSE.md
+//
+// Source: https://github.com/kolapsis/maintenant
+
+package trust
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// resetPool clears the package state so each test starts from "no extra CA".
+func resetPool(t *testing.T) {
+	t.Helper()
+	t.Cleanup(func() { pool.Store(nil) })
+	pool.Store(nil)
+}
+
+// writeCA generates a self-signed CA and writes it as PEM, returning its path.
+func writeCA(t *testing.T, dir string) (string, *x509.Certificate) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "maintenant-test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	path := filepath.Join(dir, "ca.pem")
+	require.NoError(t, os.WriteFile(path, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), 0o600))
+
+	parsed, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+	return path, parsed
+}
+
+// An install with no custom CA must behave exactly as before this package:
+// a nil pool tells crypto/tls and crypto/x509 to use the system store.
+func TestPool_NilWhenUnconfigured(t *testing.T) {
+	resetPool(t)
+
+	require.NoError(t, Load(""))
+	assert.Nil(t, Pool(), "an empty path must leave the system store untouched")
+}
+
+func TestLoad_AppendsToSystemRoots(t *testing.T) {
+	resetPool(t)
+
+	path, ca := writeCA(t, t.TempDir())
+	require.NoError(t, Load(path))
+
+	p := Pool()
+	require.NotNil(t, p)
+
+	// The custom root is trusted...
+	_, err := ca.Verify(x509.VerifyOptions{Roots: p})
+	assert.NoError(t, err, "the loaded CA must be trusted by the resulting pool")
+
+	// ...and it did not replace the store, which is what SSL_CERT_FILE does.
+	// Compared against a pool holding only our CA: they must differ, meaning the
+	// system roots are still in there. (Subjects() is useless here — it returns
+	// nothing for a system-derived pool.)
+	onlyCustom := x509.NewCertPool()
+	onlyCustom.AddCert(ca)
+	assert.False(t, p.Equal(onlyCustom),
+		"the pool must be the system store plus our CA, not our CA on its own")
+}
+
+// The whole point of this package: a misconfiguration is loud. SSL_CERT_FILE
+// answers an unreadable file with an empty pool and a nil error.
+func TestLoad_MissingFileIsAnError(t *testing.T) {
+	resetPool(t)
+
+	err := Load(filepath.Join(t.TempDir(), "absent.pem"))
+
+	require.Error(t, err)
+	assert.Nil(t, Pool(), "a failed load must not leave a half-built pool behind")
+}
+
+func TestLoad_UnreadableFileIsAnError(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses file permissions")
+	}
+	resetPool(t)
+
+	path := filepath.Join(t.TempDir(), "ca.pem")
+	require.NoError(t, os.WriteFile(path, []byte("whatever"), 0o000))
+
+	err := Load(path)
+
+	require.Error(t, err, "an unreadable bundle is the exact case SSL_CERT_FILE swallows")
+	assert.Nil(t, Pool())
+}
+
+func TestLoad_NonCertificateContentIsAnError(t *testing.T) {
+	resetPool(t)
+
+	path := filepath.Join(t.TempDir(), "notacert.pem")
+	require.NoError(t, os.WriteFile(path, []byte("-----BEGIN NONSENSE-----\nzzz\n-----END NONSENSE-----\n"), 0o600))
+
+	err := Load(path)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no valid PEM certificate")
+	assert.Nil(t, Pool())
+}


### PR DESCRIPTION
Closes #36.

**Internal CA.** New `MAINTENANT_CA_CERT` (and `--ca-cert`): a PEM bundle appended to the system roots, applied to both endpoint probes and chain validation. Loaded before either mode starts, so agents get it too. An invalid path or an empty PEM stops the process at startup.

A dedicated variable rather than `SSL_CERT_FILE`, which replaces the system bundle instead of extending it and fails silently when the file cannot be read.

**Classification.** A rejected certificate now triggers one retry without verification. If the host answers, the status is `degraded`: counted as available in uptime, with a `certificate_untrusted` alert at warning severity. Timeout, DNS failure and refused connections stay `down`.

That retry also recovers the chain, which was lost whenever the handshake failed ? expiry monitoring works again on these hosts.

**Notes**
- No proto change: `ENDPOINT_STATUS_DEGRADED` already existed. The agent path, which collapsed anything but UP into `down`, is fixed.
- The status `CHECK` is widened by a post-conversion rebuild rather than a numbered migration: migrations run before the UUID conversion, where `endpoints` has no `agent_id`. Same pattern as `rebuildCertMonitorsForSNI` (#34).
- Frontend: the `warning` severity already existed, endpoints just had to be wired to it.

**Validation** : `go test -race ./...` and `-tags=integration`, golangci-lint, gosec, eslint, vitest, type-check, npm audit.