### PR TITLE
fix(frontend): react to auth-proxy session expiry instead of showing a broken UI

### DIFF
--- a/compose.authproxy.yml
+++ b/compose.authproxy.yml
@@ -1,0 +1,116 @@
+# Auth-proxy lab: Maintenant behind an OIDC login, to exercise the session
+# expiry handling (frontend/src/services/authGuard.ts).
+#
+#   docker compose -f compose.authproxy.yml up -d
+#   open http://localhost:8088   →   admin@lab.test / password
+#
+# Everything is served from localhost on purpose: a service worker only
+# registers on a secure origin, and http://something.local is not one. Without
+# the service worker the very bug this lab reproduces (cached app shell booting
+# on a dead session) cannot happen.
+#
+# See deploy/authproxy-lab/README.md for the test scenarios.
+
+# Own project name: without it Compose would adopt — and recreate — the
+# containers of compose.local.yml, which declares a `maintenant` service too.
+name: maintenant-authlab
+
+services:
+  # Not published: the only way in is through the proxy.
+  maintenant:
+    image: ghcr.io/kolapsis/maintenant
+    build:
+      context: .
+      args:
+        - VERSION=dev
+        - COMMIT=xxxxx
+        - BUILD_DATE=2026-03-01
+        - LICENSE_PUBLIC_KEY=XRnZAk+VcCWdtsNrIsJZ4GBKKzbP6RyH/EO0F4qYdyI=
+    container_name: authlab-maintenant
+    restart: unless-stopped
+    read_only: true
+    security_opt:
+      - no-new-privileges:true
+    tmpfs:
+      - /tmp:noexec,nosuid,size=64m
+    volumes:
+      - authlab_data:/data
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /proc:/host/proc:ro
+    environment:
+      MAINTENANT_LOG_LEVEL: debug
+      MAINTENANT_ADDR: "0.0.0.0:8080"
+      MAINTENANT_GRPC_LISTEN: "0.0.0.0:8443"
+      MAINTENANT_DB: "/data/maintenant.db"
+      MAINTENANT_BASE_URL: "http://localhost:8088"
+      MAINTENANT_ORGANISATION_NAME: "Auth lab"
+      MAINTENANT_DISABLE_TELEMETRY: true
+      # No licence on purpose: Pro endpoints answer a JSON 403 (PRO_REQUIRED),
+      # which the guard must NOT mistake for an expired session.
+    networks:
+      - authlab
+
+  # Owns the network namespace shared with oauth2-proxy, hence both published
+  # ports. Publishing them from oauth2-proxy instead would be a startup cycle.
+  dex:
+    image: ghcr.io/dexidp/dex:v2.44.0
+    container_name: authlab-dex
+    restart: unless-stopped
+    command: ["dex", "serve", "/etc/dex/config.yaml"]
+    volumes:
+      - ./deploy/authproxy-lab/dex.yaml:/etc/dex/config.yaml:ro
+    ports:
+      - "8088:4180"   # oauth2-proxy → the app
+      - "5556:5556"   # dex → the login form
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O-", "http://localhost:5556/dex/.well-known/openid-configuration"]
+      interval: 3s
+      timeout: 2s
+      retries: 20
+    networks:
+      - authlab
+
+  oauth2-proxy:
+    image: quay.io/oauth2-proxy/oauth2-proxy:v7.13.0
+    container_name: authlab-oauth2-proxy
+    restart: unless-stopped
+    # Shares dex's namespace so http://localhost:5556/dex is a single valid
+    # issuer URL for the browser and for the proxy alike.
+    network_mode: "service:dex"
+    depends_on:
+      dex:
+        condition: service_healthy
+      maintenant:
+        condition: service_started
+    # Setting `prompt` is what suppresses the legacy approval_prompt=force the
+    # proxy sends otherwise — which makes dex raise a "Grant Access" screen on
+    # every re-auth round-trip, whatever skipApprovalScreen says.
+    command: ["--prompt=login"]
+    environment:
+      OAUTH2_PROXY_HTTP_ADDRESS: "0.0.0.0:4180"
+      OAUTH2_PROXY_UPSTREAMS: "http://maintenant:8080"
+      OAUTH2_PROXY_PROVIDER: oidc
+      OAUTH2_PROXY_OIDC_ISSUER_URL: "http://localhost:5556/dex"
+      OAUTH2_PROXY_CLIENT_ID: maintenant
+      OAUTH2_PROXY_CLIENT_SECRET: maintenant-lab-secret
+      OAUTH2_PROXY_REDIRECT_URL: "http://localhost:8088/oauth2/callback"
+      OAUTH2_PROXY_COOKIE_SECRET: "JOA9A-EsluWxAA7sTWCK5UasgS419L4Afw06WzeTLJ0="
+      OAUTH2_PROXY_EMAIL_DOMAINS: "*"
+      # Straight to the provider, no "Sign in with…" interstitial.
+      OAUTH2_PROXY_SKIP_PROVIDER_BUTTON: "true"
+      OAUTH2_PROXY_COOKIE_SECURE: "false"
+      # Lab only — lets the console one-liner in the README kill the session.
+      OAUTH2_PROXY_COOKIE_HTTPONLY: "false"
+      # Lower it (1m) to watch the session die on its own.
+      OAUTH2_PROXY_COOKIE_EXPIRE: "${AUTHLAB_COOKIE_EXPIRE:-30m}"
+      # SSE would otherwise be buffered for a second at a time.
+      OAUTH2_PROXY_FLUSH_INTERVAL: "100ms"
+      # Uncomment to answer API calls with a bare 401 instead of a 302 to the
+      # provider — the other branch of isAuthChallenge().
+      # OAUTH2_PROXY_API_ROUTES: "^/api/"
+
+volumes:
+  authlab_data:
+
+networks:
+  authlab:

--- a/deploy/authproxy-lab/README.md
+++ b/deploy/authproxy-lab/README.md
@@ -1,0 +1,54 @@
+# Auth-proxy lab
+
+Maintenant behind an OIDC login, to exercise the session-expiry handling in
+`frontend/src/services/authGuard.ts` without a VM and without touching DNS.
+
+    docker compose -f compose.authproxy.yml up -d
+    # http://localhost:8088 → admin@lab.test / password
+
+- `oauth2-proxy` fronts the app; nothing else is published.
+- `dex` is the OIDC provider: in-memory, one static user, restart wipes it.
+- Add `--build` to rebuild the app image after a frontend change.
+
+Everything is on `localhost` on purpose. A service worker only registers on a
+secure origin, and `http://anything.local` is not one — on a `.local` name the
+app shell is never cached, and the bug this lab reproduces (cached shell booting
+on a dead session) cannot happen at all. A `.local` variant would need HTTPS and
+a CA trusted by the browser.
+
+## Killing the session
+
+The session lives in the `_oauth2_proxy` cookie. From the browser console:
+
+```js
+document.cookie.split(';').map(c => c.trim().split('=')[0])
+  .filter(n => n.startsWith('_oauth2_proxy'))
+  .forEach(n => { document.cookie = `${n}=; Max-Age=0; path=/` })
+```
+
+The cookie is deliberately not `HttpOnly` here so that one-liner works. To watch
+a session die on its own instead:
+
+    AUTHLAB_COOKIE_EXPIRE=1m docker compose -f compose.authproxy.yml up -d
+
+## Scenarios
+
+1. **Expiry while the tab is open** — kill the cookie, then let the app poll or
+   click through a page. Expected: the overlay, then a round-trip to dex.
+2. **Boot on a dead session** — kill the cookie, then reload. This is the
+   original bug: the service worker replays the cached shell, so the SPA boots
+   with no session at all.
+3. **Re-auth that does not stick** — kill the cookie again within 15s of the
+   previous round-trip. The loop guard fires: the overlay stays put in its
+   stalled state, with a "Sign in again" button, instead of bouncing forever.
+4. **A JSON 403 is not an expired session** — the lab runs Community edition, so
+   Pro endpoints answer `403 PRO_REQUIRED`. Nothing should ever appear.
+
+## Two flavours of challenge
+
+By default the proxy answers unauthenticated API calls with a `302` to dex.
+Because dex is another origin, the browser blocks the redirected response on
+CORS and `fetch` rejects — which is what sends `authGuard` to `probeAuth()`.
+
+Uncomment `OAUTH2_PROXY_API_ROUTES` in the compose file to get a bare `401` on
+`/api/` instead, the other branch of `isAuthChallenge()`.

--- a/deploy/authproxy-lab/dex.yaml
+++ b/deploy/authproxy-lab/dex.yaml
@@ -1,0 +1,34 @@
+# Throwaway OIDC provider for the auth-proxy lab. In-memory storage: every
+# restart wipes the sessions, which is exactly what we want when testing
+# session expiry.
+#
+# The issuer must be reachable under the SAME URL from the browser and from
+# oauth2-proxy, which is why oauth2-proxy shares this container's network
+# namespace (see compose.authproxy.yml): both sides say localhost:5556.
+
+issuer: http://localhost:5556/dex
+
+storage:
+  type: memory
+
+web:
+  http: 0.0.0.0:5556
+
+oauth2:
+  # No consent screen: a re-auth round-trip should land straight on the form.
+  skipApprovalScreen: true
+
+staticClients:
+  - id: maintenant
+    name: Maintenant
+    secret: maintenant-lab-secret
+    redirectURIs:
+      - http://localhost:8088/oauth2/callback
+
+enablePasswordDB: true
+staticPasswords:
+  - email: admin@lab.test
+    username: admin
+    userID: 6f4e3d2c-1b0a-4e8d-9c7b-5a4f3e2d1c0b
+    # bcrypt of "password" — $2a, the only prefix Go's bcrypt accepts.
+    hash: "$2a$10$xHypoIwcpseDmLIG/vrzye0eiJfkjtiuBfoigHsJvrFx6p3wOpVkm"

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -13,8 +13,10 @@
 
 <template>
   <RouterView />
+  <SessionExpiredOverlay />
 </template>
 
 <script setup lang="ts">
 import { RouterView } from 'vue-router'
+import SessionExpiredOverlay from '@/components/ui/SessionExpiredOverlay.vue'
 </script>

--- a/frontend/src/components/AppHeader.vue
+++ b/frontend/src/components/AppHeader.vue
@@ -167,7 +167,7 @@ const themeTooltip = computed(() => {
 </script>
 
 <template>
-  <header class="hidden md:flex h-16 shrink-0 border-b border-mnt-default items-center justify-between px-6 bg-mnt-surface/60 backdrop-blur-md z-10">
+  <header class="header-glass hidden md:flex h-16 shrink-0 border-b border-mnt-default items-center justify-between px-6 backdrop-blur-md z-10">
     <div class="flex items-center gap-5">
       <!-- Global host/resource scope selector (hidden on single-host installs) -->
       <HostFilterDropdown v-if="activeAgentIds.length > 0" class="w-48 shrink-0" />
@@ -361,3 +361,11 @@ const themeTooltip = computed(() => {
     <strong class="font-semibold">{{ containers.runtimeLabel }}</strong> runtime disconnected — monitoring paused until connection is restored.
   </AlertBanner>
 </template>
+
+<style scoped>
+/* `bg-mnt-*` are hand-written utilities: Tailwind's `/60` opacity modifier
+   does not apply to them, so mix the token here. */
+.header-glass {
+  background-color: color-mix(in srgb, var(--mnt-bg-surface) 60%, transparent);
+}
+</style>

--- a/frontend/src/components/ui/SessionExpiredOverlay.vue
+++ b/frontend/src/components/ui/SessionExpiredOverlay.vue
@@ -1,0 +1,55 @@
+<!--
+  Copyright 2026 Benjamin Touchard (kOlapsis)
+  Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+  or a commercial license. See COMMERCIAL-LICENSE.md.
+-->
+<script setup lang="ts">
+import { LogIn, ShieldAlert } from 'lucide-vue-next'
+import { reauthStalled, sessionExpired, startReauth } from '@/services/authGuard'
+</script>
+
+<template>
+  <div
+    v-if="sessionExpired"
+    role="alertdialog"
+    aria-modal="true"
+    aria-labelledby="session-expired-title"
+    class="session-scrim fixed inset-0 z-[100] flex items-center justify-center px-6 backdrop-blur-sm"
+  >
+    <div
+      class="w-full max-w-sm rounded-xl border border-mnt-default bg-mnt-surface p-6 text-center shadow-lg"
+    >
+      <span
+        class="mb-3 inline-flex h-10 w-10 items-center justify-center rounded-full bg-mnt-sev-warning"
+      >
+        <ShieldAlert :size="20" class="text-mnt-sev-warning" aria-hidden="true" />
+      </span>
+      <p id="session-expired-title" class="text-sm font-semibold text-mnt-primary">
+        Session expired
+      </p>
+      <p class="mt-1 text-xs text-mnt-secondary">
+        {{
+          reauthStalled
+            ? 'Signing in again did not restore the session. Retry, or check with whoever runs the identity provider.'
+            : 'Your identity provider ended the session. Redirecting you to sign in again…'
+        }}
+      </p>
+      <button
+        type="button"
+        class="focus-ring mt-4 inline-flex items-center gap-1.5 rounded-lg border border-mnt-default px-3 py-1.5 text-xs font-semibold text-mnt-secondary transition-colors hover:text-mnt-primary"
+        @click="startReauth()"
+      >
+        <LogIn :size="13" aria-hidden="true" />
+        Sign in again
+      </button>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+/* The `bg-mnt-*` utilities are hand-written, so Tailwind's `/80` opacity
+   modifier does not apply to them — mix the token here instead. */
+.session-scrim {
+  background-color: color-mix(in srgb, var(--mnt-bg-primary) 80%, transparent);
+}
+</style>

--- a/frontend/src/composables/useLogStream.ts
+++ b/frontend/src/composables/useLogStream.ts
@@ -12,6 +12,7 @@
 */
 
 import { ref, watch, watchEffect, nextTick, type Ref, type ComponentPublicInstance } from 'vue'
+import { guardedFetch } from '@/services/apiFetch'
 import { parseAnsi, type AnsiToken } from './useAnsiParser'
 import { detectLogLevel, parseJsonLine, parseTimestamp } from './useLogParser'
 
@@ -226,7 +227,7 @@ export function useLogStream(options: UseLogStreamOptions): UseLogStreamReturn {
   async function fetchLogsStatic() {
     status.value = 'connecting'
     try {
-      const res = await fetch(
+      const res = await guardedFetch(
         `${API_BASE}/containers/${options.containerId.value}/logs?lines=100&timestamps=true`,
       )
       if (!res.ok) {

--- a/frontend/src/layouts/DefaultLayout.vue
+++ b/frontend/src/layouts/DefaultLayout.vue
@@ -297,7 +297,7 @@ watch(
 
     <!-- Mobile top bar -->
     <div
-      class="md:hidden fixed top-0 left-0 right-0 z-30 flex items-center h-14 px-4 bg-mnt-surface/90 backdrop-blur-md border-b border-mnt-default"
+      class="mobile-bar md:hidden fixed top-0 left-0 right-0 z-30 flex items-center h-14 px-4 backdrop-blur-md border-b border-mnt-default"
     >
       <button
         @click="mobileMenuOpen = !mobileMenuOpen"
@@ -487,5 +487,11 @@ watch(
 }
 .license-action--info:hover {
   background: var(--mnt-alert-info-action-hover);
+}
+
+/* `bg-mnt-*` are hand-written utilities: Tailwind's `/90` opacity modifier
+   does not apply to them, so mix the token here. */
+.mobile-bar {
+  background-color: color-mix(in srgb, var(--mnt-bg-surface) 90%, transparent);
 }
 </style>

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -16,6 +16,9 @@ import { createPinia } from 'pinia'
 
 import App from './App.vue'
 import router from './router'
+import { initAuthGuard } from './services/authGuard'
+
+initAuthGuard()
 
 const app = createApp(App)
 

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -18,11 +18,13 @@ import App from './App.vue'
 import router from './router'
 import { initAuthGuard } from './services/authGuard'
 
-initAuthGuard()
-
 const app = createApp(App)
 
 app.use(createPinia())
 app.use(router)
+
+// After the router settles, not before: it reads window.location when its
+// module is imported, and would put the re-auth param straight back.
+router.isReady().then(initAuthGuard)
 
 app.mount('#app')

--- a/frontend/src/pages/PublicStatusPage.vue
+++ b/frontend/src/pages/PublicStatusPage.vue
@@ -15,6 +15,7 @@
 import { ref, onMounted, onUnmounted, computed, watch } from 'vue'
 import StatusComponentBreakdown from '@/components/StatusComponentBreakdown.vue'
 import { useStatusPageI18n } from '@/composables/useStatusPageI18n'
+import { guardedFetch } from '@/services/apiFetch'
 import type { MonitorRef } from '@/services/statusApi'
 
 // --- Personalization settings ---
@@ -49,7 +50,7 @@ const { t } = useStatusPageI18n(locale)
 
 async function fetchSettings() {
   try {
-    const res = await fetch('/status/settings.json')
+    const res = await guardedFetch('/status/settings.json')
     if (res.ok) settings.value = await res.json()
   } catch {
     // graceful degradation — defaults already applied via null checks
@@ -115,7 +116,7 @@ let eventSource: EventSource | null = null
 
 async function fetchStatus() {
   try {
-    const res = await fetch('/status/api')
+    const res = await guardedFetch('/status/api')
     if (!res.ok) throw new Error(`HTTP ${res.status}`)
     data.value = await res.json()
   } catch (e) {

--- a/frontend/src/services/__tests__/authGuard.spec.ts
+++ b/frontend/src/services/__tests__/authGuard.spec.ts
@@ -1,0 +1,60 @@
+// Copyright 2026 Benjamin Touchard (Kolapsis)
+//
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+// or a commercial license. See COMMERCIAL-LICENSE.md.
+
+import { describe, it, expect } from 'vitest'
+import { isAuthChallenge } from '../authGuard'
+
+/** Builds a Response-like object; jsdom's Response cannot fake `redirected`. */
+function response(init: {
+  status?: number
+  contentType?: string | null
+  redirected?: boolean
+  type?: string
+}): Response {
+  const { status = 200, contentType = 'application/json', redirected = false, type = 'basic' } = init
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    redirected,
+    type,
+    headers: { get: (name: string) => (name.toLowerCase() === 'content-type' ? contentType : null) },
+  } as unknown as Response
+}
+
+describe('isAuthChallenge', () => {
+  it('leaves genuine API answers alone', () => {
+    expect(isAuthChallenge(response({ status: 200 }))).toBe(false)
+    expect(isAuthChallenge(response({ status: 500 }))).toBe(false)
+    expect(isAuthChallenge(response({ status: 204, contentType: null }))).toBe(false)
+  })
+
+  it('does not mistake the API 403s (PRO_REQUIRED, quotas) for an expired session', () => {
+    expect(isAuthChallenge(response({ status: 403 }))).toBe(false)
+    expect(isAuthChallenge(response({ status: 401 }))).toBe(false)
+  })
+
+  it('catches a proxy 302 that fetch followed to a login page', () => {
+    expect(
+      isAuthChallenge(response({ status: 200, contentType: 'text/html', redirected: true })),
+    ).toBe(true)
+  })
+
+  it('catches a login page served straight up as 200 HTML', () => {
+    expect(isAuthChallenge(response({ status: 200, contentType: 'text/html; charset=utf-8' }))).toBe(
+      true,
+    )
+  })
+
+  it('catches a non-JSON 401/403 from the proxy', () => {
+    expect(isAuthChallenge(response({ status: 401, contentType: 'text/plain' }))).toBe(true)
+    expect(isAuthChallenge(response({ status: 403, contentType: null }))).toBe(true)
+  })
+
+  it('catches the opaque redirect returned under redirect: manual', () => {
+    expect(isAuthChallenge(response({ status: 0, contentType: null, type: 'opaqueredirect' }))).toBe(
+      true,
+    )
+  })
+})

--- a/frontend/src/services/__tests__/authGuard.spec.ts
+++ b/frontend/src/services/__tests__/authGuard.spec.ts
@@ -32,7 +32,10 @@ describe('isAuthChallenge', () => {
 
   it('does not mistake the API 403s (PRO_REQUIRED, quotas) for an expired session', () => {
     expect(isAuthChallenge(response({ status: 403 }))).toBe(false)
-    expect(isAuthChallenge(response({ status: 401 }))).toBe(false)
+  })
+
+  it('catches the JSON 401 oauth2-proxy answers AJAX calls with', () => {
+    expect(isAuthChallenge(response({ status: 401 }))).toBe(true)
   })
 
   it('catches a proxy 302 that fetch followed to a login page', () => {

--- a/frontend/src/services/apiFetch.ts
+++ b/frontend/src/services/apiFetch.ts
@@ -13,6 +13,8 @@
  * Shared fetch wrapper for all API services.
  */
 
+import { AuthChallengeError, isAuthChallenge, probeAuth, reportAuthChallenge } from './authGuard'
+
 // Sentinel agent id the backend sends for server-local entities. Treat it as
 // "local" everywhere a host is grouped or displayed.
 export const LOCAL_AGENT = '00000000-0000-0000-0000-000000000000'
@@ -21,8 +23,29 @@ export function isLocalAgent(id?: string | null): boolean {
   return !id || id === LOCAL_AGENT
 }
 
+/**
+ * fetch, but an auth-proxy challenge becomes an AuthChallengeError instead of a
+ * login page the caller would try to parse as JSON.
+ */
+export async function guardedFetch(url: string, init?: RequestInit): Promise<Response> {
+  let res: Response
+  try {
+    res = await fetch(url, init)
+  } catch (err) {
+    if (await probeAuth()) throw new AuthChallengeError()
+    throw err
+  }
+
+  if (isAuthChallenge(res)) {
+    reportAuthChallenge()
+    throw new AuthChallengeError()
+  }
+
+  return res
+}
+
 export async function apiFetch<T>(url: string, init?: RequestInit): Promise<T> {
-  const res = await fetch(url, init)
+  const res = await guardedFetch(url, init)
 
   if (!res.ok) {
     const body = await res.json().catch(() => ({}))
@@ -33,7 +56,7 @@ export async function apiFetch<T>(url: string, init?: RequestInit): Promise<T> {
 }
 
 export async function apiFetchVoid(url: string, init?: RequestInit): Promise<void> {
-  const res = await fetch(url, init)
+  const res = await guardedFetch(url, init)
 
   if (!res.ok) {
     const body = await res.json().catch(() => ({}))

--- a/frontend/src/services/authGuard.ts
+++ b/frontend/src/services/authGuard.ts
@@ -52,10 +52,16 @@ export function isAuthChallenge(res: Response): boolean {
   // redirect: 'manual' turns the proxy's 302 into an opaque redirect.
   if (res.type === 'opaqueredirect') return true
 
+  // A 401 always comes from the proxy: the API has no authentication of its
+  // own and never sends one. Checked before the content type because
+  // oauth2-proxy answers `Accept: application/json` calls — the session probe
+  // among them — with a JSON 401.
+  if (res.status === 401) return true
+
   const contentType = res.headers.get('content-type') ?? ''
   if (contentType.includes('json')) return false
 
-  if (res.status === 401 || res.status === 403) return true
+  if (res.status === 403) return true
   // fetch followed the proxy's 302 and handed us its login page under a 200.
   if (res.redirected) return true
   return res.ok && contentType.includes('html')

--- a/frontend/src/services/authGuard.ts
+++ b/frontend/src/services/authGuard.ts
@@ -1,0 +1,150 @@
+// Copyright 2026 Benjamin Touchard (Kolapsis)
+//
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+// or a commercial license. You may not use this file except in compliance
+// with one of these licenses.
+//
+// AGPL-3.0: https://www.gnu.org/licenses/agpl-3.0.html
+// Commercial: See COMMERCIAL-LICENSE.md
+//
+// Source: https://github.com/kolapsis/maintenant
+
+/**
+ * Session handling for deployments sitting behind an authentication proxy
+ * (Authentik, oauth2-proxy, Cloudflare Access…).
+ *
+ * The service worker serves the app shell from cache, so the SPA boots even
+ * when the proxy session is gone. Every API call then lands on a login page
+ * instead of the API. This module recognises that answer and sends the browser
+ * back through the proxy so it can challenge the user again.
+ */
+
+import { ref } from 'vue'
+
+const API_BASE = import.meta.env.VITE_API_BASE || '/api/v1'
+
+/** Query param carried by the re-auth navigation; the SW denylist skips it. */
+export const REAUTH_PARAM = '__reauth'
+const REAUTH_STAMP_KEY = 'mnt:reauth-at'
+/** A challenge landing again within this window means the re-auth did not stick. */
+const REAUTH_LOOP_WINDOW_MS = 15_000
+const PROBE_THROTTLE_MS = 5_000
+
+/** true once a proxy challenge has been seen; the overlay takes over the UI. */
+export const sessionExpired = ref(false)
+/** true when the automatic round-trip already failed: only a manual retry is left. */
+export const reauthStalled = ref(false)
+
+export class AuthChallengeError extends Error {
+  constructor() {
+    super('Session expired')
+    this.name = 'AuthChallengeError'
+  }
+}
+
+/**
+ * Tells an auth-proxy answer apart from a genuine API answer.
+ *
+ * The API always replies JSON — including its own 403s (PRO_REQUIRED, quotas),
+ * which must never be mistaken for an expired session.
+ */
+export function isAuthChallenge(res: Response): boolean {
+  // redirect: 'manual' turns the proxy's 302 into an opaque redirect.
+  if (res.type === 'opaqueredirect') return true
+
+  const contentType = res.headers.get('content-type') ?? ''
+  if (contentType.includes('json')) return false
+
+  if (res.status === 401 || res.status === 403) return true
+  // fetch followed the proxy's 302 and handed us its login page under a 200.
+  if (res.redirected) return true
+  return res.ok && contentType.includes('html')
+}
+
+function lastReauthAt(): number {
+  try {
+    return Number(window.sessionStorage.getItem(REAUTH_STAMP_KEY)) || 0
+  } catch {
+    return 0
+  }
+}
+
+function stampReauth(): void {
+  try {
+    window.sessionStorage.setItem(REAUTH_STAMP_KEY, String(Date.now()))
+  } catch {
+    // Private mode without storage: we lose the loop guard, not the re-auth.
+  }
+}
+
+/**
+ * Navigates through the proxy so it can challenge us. The `__reauth` param is
+ * denylisted in the service worker, so this navigation reaches the network
+ * instead of being answered from the precached app shell.
+ */
+export function startReauth(): void {
+  stampReauth()
+  const url = new URL(window.location.href)
+  url.searchParams.set(REAUTH_PARAM, Date.now().toString(36))
+  window.location.assign(url.toString())
+}
+
+/** Called on every detected challenge; triggers the overlay and one re-auth. */
+export function reportAuthChallenge(): void {
+  if (sessionExpired.value) return
+  sessionExpired.value = true
+
+  if (Date.now() - lastReauthAt() < REAUTH_LOOP_WINDOW_MS) {
+    // We just came back from the proxy and it is challenging us again: stop
+    // bouncing and let the user decide.
+    reauthStalled.value = true
+    return
+  }
+  startReauth()
+}
+
+let probeInFlight: Promise<boolean> | null = null
+let lastProbeAt = 0
+
+/**
+ * Distinguishes an expired session from a real network outage when fetch
+ * rejects outright — a proxy hosted on another origin fails the request on
+ * CORS instead of answering it.
+ */
+export async function probeAuth(): Promise<boolean> {
+  if (sessionExpired.value) return true
+  if (probeInFlight) return probeInFlight
+  if (Date.now() - lastProbeAt < PROBE_THROTTLE_MS) return false
+  lastProbeAt = Date.now()
+
+  probeInFlight = (async () => {
+    try {
+      const res = await fetch(`${API_BASE}/edition?__probe=1`, {
+        redirect: 'manual',
+        cache: 'no-store',
+        headers: { Accept: 'application/json' },
+      })
+      if (isAuthChallenge(res)) {
+        reportAuthChallenge()
+        return true
+      }
+    } catch {
+      // Nothing answered at all: the network is down, not the session.
+    }
+    return false
+  })()
+
+  try {
+    return await probeInFlight
+  } finally {
+    probeInFlight = null
+  }
+}
+
+/** Strips the re-auth param from the address bar once the app has booted. */
+export function initAuthGuard(): void {
+  const url = new URL(window.location.href)
+  if (!url.searchParams.has(REAUTH_PARAM)) return
+  url.searchParams.delete(REAUTH_PARAM)
+  window.history.replaceState(null, '', `${url.pathname}${url.search}${url.hash}`)
+}

--- a/frontend/src/services/containerApi.ts
+++ b/frontend/src/services/containerApi.ts
@@ -106,7 +106,7 @@ export interface ListTransitionsParams {
   offset?: number
 }
 
-import { apiFetch } from './apiFetch'
+import { apiFetch, guardedFetch } from './apiFetch'
 
 function fetchJSON<T>(url: string): Promise<T> {
   return apiFetch<T>(url)
@@ -126,7 +126,7 @@ export function getContainer(id: string): Promise<ContainerDetailResponse> {
 }
 
 export async function deleteContainer(id: string): Promise<void> {
-  await fetch(`${API_BASE}/containers/${id}`, { method: 'DELETE' })
+  await guardedFetch(`${API_BASE}/containers/${id}`, { method: 'DELETE' })
 }
 
 export function listTransitions(

--- a/frontend/src/services/personalizationApi.ts
+++ b/frontend/src/services/personalizationApi.ts
@@ -1,3 +1,5 @@
+import { guardedFetch } from './apiFetch'
+
 const BASE = '/api/v1/status-page'
 
 export interface PalettePayload {
@@ -72,7 +74,7 @@ export interface FAQItem {
 }
 
 async function request<T>(method: string, url: string, body?: unknown): Promise<T> {
-  const res = await fetch(url, {
+  const res = await guardedFetch(url, {
     method,
     headers: body ? { 'Content-Type': 'application/json' } : {},
     body: body ? JSON.stringify(body) : undefined,
@@ -95,7 +97,7 @@ export const personalizationApi = {
     const form = new FormData()
     form.append('file', file)
     if (altText !== undefined) form.append('alt_text', altText)
-    const res = await fetch(`${BASE}/assets/${role}`, { method: 'PUT', body: form })
+    const res = await guardedFetch(`${BASE}/assets/${role}`, { method: 'PUT', body: form })
     if (!res.ok) {
       const err = await res.json().catch(() => ({}))
       throw new Error(err?.error?.message || `HTTP ${res.status}`)

--- a/frontend/src/services/sseBus.ts
+++ b/frontend/src/services/sseBus.ts
@@ -11,6 +11,8 @@
 
 import { ref } from 'vue'
 
+import { probeAuth } from './authGuard'
+
 const API_BASE = import.meta.env.VITE_API_BASE || '/api/v1'
 
 type EventHandler = (event: MessageEvent) => void
@@ -86,6 +88,9 @@ function openConnection() {
     // (we manage reconnection ourselves with backoff).
     es.close()
     eventSource = null
+    // EventSource never tells us why it failed: ask the API whether the proxy
+    // session died, otherwise we would retry a dead stream forever.
+    void probeAuth()
     scheduleRetry()
   }
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -24,8 +24,23 @@ export default defineConfig({
         cleanupOutdatedCaches: true,
         skipWaiting: true,
         clientsClaim: true,
-        navigateFallbackDenylist: [/\/api\//, /\/ping\//, /\/status\//, /\/oauth\//, /\/\.well-known\//, /\/mcp/],
+        // `__reauth` must reach the network: it is how the app hands a navigation
+        // back to an auth proxy (Authentik…) instead of replaying the cached shell.
+        navigateFallbackDenylist: [
+          /\/api\//,
+          /\/ping\//,
+          /\/status\//,
+          /\/oauth\//,
+          /\/\.well-known\//,
+          /\/mcp/,
+          /__reauth=/,
+        ],
         runtimeCaching: [
+          {
+            // Session probe: must always see the live answer, never a cached one.
+            urlPattern: /__probe=1/,
+            handler: 'NetworkOnly',
+          },
           {
             urlPattern: /\/api\/v1\/(?!containers\/events|status\/smtp|channels|webhooks)/,
             handler: 'NetworkFirst',
@@ -33,6 +48,9 @@ export default defineConfig({
               cacheName: `api-${buildRevision}`,
               expiration: { maxEntries: 50, maxAgeSeconds: 300 },
               networkTimeoutSeconds: 5,
+              // Keeps an auth proxy's login page out of the API cache, which
+              // would otherwise be replayed as a fake expired session.
+              cacheableResponse: { statuses: [200], headers: { 'content-type': 'application/json' } },
             },
           },
           {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -30,7 +30,15 @@ export default defineConfig({
           /\/api\//,
           /\/ping\//,
           /\/status\//,
-          /\/oauth\//,
+          // An auth proxy's own endpoints: oauth2-proxy answers under /oauth2/,
+          // Authentik under /outpost.goauthentik.io/. Replaying the shell there
+          // swallows the OIDC callback, so the session is never established and
+          // re-auth can only loop.
+          /\/oauth2?\//,
+          /\/outpost\.goauthentik\.io\//,
+          // Whatever prefix the proxy uses, a provider handing an authorization
+          // code back to us must reach the network.
+          /[?&](code|state|error)=/,
           /\/\.well-known\//,
           /\/mcp/,
           /__reauth=/,


### PR DESCRIPTION
## Problem

Behind an auth proxy (Authentik with a short session TTL, oauth2-proxy, Cloudflare Access), the service worker serves the cached app shell, so the SPA boots even once the proxy session is gone. Every API call then lands on a login page the services try to parse as JSON: the UI renders with failed panels and a missing logo, and never tells the user to sign in again.

## Change

- `services/authGuard.ts`: recognises a proxy challenge (opaque redirect, followed 302, non-JSON 401/403). The API's own JSON 403s (`PRO_REQUIRED`, quotas) are explicitly excluded.
- `guardedFetch` in `services/apiFetch.ts`: network calls now reject with `AuthChallengeError` on a challenge. Remaining raw `fetch` callers migrated (log stream, public status page, personalization).
- `SessionExpiredOverlay.vue`: blocking overlay that hands the navigation back to the proxy once via a `__reauth` param, with a loop guard when re-auth does not stick.
- SSE bus probes the API when the stream errors, instead of retrying a dead stream forever.
- Service worker: `__reauth` navigations skip the shell fallback, and the API cache stores JSON only — otherwise a cached login page would be replayed as a fake expired session.
