### PR TITLE
fix(retention): drain expired rows instead of capping each pass at one batch

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,17 @@ MAINTENANT_DB=./maintenant.db
 # Update intelligence scan interval (Go duration, default: 24h)
 # MAINTENANT_UPDATE_INTERVAL=24h
 
+# How long raw resource samples are kept (Go duration, default: 168h = 7 days).
+# Resource graphs aggregate raw samples even for the 7-day range, so a shorter
+# window also shortens those charts. Minimum 24h.
+# MAINTENANT_RETENTION_SNAPSHOTS=168h
+
+# Time between two retention passes (Go duration, default: 1h, minimum 1m)
+# MAINTENANT_RETENTION_INTERVAL=1h
+
+# Rows deleted per transaction during retention (default: 1000, range 100-100000)
+# MAINTENANT_RETENTION_BATCH_SIZE=1000
+
 # Kubernetes namespaces to monitor (comma-separated, empty = all)
 # MAINTENANT_K8S_NAMESPACES=default,production
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -164,7 +164,8 @@ maintenant uses SQLite in WAL (Write-Ahead Logging) mode with a single-writer pa
 - **One writer goroutine** — All writes are serialized through a channel-based writer to avoid `SQLITE_BUSY` errors
 - **Multiple readers** — Read queries run concurrently without blocking
 - **Automatic migrations** — Schema migrations run at startup using embedded SQL files
-- **Retention cleanup** — Background goroutine prunes old data hourly (transitions: 90 days, check results: 30 days, heartbeat pings: 30 days, resource snapshots: 7 days, resource hourly: 90 days, resource daily: 1 year)
+- **Retention cleanup** — Background goroutine prunes old data (transitions: 90 days, check results: 30 days, heartbeat pings: 30 days, resource snapshots: 7 days, resource hourly: 90 days, resource daily: 1 year). A pass runs at startup and then hourly, deleting in batches of 1000 rows until each table is drained. If a pass hits its 2-minute-per-table budget it reschedules itself a minute later instead of waiting for the next hour, so a backlog is cleared instead of accumulating. Tunable with `MAINTENANT_RETENTION_SNAPSHOTS`, `MAINTENANT_RETENTION_INTERVAL` and `MAINTENANT_RETENTION_BATCH_SIZE`.
+- **Bounded WAL** — Every pooled connection sets `journal_size_limit` (64 MiB) and `wal_autocheckpoint` (1000 pages) through a driver `ConnectHook`; pages freed by retention are returned to the filesystem with `incremental_vacuum` in slices
 
 ---
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -114,3 +114,54 @@ Make sure the mounted file is readable by uid **65534** — the container runs u
 Do not reach for `SSL_CERT_FILE`. Go treats it as a replacement for the whole system bundle rather than an addition, so setting it drops every public CA, and an unreadable file yields an empty trust store with no error reported.
 
 As a last resort you can turn verification off for a single container endpoint with the label `maintenant.endpoint.http.tls-verify=false`, but that also stops expiry and hostname checks for it.
+
+---
+
+## The database keeps growing, or the -wal file is huge
+
+Up to and including 1.3.7, the retention cleanup deleted at most 1000 rows per hour, whatever
+the number of monitored containers. Since each container produces around 360 raw samples per
+hour, the purge fell behind past roughly three containers and `resource_snapshots` grew without
+bound. Upgrading fixes the throughput: the first pass runs at startup and drains the whole
+backlog.
+
+Check where you stand:
+
+```bash
+sqlite3 /data/maintenant.db "
+  SELECT COUNT(*) AS rows, datetime(MIN(timestamp),'unixepoch') AS oldest FROM resource_snapshots;
+  PRAGMA auto_vacuum;
+  PRAGMA freelist_count;
+"
+```
+
+`oldest` should stay inside the retention window (7 days by default). The `retention cleanup:
+deleted resource snapshots` log line should no longer report a `count` stuck at exactly the batch
+size — that was the signature of the purge never catching up.
+
+### Reclaiming disk space already used
+
+`PRAGMA auto_vacuum` tells you whether freed pages return to the filesystem:
+
+- **`2` (incremental)** — nothing to do. Retention hands freed pages back automatically and
+  `freelist_count` shrinks pass after pass.
+- **`0` (none)** — the database was created before auto-vacuum was enabled and only a full
+  `VACUUM` can convert it. maintenant logs a warning at startup in this case. The database stops
+  growing regardless, since SQLite reuses freed pages, but the file stays at its high-water mark.
+
+A full `VACUUM` is a manual, offline operation. It takes an exclusive lock for its whole duration
+(minutes on a multi-gigabyte database, much longer on an SD card or NAS) and rewrites the file, so
+you need **free disk space equal to the current database size** on top of it:
+
+```bash
+docker compose stop maintenant
+sqlite3 /path/to/maintenant.db "PRAGMA auto_vacuum=INCREMENTAL; VACUUM;"
+docker compose start maintenant
+```
+
+Take a backup first. Running out of disk space mid-VACUUM leaves a journal file behind.
+
+### The -wal file
+
+Newer versions set, on every connection, a `journal_size_limit` of 64 MiB, so the WAL is truncated back after each
+checkpoint. Up to 1.3.7 it was unbounded and only shrank when the process restarted.

--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -60,6 +60,8 @@
 /* Light theme overrides */
 @layer base {
   :root[data-theme="light"] {
+    color-scheme: light;
+
     /* Gray scale — light equivalents */
     --color-slate-50: #F0F3FA;
     --color-slate-100: #E8ECF4;
@@ -205,6 +207,11 @@
 /* Dark theme (default) */
 @layer base {
   :root {
+    /* Tells the browser which palette to use for native controls it paints
+       itself — range tracks, checkboxes, number spinners, scrollbars. Without
+       it they stay on the UA default and ignore the selected theme. */
+    color-scheme: dark;
+
     /* Semantic: backgrounds */
     --mnt-bg-primary: #0B0E13;
     --mnt-bg-surface: #12151C;

--- a/frontend/src/components/ContainerDetail.vue
+++ b/frontend/src/components/ContainerDetail.vue
@@ -32,6 +32,9 @@ import { fetchContainerDailyUptime, type UptimeDay } from '@/services/uptimeApi'
 import SecurityInsightList from './SecurityInsightList.vue'
 import PostureScoreBadge from './PostureScoreBadge.vue'
 import PostureCategoryBreakdown from './PostureCategoryBreakdown.vue'
+import ResourceCharts from './ResourceCharts.vue'
+import ResourceAlertConfig from './ResourceAlertConfig.vue'
+import FeatureGate from './FeatureGate.vue'
 import { useSecurityStore } from '@/stores/security'
 import { usePostureStore } from '@/stores/posture'
 import { useEdition } from '@/composables/useEdition'
@@ -41,6 +44,7 @@ import {
   Trash2,
   Terminal,
   Activity,
+  ChartLine,
   ChevronRight,
 } from 'lucide-vue-next'
 import { fetchSwarmServiceDetail, type SwarmServiceDetailResponse } from '@/services/swarmApi'
@@ -60,7 +64,7 @@ const uptimeDays = ref<UptimeDay[]>([])
 const loading = ref(true)
 const error = ref<string | null>(null)
 const selectedLogContainer = ref<string | undefined>(undefined)
-const activeTab = ref<'logs' | 'info'>('info')
+const activeTab = ref<'logs' | 'info' | 'resources'>('info')
 const isLogExpanded = ref(false)
 
 const logStream = useLogStream({
@@ -360,6 +364,17 @@ watch(() => props.containerId, () => {
           <Terminal :size="13" />
           Logs
         </button>
+        <button
+          class="flex items-center gap-1.5 px-3 py-2.5 text-xs font-semibold transition-colors"
+          :style="{
+            color: activeTab === 'resources' ? 'var(--mnt-accent)' : 'var(--mnt-text-muted)',
+            borderBottom: activeTab === 'resources' ? '2px solid var(--mnt-accent)' : '2px solid transparent',
+          }"
+          @click="activeTab = 'resources'"
+        >
+          <ChartLine :size="13" />
+          Resources
+        </button>
 
         <!-- K8s container selector (logs tab only) -->
         <select
@@ -395,6 +410,20 @@ watch(() => props.containerId, () => {
             class="flex-1"
             @toggle-expand="isLogExpanded = true"
           />
+        </div>
+
+        <!-- RESOURCES TAB -->
+        <!-- v-if, not v-show: the charts only fetch their history once the tab
+             is opened, so the panel costs nothing until then. -->
+        <div v-else-if="activeTab === 'resources'" class="space-y-5 p-5">
+          <FeatureGate
+            feature="resource_history"
+            title="Resource History"
+            description="Track CPU, memory, network and block I/O over time, and alert on thresholds."
+          >
+            <ResourceCharts :container-id="containerId" />
+            <ResourceAlertConfig :container-id="containerId" class="mt-5" />
+          </FeatureGate>
         </div>
 
         <!-- INFO TAB -->

--- a/frontend/src/components/ResourceAlertConfig.vue
+++ b/frontend/src/components/ResourceAlertConfig.vue
@@ -12,7 +12,7 @@
 -->
 
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { computed, ref, onMounted } from 'vue'
 import {
   getAlertConfig,
   updateAlertConfig,
@@ -30,6 +30,17 @@ const enabled = ref(false)
 const saving = ref(false)
 const error = ref<string | null>(null)
 const saved = ref(false)
+
+// Chrome derives the unfilled range track from accent-color, which turns it
+// near-black under our green. The track is drawn as a gradient instead, so both
+// halves come from design tokens; these are the split points.
+const cpuFill = computed(() => fillPercent(cpuThreshold.value, 1, 1000))
+const memFill = computed(() => fillPercent(memThreshold.value, 1, 100))
+
+function fillPercent(value: number, min: number, max: number): string {
+  const ratio = (value - min) / (max - min)
+  return `${Math.min(Math.max(ratio, 0), 1) * 100}%`
+}
 
 const alertStateColors: Record<string, string> = {
   normal: 'text-mnt-status-ok',
@@ -70,9 +81,18 @@ async function save() {
 </script>
 
 <template>
-  <div class="rounded border border-gray-200 bg-white p-4">
+  <div
+    class="rounded border p-4"
+    :style="{
+      backgroundColor: 'var(--mnt-bg-surface)',
+      borderColor: 'var(--mnt-border-default)',
+      borderRadius: 'var(--mnt-radius-md)',
+    }"
+  >
     <div class="mb-3 flex items-center justify-between">
-      <h4 class="text-sm font-semibold text-mnt-muted">Resource Alerts</h4>
+      <h4 class="text-sm font-semibold" :style="{ color: 'var(--mnt-text-secondary)' }">
+        Resource Alerts
+      </h4>
       <span
         v-if="config"
         class="text-xs font-medium"
@@ -85,7 +105,12 @@ async function save() {
     <div class="space-y-3">
       <!-- Enable toggle -->
       <label class="flex items-center gap-2 text-sm">
-        <input v-model="enabled" type="checkbox" class="rounded border-gray-300" />
+        <input
+          v-model="enabled"
+          type="checkbox"
+          class="rounded"
+          style="accent-color: var(--mnt-accent)"
+        />
         <span class="text-mnt-muted">Enable alerts</span>
       </label>
 
@@ -99,13 +124,19 @@ async function save() {
             min="1"
             max="1000"
             class="flex-1"
+            :style="{ '--fill': cpuFill }"
           />
           <input
             v-model.number="cpuThreshold"
             type="number"
             min="1"
             max="1000"
-            class="w-16 rounded border border-gray-300 px-2 py-1 text-xs"
+            class="w-16 rounded-md border px-2 py-1 text-xs outline-none"
+            style="
+              background: var(--mnt-bg-elevated);
+              border-color: var(--mnt-border-default);
+              color: var(--mnt-text-primary);
+            "
           />
         </div>
       </div>
@@ -120,13 +151,19 @@ async function save() {
             min="1"
             max="100"
             class="flex-1"
+            :style="{ '--fill': memFill }"
           />
           <input
             v-model.number="memThreshold"
             type="number"
             min="1"
             max="100"
-            class="w-16 rounded border border-gray-300 px-2 py-1 text-xs"
+            class="w-16 rounded-md border px-2 py-1 text-xs outline-none"
+            style="
+              background: var(--mnt-bg-elevated);
+              border-color: var(--mnt-border-default);
+              color: var(--mnt-text-primary);
+            "
           />
         </div>
       </div>
@@ -146,3 +183,37 @@ async function save() {
     </div>
   </div>
 </template>
+
+<style scoped>
+input[type='range'] {
+  appearance: none;
+  -webkit-appearance: none;
+  height: 6px;
+  border-radius: 999px;
+  background: linear-gradient(
+    to right,
+    var(--mnt-accent) var(--fill),
+    var(--mnt-bg-elevated) var(--fill)
+  );
+  outline: none;
+}
+
+input[type='range']::-webkit-slider-thumb {
+  appearance: none;
+  -webkit-appearance: none;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--mnt-accent);
+  cursor: pointer;
+}
+
+input[type='range']::-moz-range-thumb {
+  width: 14px;
+  height: 14px;
+  border: none;
+  border-radius: 50%;
+  background: var(--mnt-accent);
+  cursor: pointer;
+}
+</style>

--- a/frontend/src/components/ResourceCharts.vue
+++ b/frontend/src/components/ResourceCharts.vue
@@ -12,7 +12,7 @@
 -->
 
 <script setup lang="ts">
-import { ref, watch, onMounted } from 'vue'
+import { ref, watch, onMounted, nextTick } from 'vue'
 import { getResourceHistory, type HistoryPoint } from '@/services/resourceApi'
 import { useChart } from '@/composables/useChart'
 import { useResourcesStore } from '@/stores/resources'
@@ -118,18 +118,34 @@ const ioChart = useChart({
   data: () => [[], [], []] as uPlot.AlignedData,
 })
 
+const charts = [cpuChart, memChart, netChart, ioChart]
+
 async function fetchHistory() {
   loading.value = true
   try {
     const res = await getResourceHistory(props.containerId, selectedRange.value)
     points.value = res.points || []
-    updateCharts()
   } catch {
     points.value = []
   } finally {
     loading.value = false
   }
 }
+
+// The chart elements sit behind the v-else, so they do not exist until there is
+// data to show: uPlot has to be created once they are in the DOM, and torn down
+// again when a range comes back empty and the branch is swapped out.
+watch(points, async (pts) => {
+  await nextTick()
+  if (!pts.length) {
+    charts.forEach((c) => c.destroy())
+    return
+  }
+  charts.forEach((c) => {
+    if (!c.ready.value) c.create()
+  })
+  updateCharts()
+})
 
 function updateCharts() {
   const ts = toTimestamps(points.value)

--- a/frontend/src/components/__tests__/ContainerDetail.spec.ts
+++ b/frontend/src/components/__tests__/ContainerDetail.spec.ts
@@ -1,0 +1,178 @@
+// Copyright 2026 Benjamin Touchard (kOlapsis)
+//
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+// or a commercial license. You may not use this file except in compliance
+// with one of these licenses.
+//
+// AGPL-3.0: https://www.gnu.org/licenses/agpl-3.0.html
+// Commercial: See COMMERCIAL-LICENSE.md
+//
+// Source: https://github.com/kolapsis/maintenant
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import ContainerDetail from '@/components/ContainerDetail.vue'
+import type { ContainerDetailResponse } from '@/services/containerApi'
+
+vi.mock('@/services/containerApi', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/services/containerApi')>()
+  return {
+    ...actual,
+    getContainer: vi.fn(),
+    listTransitions: vi.fn(),
+    deleteContainer: vi.fn(),
+  }
+})
+
+vi.mock('@/services/uptimeApi', () => ({
+  fetchContainerDailyUptime: vi.fn().mockResolvedValue([]),
+}))
+
+vi.mock('@/services/swarmApi', () => ({
+  fetchSwarmServiceDetail: vi.fn().mockResolvedValue(null),
+}))
+
+vi.mock('@/composables/useLogStream', () => ({
+  useLogStream: () => ({
+    lines: { value: [] },
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+  }),
+}))
+
+vi.mock('@/composables/useEdition', () => ({
+  useEdition: () => ({ hasFeature: () => true, edition: 'pro' }),
+}))
+
+vi.mock('@/services/sseBus', () => ({
+  sseBus: { on: vi.fn(), off: vi.fn() },
+}))
+
+// Mocked at module level, not stubbed: importing the real charts pulls in uPlot,
+// which touches matchMedia at import time and is unavailable under jsdom.
+vi.mock('@/components/ResourceCharts.vue', () => ({
+  default: { template: '<div data-test="resource-charts" />' },
+}))
+vi.mock('@/components/ResourceAlertConfig.vue', () => ({
+  default: { template: '<div data-test="resource-alerts" />' },
+}))
+
+import { getContainer, listTransitions } from '@/services/containerApi'
+
+const container = {
+  id: 'ctr1',
+  external_id: '0a65480373d9abcdef',
+  name: 'authlab-maintenant',
+  image: 'ghcr.io/kolapsis/maintenant',
+  state: 'running',
+  health_status: 'healthy',
+  has_health_check: true,
+  is_ignored: false,
+  alert_severity: 'warning',
+  restart_threshold: 3,
+  archived: false,
+  first_seen_at: '2026-07-27T22:05:59Z',
+  last_state_change_at: '2026-07-27T22:05:59Z',
+} as ContainerDetailResponse
+
+function mountDetail() {
+  vi.mocked(getContainer).mockResolvedValue(container)
+  vi.mocked(listTransitions).mockResolvedValue({
+    container_id: 'ctr1',
+    transitions: [],
+    total: 0,
+    has_more: false,
+  })
+  return mount(ContainerDetail, {
+    props: { containerId: 'ctr1' },
+    global: {
+      plugins: [createPinia()],
+      stubs: {
+        // Pass-through so the gated children render, while exposing the key.
+        FeatureGate: {
+          props: ['feature'],
+          template: '<div :data-feature="feature"><slot /></div>',
+        },
+        LogViewer: true,
+        LogExpandedView: true,
+        ContainerEventTimeline: true,
+        UptimeBar90: true,
+        SecurityInsightList: true,
+        PostureScoreBadge: true,
+        PostureCategoryBreakdown: true,
+      },
+    },
+  })
+}
+
+async function settle(wrapper: ReturnType<typeof mountDetail>) {
+  await new Promise((r) => setTimeout(r, 50))
+  await wrapper.vm.$nextTick()
+}
+
+function resourcesTab(wrapper: ReturnType<typeof mountDetail>) {
+  return wrapper.findAll('button').find((b) => b.text().includes('Resources'))
+}
+
+describe('ContainerDetail — Resources tab', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('offers a Resources tab alongside Details and Logs', async () => {
+    const wrapper = mountDetail()
+    await settle(wrapper)
+
+    const labels = wrapper.findAll('button').map((b) => b.text())
+    expect(labels).toContain('Details')
+    expect(labels).toContain('Logs')
+    expect(labels).toContain('Resources')
+  })
+
+  // The charts fetch their history on mount, so keeping them out of the DOM
+  // until the tab is opened is what stops every panel from hitting the API.
+  it('does not mount the charts until the tab is opened', async () => {
+    const wrapper = mountDetail()
+    await settle(wrapper)
+
+    expect(wrapper.find('[data-test="resource-charts"]').exists()).toBe(false)
+  })
+
+  it('renders the charts and the alert thresholds once the tab is opened', async () => {
+    const wrapper = mountDetail()
+    await settle(wrapper)
+
+    await resourcesTab(wrapper)!.trigger('click')
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('[data-test="resource-charts"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="resource-alerts"]').exists()).toBe(true)
+  })
+
+  it('gates the tab content behind the resource_history feature', async () => {
+    const wrapper = mountDetail()
+    await settle(wrapper)
+
+    await resourcesTab(wrapper)!.trigger('click')
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('[data-feature="resource_history"]').exists()).toBe(true)
+  })
+
+  it('leaves the Details tab intact', async () => {
+    const wrapper = mountDetail()
+    await settle(wrapper)
+
+    expect(wrapper.text()).toContain('External ID')
+
+    await resourcesTab(wrapper)!.trigger('click')
+    await wrapper.vm.$nextTick()
+    expect(wrapper.text()).not.toContain('External ID')
+
+    const detailsTab = wrapper.findAll('button').find((b) => b.text().includes('Details'))
+    await detailsTab!.trigger('click')
+    await wrapper.vm.$nextTick()
+    expect(wrapper.text()).toContain('External ID')
+  })
+})

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // Config holds all application configuration parsed from environment variables.
@@ -24,7 +25,8 @@ type Config struct {
 	BaseURL string
 
 	// Database
-	DBPath string
+	DBPath    string
+	Retention RetentionConfig
 
 	// License
 	LicenseKey string
@@ -92,6 +94,16 @@ type MultiHostConfig struct {
 	EmbeddedAgent      bool
 }
 
+// RetentionConfig holds the tunable part of the retention cleanup. Zero values
+// mean "use the store defaults".
+type RetentionConfig struct {
+	// Snapshots is how long raw resource samples are kept. Lowering it below
+	// 168h also shortens the 7-day resource graphs, which aggregate raw rows.
+	Snapshots time.Duration
+	Interval  time.Duration
+	BatchSize int
+}
+
 // SMTPConfig holds SMTP mail server configuration.
 type SMTPConfig struct {
 	Host     string
@@ -151,6 +163,12 @@ func ConfigFromEnv() Config {
 		}
 	}
 
+	cfg.Retention = RetentionConfig{
+		Snapshots: envDurationOr("MAINTENANT_RETENTION_SNAPSHOTS", 7*24*time.Hour),
+		Interval:  envDurationOr("MAINTENANT_RETENTION_INTERVAL", time.Hour),
+		BatchSize: envIntOr("MAINTENANT_RETENTION_BATCH_SIZE", 1000),
+	}
+
 	cfg.DisableTelemetry = parseTruthy(os.Getenv("MAINTENANT_DISABLE_TELEMETRY"))
 	cfg.AllowPrivateWebhooks = parseTruthy(os.Getenv("MAINTENANT_ALLOW_PRIVATE_WEBHOOKS"))
 
@@ -191,6 +209,15 @@ func envIntOr(key string, fallback int) int {
 	if v := os.Getenv(key); v != "" {
 		if n, err := strconv.Atoi(v); err == nil && n > 0 {
 			return n
+		}
+	}
+	return fallback
+}
+
+func envDurationOr(key string, fallback time.Duration) time.Duration {
+	if v := os.Getenv(key); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d > 0 {
+			return d
 		}
 	}
 	return fallback

--- a/internal/app/config_test.go
+++ b/internal/app/config_test.go
@@ -1,0 +1,51 @@
+// Copyright 2026 Benjamin Touchard (Kolapsis)
+//
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+// or a commercial license. You may not use this file except in compliance
+// with one of these licenses.
+//
+// AGPL-3.0: https://www.gnu.org/licenses/agpl-3.0.html
+// Commercial: See COMMERCIAL-LICENSE.md
+//
+// Source: https://github.com/kolapsis/maintenant
+
+package app
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfigFromEnv_Retention(t *testing.T) {
+	t.Run("defaults when unset", func(t *testing.T) {
+		cfg := ConfigFromEnv()
+		assert.Equal(t, 7*24*time.Hour, cfg.Retention.Snapshots)
+		assert.Equal(t, time.Hour, cfg.Retention.Interval)
+		assert.Equal(t, 1000, cfg.Retention.BatchSize)
+	})
+
+	t.Run("values are read", func(t *testing.T) {
+		t.Setenv("MAINTENANT_RETENTION_SNAPSHOTS", "48h")
+		t.Setenv("MAINTENANT_RETENTION_INTERVAL", "15m")
+		t.Setenv("MAINTENANT_RETENTION_BATCH_SIZE", "5000")
+
+		cfg := ConfigFromEnv()
+		assert.Equal(t, 48*time.Hour, cfg.Retention.Snapshots)
+		assert.Equal(t, 15*time.Minute, cfg.Retention.Interval)
+		assert.Equal(t, 5000, cfg.Retention.BatchSize)
+	})
+
+	// Unparseable or negative values fall back rather than disabling the purge.
+	t.Run("invalid values fall back to defaults", func(t *testing.T) {
+		t.Setenv("MAINTENANT_RETENTION_SNAPSHOTS", "abc")
+		t.Setenv("MAINTENANT_RETENTION_INTERVAL", "-5m")
+		t.Setenv("MAINTENANT_RETENTION_BATCH_SIZE", "not-a-number")
+
+		cfg := ConfigFromEnv()
+		assert.Equal(t, 7*24*time.Hour, cfg.Retention.Snapshots)
+		assert.Equal(t, time.Hour, cfg.Retention.Interval)
+		assert.Equal(t, 1000, cfg.Retention.BatchSize)
+	})
+}

--- a/internal/app/lifecycle.go
+++ b/internal/app/lifecycle.go
@@ -312,6 +312,11 @@ func (a *App) startRetentionCleanup(ctx context.Context) {
 		HeartbeatStore:   a.hbStore,
 		CertificateStore: a.certStore,
 		ResourceStore:    a.resStore,
+		Config: sqlite.RetentionConfig{
+			Snapshots: a.cfg.Retention.Snapshots,
+			Interval:  a.cfg.Retention.Interval,
+			BatchSize: a.cfg.Retention.BatchSize,
+		},
 	})
 
 	// Alert retention cleanup (90 days)

--- a/internal/store/sqlite/batchdelete.go
+++ b/internal/store/sqlite/batchdelete.go
@@ -1,0 +1,90 @@
+// Copyright 2026 Benjamin Touchard (Kolapsis)
+//
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+// or a commercial license. You may not use this file except in compliance
+// with one of these licenses.
+//
+// AGPL-3.0: https://www.gnu.org/licenses/agpl-3.0.html
+// Commercial: See COMMERCIAL-LICENSE.md
+//
+// Source: https://github.com/kolapsis/maintenant
+
+package sqlite
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+const defaultBatchSize = 1000
+
+// batchOpts bounds a batched delete: batchSize caps the rows removed per
+// transaction, budget caps how long the loop may hold the serialized writer.
+type batchOpts struct {
+	batchSize int
+	budget    time.Duration // 0 = no time limit
+}
+
+func (o batchOpts) normalized() batchOpts {
+	if o.batchSize <= 0 {
+		o.batchSize = defaultBatchSize
+	}
+	return o
+}
+
+// runBatchedDelete repeats step until it stops filling a batch, the context is
+// cancelled, or the time budget runs out. truncated reports that rows matching
+// the cutoff are still present, so the caller should come back sooner.
+//
+// A cancelled context is not an error: the rows deleted so far are committed and
+// the remaining ones are picked up by the next run.
+func runBatchedDelete(ctx context.Context, o batchOpts, step func(context.Context, int) (int64, error)) (total int64, truncated bool, err error) {
+	o = o.normalized()
+	var deadline time.Time
+	if o.budget > 0 {
+		deadline = time.Now().Add(o.budget)
+	}
+
+	for {
+		if ctx.Err() != nil {
+			return total, true, nil
+		}
+
+		affected, err := step(ctx, o.batchSize)
+		total += affected
+		if err != nil {
+			return total, true, err
+		}
+		// Two exit conditions rather than one: a partial batch means the table is
+		// drained, and a zero batch guards against a LIMIT that yields nothing.
+		if affected == 0 || affected < int64(o.batchSize) {
+			return total, false, nil
+		}
+
+		if !deadline.IsZero() && time.Now().After(deadline) {
+			return total, true, nil
+		}
+	}
+}
+
+// deleteRowsBefore drains every row of table whose col is older than before.
+// It deletes by rowid: the subquery is then served by the index on col alone,
+// without reading the table to resolve a TEXT uuid primary key.
+//
+// table and col are package-level literals, never user input.
+func deleteRowsBefore(ctx context.Context, w *Writer, o batchOpts, table, col string, before time.Time) (int64, bool, error) {
+	query := fmt.Sprintf(
+		`DELETE FROM %s WHERE rowid IN (SELECT rowid FROM %s WHERE %s<? LIMIT ?)`,
+		table, table, col)
+	cutoff := before.Unix()
+
+	total, truncated, err := runBatchedDelete(ctx, o, func(ctx context.Context, batchSize int) (int64, error) {
+		res, err := w.Exec(ctx, query, cutoff, batchSize)
+		if err != nil {
+			return res.RowsAffected, fmt.Errorf("delete from %s: %w", table, err)
+		}
+		return res.RowsAffected, nil
+	})
+	return total, truncated, err
+}

--- a/internal/store/sqlite/certificates.go
+++ b/internal/store/sqlite/certificates.go
@@ -412,30 +412,30 @@ func (s *CertificateStore) ListMonitorsByExternalID(ctx context.Context, externa
 // --- Retention ---
 
 func (s *CertificateStore) DeleteCheckResultsBefore(ctx context.Context, before time.Time, batchSize int) (int64, error) {
-	var totalDeleted int64
-	for {
+	deleted, _, err := s.deleteCheckResultsBefore(ctx, before, batchOpts{batchSize: batchSize})
+	return deleted, err
+}
+
+func (s *CertificateStore) deleteCheckResultsBefore(ctx context.Context, before time.Time, o batchOpts) (int64, bool, error) {
+	cutoff := before.Unix()
+	return runBatchedDelete(ctx, o, func(ctx context.Context, batchSize int) (int64, error) {
 		// First, delete chain entries for the check results we're about to delete
-		_, err := s.writer.Exec(ctx,
+		if _, err := s.writer.Exec(ctx,
 			`DELETE FROM cert_chain_entries WHERE check_result_id IN (
 				SELECT id FROM cert_check_results WHERE checked_at<? LIMIT ?
-			)`, before.Unix(), batchSize)
-		if err != nil {
-			return totalDeleted, fmt.Errorf("delete cert chain entries: %w", err)
+			)`, cutoff, batchSize); err != nil {
+			return 0, fmt.Errorf("delete cert chain entries: %w", err)
 		}
 
 		res, err := s.writer.Exec(ctx,
 			`DELETE FROM cert_check_results WHERE rowid IN (
 				SELECT rowid FROM cert_check_results WHERE checked_at<? LIMIT ?
-			)`, before.Unix(), batchSize)
+			)`, cutoff, batchSize)
 		if err != nil {
-			return totalDeleted, fmt.Errorf("delete cert check results: %w", err)
+			return res.RowsAffected, fmt.Errorf("delete cert check results: %w", err)
 		}
-		totalDeleted += res.RowsAffected
-		if res.RowsAffected < int64(batchSize) {
-			break
-		}
-	}
-	return totalDeleted, nil
+		return res.RowsAffected, nil
+	})
 }
 
 // --- Scanners ---

--- a/internal/store/sqlite/containers.go
+++ b/internal/store/sqlite/containers.go
@@ -323,21 +323,12 @@ func (s *ContainerStore) GetTransitionsInWindow(ctx context.Context, containerID
 }
 
 func (s *ContainerStore) DeleteTransitionsBefore(ctx context.Context, before time.Time, batchSize int) (int64, error) {
-	var totalDeleted int64
-	for {
-		res, err := s.writer.Exec(ctx,
-			`DELETE FROM state_transitions WHERE rowid IN (
-				SELECT rowid FROM state_transitions WHERE timestamp<? LIMIT ?
-			)`, before.Unix(), batchSize)
-		if err != nil {
-			return totalDeleted, fmt.Errorf("delete transitions: %w", err)
-		}
-		totalDeleted += res.RowsAffected
-		if res.RowsAffected < int64(batchSize) {
-			break
-		}
-	}
-	return totalDeleted, nil
+	deleted, _, err := s.deleteTransitionsBefore(ctx, before, batchOpts{batchSize: batchSize})
+	return deleted, err
+}
+
+func (s *ContainerStore) deleteTransitionsBefore(ctx context.Context, before time.Time, o batchOpts) (int64, bool, error) {
+	return deleteRowsBefore(ctx, s.writer, o, "state_transitions", "timestamp", before)
 }
 
 func (s *ContainerStore) DeleteArchivedContainersBefore(ctx context.Context, before time.Time) (int64, error) {

--- a/internal/store/sqlite/db.go
+++ b/internal/store/sqlite/db.go
@@ -17,14 +17,45 @@ import (
 	"fmt"
 	"log/slog"
 
-	_ "github.com/mattn/go-sqlite3"
+	"github.com/mattn/go-sqlite3"
 )
+
+// driverName registers our own driver so every pooled connection gets the
+// per-connection PRAGMAs below. They are not persisted in the database file and
+// the go-sqlite3 DSN parser does not accept them, so a ConnectHook is the only
+// way to apply them to connections the pool opens later.
+const driverName = "sqlite3_maintenant"
+
+func init() {
+	// These bound the WAL. Without journal_size_limit the -wal file grows
+	// without limit on a continuously written database and is only truncated
+	// when the process restarts.
+	pragmas := []string{
+		"PRAGMA wal_autocheckpoint = 1000",     // pages, ~4 MB
+		"PRAGMA journal_size_limit = 67108864", // 64 MiB
+	}
+	sql.Register(driverName, &sqlite3.SQLiteDriver{
+		ConnectHook: func(conn *sqlite3.SQLiteConn) error {
+			for _, p := range pragmas {
+				if _, err := conn.Exec(p, nil); err != nil {
+					return fmt.Errorf("exec pragma %q: %w", p, err)
+				}
+			}
+			return nil
+		},
+	})
+}
 
 // DB wraps a SQLite database connection with maintenant configuration.
 type DB struct {
 	db     *sql.DB
 	writer *Writer
 	logger *slog.Logger
+
+	// incrementalVacuum records whether the file header allows reclaiming pages
+	// without a full VACUUM. Databases created before auto_vacuum was set stay
+	// in NONE mode for good, and incremental_vacuum is a no-op on them.
+	incrementalVacuum bool
 }
 
 // Open creates and configures a SQLite database connection with WAL mode.
@@ -35,9 +66,12 @@ type DB struct {
 // A Postgres backend is a drop-in: its own Open (pgx DSN), a `?`→`$n` placeholder
 // rewrite, and a Postgres migrations dir — no schema or query changes.
 func Open(dbPath string, logger *slog.Logger) (*DB, error) {
-	dsn := fmt.Sprintf("file:%s?_journal_mode=WAL&_busy_timeout=5000&_synchronous=NORMAL&_cache_size=-8000&_foreign_keys=ON", dbPath)
+	// auto_vacuum has to be part of the DSN, not a later Exec: switching to WAL
+	// writes the file header, and once that is done the pragma is silently
+	// ignored. The driver applies the DSN pragmas in the working order.
+	dsn := fmt.Sprintf("file:%s?_journal_mode=WAL&_auto_vacuum=incremental&_busy_timeout=5000&_synchronous=NORMAL&_cache_size=-8000&_foreign_keys=ON", dbPath)
 
-	db, err := sql.Open("sqlite3", dsn)
+	db, err := sql.Open(driverName, dsn)
 	if err != nil {
 		return nil, fmt.Errorf("open sqlite: %w", err)
 	}
@@ -46,25 +80,43 @@ func Open(dbPath string, logger *slog.Logger) (*DB, error) {
 	// but allow multiple read connections.
 	db.SetMaxOpenConns(4)
 
-	// Apply PRAGMAs that can't be set via DSN
-	pragmas := []string{
-		"PRAGMA auto_vacuum = INCREMENTAL",
-		"PRAGMA wal_autocheckpoint = 1000",
-	}
-	for _, p := range pragmas {
-		if _, err := db.Exec(p); err != nil {
-			_ = db.Close()
-			return nil, fmt.Errorf("exec pragma %q: %w", p, err)
-		}
-	}
-
 	sdb := &DB{
 		db:     db,
 		writer: NewWriter(db, logger),
 		logger: logger,
 	}
+	sdb.readStorageMode()
 
 	return sdb, nil
+}
+
+// readStorageMode reports the settings that decide whether freed pages ever
+// return to the filesystem, and records the answer for the retention cleanup.
+func (d *DB) readStorageMode() {
+	var autoVacuum, pageSize, freelist int
+	row := d.db.QueryRow("PRAGMA auto_vacuum")
+	if err := row.Scan(&autoVacuum); err != nil {
+		d.logger.Warn("sqlite: cannot read storage mode", "error", err)
+		return
+	}
+	_ = d.db.QueryRow("PRAGMA page_size").Scan(&pageSize)
+	_ = d.db.QueryRow("PRAGMA freelist_count").Scan(&freelist)
+
+	modes := map[int]string{0: "none", 1: "full", 2: "incremental"}
+	mode, ok := modes[autoVacuum]
+	if !ok {
+		mode = fmt.Sprintf("unknown(%d)", autoVacuum)
+	}
+	d.incrementalVacuum = autoVacuum == 2
+
+	d.logger.Info("sqlite storage",
+		"auto_vacuum", mode,
+		"page_size", pageSize,
+		"freelist_pages", freelist)
+	if autoVacuum == 0 {
+		d.logger.Warn("sqlite: auto_vacuum is NONE, space freed by retention stays inside the file; run a manual VACUUM to return it to the filesystem",
+			"reclaimable_pages", freelist)
+	}
 }
 
 // StartWriter starts the single-writer goroutine.

--- a/internal/store/sqlite/db_test.go
+++ b/internal/store/sqlite/db_test.go
@@ -1,6 +1,8 @@
 package sqlite
 
 import (
+	"context"
+	"database/sql"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -24,4 +26,46 @@ func TestWriterAvailableBeforeStart(t *testing.T) {
 
 	w := db.Writer()
 	assert.NotNil(t, w, "Writer() must return a non-nil *Writer before StartWriter is called")
+}
+
+// A database created by Open must end up in incremental auto-vacuum mode, which
+// is what lets retention hand freed pages back to the filesystem. The mode can
+// only be set while the file is still empty, so this has to hold from the start.
+func TestOpenEnablesIncrementalAutoVacuum(t *testing.T) {
+	db := openTestDB(t)
+
+	var mode int
+	require.NoError(t, db.ReadDB().QueryRow("PRAGMA auto_vacuum").Scan(&mode))
+	assert.Equal(t, 2, mode, "a fresh database must use incremental auto-vacuum")
+	assert.True(t, db.incrementalVacuum, "Open must record the mode for the retention cleanup")
+}
+
+// journal_size_limit and wal_autocheckpoint are per-connection settings, so
+// running them once through *sql.DB only configures whichever connection the
+// pool happened to hand out. An unbounded WAL on the other connections is what
+// let the -wal file reach hundreds of megabytes in production.
+func TestOpenAppliesPragmasToEveryPooledConnection(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+
+	// Hold every connection of the pool at once so each one is distinct.
+	conns := make([]*sql.Conn, 0, 4)
+	defer func() {
+		for _, c := range conns {
+			_ = c.Close()
+		}
+	}()
+
+	for i := range 4 {
+		conn, err := db.ReadDB().Conn(ctx)
+		require.NoError(t, err)
+		conns = append(conns, conn)
+
+		var sizeLimit, autocheckpoint int64
+		require.NoError(t, conn.QueryRowContext(ctx, "PRAGMA journal_size_limit").Scan(&sizeLimit))
+		require.NoError(t, conn.QueryRowContext(ctx, "PRAGMA wal_autocheckpoint").Scan(&autocheckpoint))
+
+		assert.EqualValues(t, 67108864, sizeLimit, "connection %d has an unbounded WAL", i)
+		assert.EqualValues(t, 1000, autocheckpoint, "connection %d has no autocheckpoint", i)
+	}
 }

--- a/internal/store/sqlite/endpoints.go
+++ b/internal/store/sqlite/endpoints.go
@@ -293,21 +293,12 @@ func (s *EndpointStore) GetCheckResultsInWindow(ctx context.Context, endpointID 
 }
 
 func (s *EndpointStore) DeleteCheckResultsBefore(ctx context.Context, before time.Time, batchSize int) (int64, error) {
-	var totalDeleted int64
-	for {
-		res, err := s.writer.Exec(ctx,
-			`DELETE FROM check_results WHERE rowid IN (
-				SELECT rowid FROM check_results WHERE timestamp<? LIMIT ?
-			)`, before.Unix(), batchSize)
-		if err != nil {
-			return totalDeleted, fmt.Errorf("delete check results: %w", err)
-		}
-		totalDeleted += res.RowsAffected
-		if res.RowsAffected < int64(batchSize) {
-			break
-		}
-	}
-	return totalDeleted, nil
+	deleted, _, err := s.deleteCheckResultsBefore(ctx, before, batchOpts{batchSize: batchSize})
+	return deleted, err
+}
+
+func (s *EndpointStore) deleteCheckResultsBefore(ctx context.Context, before time.Time, o batchOpts) (int64, bool, error) {
+	return deleteRowsBefore(ctx, s.writer, o, "check_results", "timestamp", before)
 }
 
 func (s *EndpointStore) DeleteInactiveEndpointsBefore(ctx context.Context, before time.Time) (int64, error) {

--- a/internal/store/sqlite/heartbeats.go
+++ b/internal/store/sqlite/heartbeats.go
@@ -411,39 +411,31 @@ func (s *HeartbeatStore) ListExecutions(ctx context.Context, heartbeatID string,
 // --- Retention ---
 
 func (s *HeartbeatStore) DeletePingsBefore(ctx context.Context, before time.Time, batchSize int) (int64, error) {
-	var totalDeleted int64
-	for {
-		res, err := s.writer.Exec(ctx,
-			`DELETE FROM heartbeat_pings WHERE rowid IN (
-				SELECT rowid FROM heartbeat_pings WHERE timestamp<? LIMIT ?
-			)`, before.Unix(), batchSize)
-		if err != nil {
-			return totalDeleted, fmt.Errorf("delete heartbeat pings: %w", err)
-		}
-		totalDeleted += res.RowsAffected
-		if res.RowsAffected < int64(batchSize) {
-			break
-		}
-	}
-	return totalDeleted, nil
+	deleted, _, err := s.deletePingsBefore(ctx, before, batchOpts{batchSize: batchSize})
+	return deleted, err
+}
+
+func (s *HeartbeatStore) deletePingsBefore(ctx context.Context, before time.Time, o batchOpts) (int64, bool, error) {
+	return deleteRowsBefore(ctx, s.writer, o, "heartbeat_pings", "timestamp", before)
 }
 
 func (s *HeartbeatStore) DeleteExecutionsBefore(ctx context.Context, before time.Time, batchSize int) (int64, error) {
-	var totalDeleted int64
-	for {
+	deleted, _, err := s.deleteExecutionsBefore(ctx, before, batchOpts{batchSize: batchSize})
+	return deleted, err
+}
+
+func (s *HeartbeatStore) deleteExecutionsBefore(ctx context.Context, before time.Time, o batchOpts) (int64, bool, error) {
+	cutoff := before.Unix()
+	return runBatchedDelete(ctx, o, func(ctx context.Context, batchSize int) (int64, error) {
 		res, err := s.writer.Exec(ctx,
 			`DELETE FROM heartbeat_executions WHERE rowid IN (
 				SELECT rowid FROM heartbeat_executions WHERE completed_at IS NOT NULL AND completed_at<? LIMIT ?
-			)`, before.Unix(), batchSize)
+			)`, cutoff, batchSize)
 		if err != nil {
-			return totalDeleted, fmt.Errorf("delete heartbeat executions: %w", err)
+			return res.RowsAffected, fmt.Errorf("delete heartbeat executions: %w", err)
 		}
-		totalDeleted += res.RowsAffected
-		if res.RowsAffected < int64(batchSize) {
-			break
-		}
-	}
-	return totalDeleted, nil
+		return res.RowsAffected, nil
+	})
 }
 
 // --- Scanners ---

--- a/internal/store/sqlite/resources.go
+++ b/internal/store/sqlite/resources.go
@@ -135,13 +135,12 @@ func (s *ResourceStore) UpsertAlertConfig(ctx context.Context, cfg *resource.Res
 }
 
 func (s *ResourceStore) DeleteSnapshotsBefore(ctx context.Context, before time.Time, batchSize int) (int64, error) {
-	res, err := s.writer.Exec(ctx,
-		`DELETE FROM resource_snapshots WHERE id IN (SELECT id FROM resource_snapshots WHERE timestamp < ? LIMIT ?)`,
-		before.Unix(), batchSize)
-	if err != nil {
-		return 0, fmt.Errorf("delete snapshots before: %w", err)
-	}
-	return res.RowsAffected, nil
+	deleted, _, err := s.deleteSnapshotsBefore(ctx, before, batchOpts{batchSize: batchSize})
+	return deleted, err
+}
+
+func (s *ResourceStore) deleteSnapshotsBefore(ctx context.Context, before time.Time, o batchOpts) (int64, bool, error) {
+	return deleteRowsBefore(ctx, s.writer, o, "resource_snapshots", "timestamp", before)
 }
 
 // rowScanner is implemented by both *sql.Row and *sql.Rows.
@@ -369,23 +368,21 @@ const rollupRowID = `lower(hex(randomblob(4))) || '-' || lower(hex(randomblob(2)
 	`lower(hex(randomblob(6)))`
 
 func (s *ResourceStore) DeleteHourlyBefore(ctx context.Context, before time.Time, batchSize int) (int64, error) {
-	res, err := s.writer.Exec(ctx,
-		`DELETE FROM resource_hourly WHERE id IN (SELECT id FROM resource_hourly WHERE bucket < ? LIMIT ?)`,
-		before.Unix(), batchSize)
-	if err != nil {
-		return 0, fmt.Errorf("delete hourly before: %w", err)
-	}
-	return res.RowsAffected, nil
+	deleted, _, err := s.deleteHourlyBefore(ctx, before, batchOpts{batchSize: batchSize})
+	return deleted, err
+}
+
+func (s *ResourceStore) deleteHourlyBefore(ctx context.Context, before time.Time, o batchOpts) (int64, bool, error) {
+	return deleteRowsBefore(ctx, s.writer, o, "resource_hourly", "bucket", before)
 }
 
 func (s *ResourceStore) DeleteDailyBefore(ctx context.Context, before time.Time, batchSize int) (int64, error) {
-	res, err := s.writer.Exec(ctx,
-		`DELETE FROM resource_daily WHERE id IN (SELECT id FROM resource_daily WHERE bucket < ? LIMIT ?)`,
-		before.Unix(), batchSize)
-	if err != nil {
-		return 0, fmt.Errorf("delete daily before: %w", err)
-	}
-	return res.RowsAffected, nil
+	deleted, _, err := s.deleteDailyBefore(ctx, before, batchOpts{batchSize: batchSize})
+	return deleted, err
+}
+
+func (s *ResourceStore) deleteDailyBefore(ctx context.Context, before time.Time, o batchOpts) (int64, bool, error) {
+	return deleteRowsBefore(ctx, s.writer, o, "resource_daily", "bucket", before)
 }
 
 func granularityToSeconds(g resource.Granularity) int64 {

--- a/internal/store/sqlite/retention.go
+++ b/internal/store/sqlite/retention.go
@@ -13,14 +13,17 @@ package sqlite
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"time"
 )
 
 const (
 	retentionInterval         = 1 * time.Hour
+	retentionCatchUpInterval  = 1 * time.Minute
+	retentionBudgetPerTable   = 2 * time.Minute
 	defaultRetention          = 90 * 24 * time.Hour // 90 days
-	retentionBatchSize        = 1000
+	retentionBatchSize        = defaultBatchSize
 	archivedRetention         = 30 * 24 * time.Hour  // 30 days
 	checkResultRetention      = 30 * 24 * time.Hour  // 30 days
 	inactiveEndpointRetention = 30 * 24 * time.Hour  // 30 days
@@ -30,7 +33,105 @@ const (
 	resourceSnapshotRetention = 7 * 24 * time.Hour   // 7 days
 	resourceHourlyRetention   = 90 * 24 * time.Hour  // 90 days
 	resourceDailyRetention    = 365 * 24 * time.Hour // 1 year
+
+	// Below this many deleted rows an autocheckpoint keeps up on its own and
+	// forcing a truncating checkpoint is just noise.
+	checkpointRowThreshold = 50000
 )
+
+// RetentionConfig tunes the retention cleanup. A zero value means "use the
+// defaults", so an empty struct reproduces the historical behaviour.
+type RetentionConfig struct {
+	// Scheduling
+	Interval        time.Duration // between two full passes
+	CatchUpInterval time.Duration // used instead of Interval while a backlog remains
+	BudgetPerTable  time.Duration // caps how long one table may hold the writer
+	BatchSize       int           // rows deleted per transaction
+
+	// Windows
+	Snapshots         time.Duration
+	Hourly            time.Duration
+	Daily             time.Duration
+	Transitions       time.Duration
+	Archived          time.Duration
+	CheckResults      time.Duration
+	InactiveEndpoints time.Duration
+	HeartbeatPings    time.Duration
+	HeartbeatExecs    time.Duration
+	CertCheckResults  time.Duration
+}
+
+// withDefaults fills unset fields and rejects values that would break the loop
+// (an interval shorter than a pass, a batch size that never terminates, a raw
+// window too short to feed the 7-day resource graphs).
+func (c RetentionConfig) withDefaults(logger *slog.Logger) RetentionConfig {
+	c.Interval = clampDuration(logger, "retention interval", c.Interval, retentionInterval, time.Minute)
+	c.CatchUpInterval = clampDuration(logger, "retention catch-up interval", c.CatchUpInterval, retentionCatchUpInterval, 10*time.Second)
+	c.BudgetPerTable = clampDuration(logger, "retention budget", c.BudgetPerTable, retentionBudgetPerTable, 10*time.Second)
+	if c.BudgetPerTable > 30*time.Minute {
+		logger.Warn("retention: budget above maximum, clamping", "requested", c.BudgetPerTable, "used", 30*time.Minute)
+		c.BudgetPerTable = 30 * time.Minute
+	}
+
+	switch {
+	case c.BatchSize == 0:
+		c.BatchSize = retentionBatchSize
+	case c.BatchSize < 100:
+		logger.Warn("retention: batch size below minimum, clamping", "requested", c.BatchSize, "used", 100)
+		c.BatchSize = 100
+	case c.BatchSize > 100000:
+		logger.Warn("retention: batch size above maximum, clamping", "requested", c.BatchSize, "used", 100000)
+		c.BatchSize = 100000
+	}
+
+	// Resource graphs aggregate raw snapshots even for the 7-day range, so a
+	// shorter window silently shortens the charts.
+	c.Snapshots = clampDuration(logger, "resource snapshot retention", c.Snapshots, resourceSnapshotRetention, 24*time.Hour)
+
+	c.Hourly = orDefault(c.Hourly, resourceHourlyRetention)
+	c.Daily = orDefault(c.Daily, resourceDailyRetention)
+	c.Transitions = orDefault(c.Transitions, defaultRetention)
+	c.Archived = orDefault(c.Archived, archivedRetention)
+	c.CheckResults = orDefault(c.CheckResults, checkResultRetention)
+	c.InactiveEndpoints = orDefault(c.InactiveEndpoints, inactiveEndpointRetention)
+	c.HeartbeatPings = orDefault(c.HeartbeatPings, heartbeatPingRetention)
+	c.HeartbeatExecs = orDefault(c.HeartbeatExecs, heartbeatExecRetention)
+	c.CertCheckResults = orDefault(c.CertCheckResults, certCheckResultRetention)
+
+	return c
+}
+
+func orDefault(v, def time.Duration) time.Duration {
+	if v <= 0 {
+		return def
+	}
+	return v
+}
+
+func clampDuration(logger *slog.Logger, name string, v, def, floor time.Duration) time.Duration {
+	if v <= 0 {
+		return def
+	}
+	if v < floor {
+		logger.Warn("retention: "+name+" below minimum, clamping", "requested", v, "used", floor)
+		return floor
+	}
+	return v
+}
+
+func (c RetentionConfig) batchOpts() batchOpts {
+	return batchOpts{batchSize: c.BatchSize, budget: c.BudgetPerTable}
+}
+
+// nextDelay decides when the following pass runs. A pass that stopped on its
+// budget left rows behind, so waiting a full interval would let the backlog grow
+// again — exactly the failure this cleanup is meant to avoid.
+func (c RetentionConfig) nextDelay(truncated bool) time.Duration {
+	if truncated {
+		return c.CatchUpInterval
+	}
+	return c.Interval
+}
 
 // RetentionOpts holds optional stores for retention cleanup.
 type RetentionOpts struct {
@@ -38,41 +139,87 @@ type RetentionOpts struct {
 	HeartbeatStore   *HeartbeatStore
 	CertificateStore *CertificateStore
 	ResourceStore    *ResourceStore
+	Config           RetentionConfig
+}
+
+// retentionPass accumulates what one pass did, so the scheduler knows whether a
+// backlog remains and the vacuum knows whether it is worth running.
+type retentionPass struct {
+	deleted   int64
+	truncated bool
+}
+
+func (p *retentionPass) add(deleted int64, truncated bool) {
+	p.deleted += deleted
+	p.truncated = p.truncated || truncated
 }
 
 // StartRetentionCleanupWithOpts starts retention cleanup with all store types.
+// The first pass runs immediately: an instance that restarts every few hours
+// would otherwise never reach its first cleanup.
 func StartRetentionCleanupWithOpts(ctx context.Context, store *ContainerStore, db *DB, logger *slog.Logger, opts RetentionOpts) {
+	cfg := opts.Config.withDefaults(logger)
+	logger.Info("retention cleanup: starting",
+		"interval", cfg.Interval.String(),
+		"batch_size", cfg.BatchSize,
+		"snapshot_window", cfg.Snapshots.String())
+
 	go func() {
-		ticker := time.NewTicker(retentionInterval)
-		defer ticker.Stop()
+		timer := time.NewTimer(0)
+		defer timer.Stop()
 
 		for {
 			select {
 			case <-ctx.Done():
 				return
-			case <-ticker.C:
-				runCleanup(ctx, store, db, logger)
-				if opts.EndpointStore != nil {
-					runEndpointCleanup(ctx, opts.EndpointStore, logger)
-				}
-				if opts.HeartbeatStore != nil {
-					runHeartbeatCleanup(ctx, opts.HeartbeatStore, logger)
-				}
-				if opts.CertificateStore != nil {
-					runCertificateCleanup(ctx, opts.CertificateStore, logger)
-				}
-				if opts.ResourceStore != nil {
-					runResourceCleanup(ctx, opts.ResourceStore, logger)
-				}
+			case <-timer.C:
 			}
+
+			truncated := runRetentionPass(ctx, store, db, logger, opts, cfg)
+			timer.Reset(cfg.nextDelay(truncated))
 		}
 	}()
 }
 
-func runCleanup(ctx context.Context, store *ContainerStore, db *DB, logger *slog.Logger) {
+// runRetentionPass runs every cleanup once and reports whether rows matching the
+// retention windows are still present.
+func runRetentionPass(ctx context.Context, store *ContainerStore, db *DB, logger *slog.Logger, opts RetentionOpts, cfg RetentionConfig) bool {
+	started := time.Now()
+	var pass retentionPass
+
+	runCleanup(ctx, store, logger, cfg, &pass)
+	if opts.EndpointStore != nil {
+		runEndpointCleanup(ctx, opts.EndpointStore, logger, cfg, &pass)
+	}
+	if opts.HeartbeatStore != nil {
+		runHeartbeatCleanup(ctx, opts.HeartbeatStore, logger, cfg, &pass)
+	}
+	if opts.CertificateStore != nil {
+		runCertificateCleanup(ctx, opts.CertificateStore, logger, cfg, &pass)
+	}
+	if opts.ResourceStore != nil {
+		runResourceCleanup(ctx, opts.ResourceStore, logger, cfg, &pass)
+	}
+
+	if pass.deleted > 0 {
+		logger.Info("retention cleanup: pass complete",
+			"deleted", pass.deleted,
+			"duration", time.Since(started).Round(time.Millisecond).String(),
+			"backlog_remaining", pass.truncated)
+		reclaimSpace(ctx, db, logger, cfg.BudgetPerTable, pass.deleted)
+	}
+	if pass.truncated {
+		logger.Warn("retention cleanup: budget exhausted, resuming shortly",
+			"next_pass_in", cfg.CatchUpInterval.String())
+	}
+	return pass.truncated
+}
+
+func runCleanup(ctx context.Context, store *ContainerStore, logger *slog.Logger, cfg RetentionConfig, pass *retentionPass) {
 	// Clean old transitions
-	cutoff := time.Now().Add(-defaultRetention)
-	deleted, err := store.DeleteTransitionsBefore(ctx, cutoff, retentionBatchSize)
+	cutoff := time.Now().Add(-cfg.Transitions)
+	deleted, truncated, err := store.deleteTransitionsBefore(ctx, cutoff, cfg.batchOpts())
+	pass.add(deleted, truncated)
 	if err != nil {
 		logger.Error("retention cleanup: transitions", "error", err)
 	} else if deleted > 0 {
@@ -80,26 +227,21 @@ func runCleanup(ctx context.Context, store *ContainerStore, db *DB, logger *slog
 	}
 
 	// Clean old archived containers
-	archiveCutoff := time.Now().Add(-archivedRetention)
+	archiveCutoff := time.Now().Add(-cfg.Archived)
 	archivedDeleted, err := store.DeleteArchivedContainersBefore(ctx, archiveCutoff)
+	pass.add(archivedDeleted, false)
 	if err != nil {
 		logger.Error("retention cleanup: archived containers", "error", err)
 	} else if archivedDeleted > 0 {
 		logger.Info("retention cleanup: deleted archived containers", "count", archivedDeleted)
 	}
-
-	// Incremental vacuum
-	if deleted > 0 || archivedDeleted > 0 {
-		if _, err := db.ReadDB().ExecContext(ctx, "PRAGMA incremental_vacuum(1000)"); err != nil {
-			logger.Error("retention cleanup: incremental vacuum", "error", err)
-		}
-	}
 }
 
-func runHeartbeatCleanup(ctx context.Context, store *HeartbeatStore, logger *slog.Logger) {
+func runHeartbeatCleanup(ctx context.Context, store *HeartbeatStore, logger *slog.Logger, cfg RetentionConfig, pass *retentionPass) {
 	// Clean old heartbeat pings
-	pingCutoff := time.Now().Add(-heartbeatPingRetention)
-	deleted, err := store.DeletePingsBefore(ctx, pingCutoff, retentionBatchSize)
+	pingCutoff := time.Now().Add(-cfg.HeartbeatPings)
+	deleted, truncated, err := store.deletePingsBefore(ctx, pingCutoff, cfg.batchOpts())
+	pass.add(deleted, truncated)
 	if err != nil {
 		logger.Error("retention cleanup: heartbeat pings", "error", err)
 	} else if deleted > 0 {
@@ -107,8 +249,9 @@ func runHeartbeatCleanup(ctx context.Context, store *HeartbeatStore, logger *slo
 	}
 
 	// Clean old heartbeat executions
-	execCutoff := time.Now().Add(-heartbeatExecRetention)
-	execDeleted, err := store.DeleteExecutionsBefore(ctx, execCutoff, retentionBatchSize)
+	execCutoff := time.Now().Add(-cfg.HeartbeatExecs)
+	execDeleted, execTruncated, err := store.deleteExecutionsBefore(ctx, execCutoff, cfg.batchOpts())
+	pass.add(execDeleted, execTruncated)
 	if err != nil {
 		logger.Error("retention cleanup: heartbeat executions", "error", err)
 	} else if execDeleted > 0 {
@@ -116,9 +259,10 @@ func runHeartbeatCleanup(ctx context.Context, store *HeartbeatStore, logger *slo
 	}
 }
 
-func runCertificateCleanup(ctx context.Context, store *CertificateStore, logger *slog.Logger) {
-	cutoff := time.Now().Add(-certCheckResultRetention)
-	deleted, err := store.DeleteCheckResultsBefore(ctx, cutoff, retentionBatchSize)
+func runCertificateCleanup(ctx context.Context, store *CertificateStore, logger *slog.Logger, cfg RetentionConfig, pass *retentionPass) {
+	cutoff := time.Now().Add(-cfg.CertCheckResults)
+	deleted, truncated, err := store.deleteCheckResultsBefore(ctx, cutoff, cfg.batchOpts())
+	pass.add(deleted, truncated)
 	if err != nil {
 		logger.Error("retention cleanup: cert check results", "error", err)
 	} else if deleted > 0 {
@@ -126,25 +270,28 @@ func runCertificateCleanup(ctx context.Context, store *CertificateStore, logger 
 	}
 }
 
-func runResourceCleanup(ctx context.Context, store *ResourceStore, logger *slog.Logger) {
-	cutoff := time.Now().Add(-resourceSnapshotRetention)
-	deleted, err := store.DeleteSnapshotsBefore(ctx, cutoff, retentionBatchSize)
+func runResourceCleanup(ctx context.Context, store *ResourceStore, logger *slog.Logger, cfg RetentionConfig, pass *retentionPass) {
+	cutoff := time.Now().Add(-cfg.Snapshots)
+	deleted, truncated, err := store.deleteSnapshotsBefore(ctx, cutoff, cfg.batchOpts())
+	pass.add(deleted, truncated)
 	if err != nil {
 		logger.Error("retention cleanup: resource snapshots", "error", err)
 	} else if deleted > 0 {
 		logger.Info("retention cleanup: deleted resource snapshots", "count", deleted)
 	}
 
-	hourlyCutoff := time.Now().Add(-resourceHourlyRetention)
-	hourlyDeleted, err := store.DeleteHourlyBefore(ctx, hourlyCutoff, retentionBatchSize)
+	hourlyCutoff := time.Now().Add(-cfg.Hourly)
+	hourlyDeleted, hourlyTruncated, err := store.deleteHourlyBefore(ctx, hourlyCutoff, cfg.batchOpts())
+	pass.add(hourlyDeleted, hourlyTruncated)
 	if err != nil {
 		logger.Error("retention cleanup: resource hourly", "error", err)
 	} else if hourlyDeleted > 0 {
 		logger.Info("retention cleanup: deleted resource hourly", "count", hourlyDeleted)
 	}
 
-	dailyCutoff := time.Now().Add(-resourceDailyRetention)
-	dailyDeleted, err := store.DeleteDailyBefore(ctx, dailyCutoff, retentionBatchSize)
+	dailyCutoff := time.Now().Add(-cfg.Daily)
+	dailyDeleted, dailyTruncated, err := store.deleteDailyBefore(ctx, dailyCutoff, cfg.batchOpts())
+	pass.add(dailyDeleted, dailyTruncated)
 	if err != nil {
 		logger.Error("retention cleanup: resource daily", "error", err)
 	} else if dailyDeleted > 0 {
@@ -152,10 +299,11 @@ func runResourceCleanup(ctx context.Context, store *ResourceStore, logger *slog.
 	}
 }
 
-func runEndpointCleanup(ctx context.Context, store *EndpointStore, logger *slog.Logger) {
+func runEndpointCleanup(ctx context.Context, store *EndpointStore, logger *slog.Logger, cfg RetentionConfig, pass *retentionPass) {
 	// Clean old check results
-	cutoff := time.Now().Add(-checkResultRetention)
-	deleted, err := store.DeleteCheckResultsBefore(ctx, cutoff, retentionBatchSize)
+	cutoff := time.Now().Add(-cfg.CheckResults)
+	deleted, truncated, err := store.deleteCheckResultsBefore(ctx, cutoff, cfg.batchOpts())
+	pass.add(deleted, truncated)
 	if err != nil {
 		logger.Error("retention cleanup: check results", "error", err)
 	} else if deleted > 0 {
@@ -163,11 +311,82 @@ func runEndpointCleanup(ctx context.Context, store *EndpointStore, logger *slog.
 	}
 
 	// Clean inactive endpoints
-	inactiveCutoff := time.Now().Add(-inactiveEndpointRetention)
+	inactiveCutoff := time.Now().Add(-cfg.InactiveEndpoints)
 	epDeleted, err := store.DeleteInactiveEndpointsBefore(ctx, inactiveCutoff)
+	pass.add(epDeleted, false)
 	if err != nil {
 		logger.Error("retention cleanup: inactive endpoints", "error", err)
 	} else if epDeleted > 0 {
 		logger.Info("retention cleanup: deleted inactive endpoints", "count", epDeleted)
 	}
+}
+
+// reclaimSpace returns the pages freed by the pass to the filesystem and keeps
+// the WAL from carrying the whole reclaim at once. On a database whose header
+// says auto_vacuum NONE there is nothing to reclaim without a full VACUUM, so
+// only the checkpoint runs — Open already told the operator why.
+func reclaimSpace(ctx context.Context, db *DB, logger *slog.Logger, budget time.Duration, deleted int64) {
+	if db.incrementalVacuum {
+		incrementalVacuum(ctx, db, logger, budget)
+	}
+	if deleted >= checkpointRowThreshold {
+		walCheckpoint(ctx, db, logger, "TRUNCATE")
+	}
+}
+
+func incrementalVacuum(ctx context.Context, db *DB, logger *slog.Logger, budget time.Duration) {
+	before, err := freelistCount(ctx, db)
+	if err != nil {
+		logger.Debug("retention cleanup: freelist count", "error", err)
+		return
+	}
+
+	remaining := before
+	deadline := time.Now().Add(budget)
+	for remaining > 0 && time.Now().Before(deadline) && ctx.Err() == nil {
+		// incremental_vacuum is a write: it must go through the serialized
+		// writer, or it races the writer goroutine for the write lock.
+		if _, err := db.Writer().Exec(ctx, "PRAGMA incremental_vacuum(2000)"); err != nil {
+			logger.Error("retention cleanup: incremental vacuum", "error", err)
+			return
+		}
+		// Moved pages travel through the WAL, so checkpoint between slices
+		// instead of reclaiming everything into an ever-growing WAL.
+		walCheckpoint(ctx, db, logger, "PASSIVE")
+
+		next, err := freelistCount(ctx, db)
+		if err != nil {
+			logger.Debug("retention cleanup: freelist count", "error", err)
+			return
+		}
+		if next >= remaining {
+			break
+		}
+		remaining = next
+	}
+
+	if before > remaining {
+		logger.Info("retention cleanup: reclaimed pages", "freed", before-remaining, "remaining", remaining)
+	}
+}
+
+func freelistCount(ctx context.Context, db *DB) (int, error) {
+	var pages int
+	err := db.ReadDB().QueryRowContext(ctx, "PRAGMA freelist_count").Scan(&pages)
+	return pages, err
+}
+
+// walCheckpoint is best effort: busy=1 simply means readers were active, which
+// is the common case here since the resource rollup reads continuously.
+func walCheckpoint(ctx context.Context, db *DB, logger *slog.Logger, mode string) {
+	var busy, walPages, checkpointed int
+	// mode is a package-level literal, never user input.
+	err := db.ReadDB().QueryRowContext(ctx, fmt.Sprintf("PRAGMA wal_checkpoint(%s)", mode)).
+		Scan(&busy, &walPages, &checkpointed)
+	if err != nil {
+		logger.Debug("retention cleanup: wal checkpoint failed", "mode", mode, "error", err)
+		return
+	}
+	logger.Debug("retention cleanup: wal checkpoint",
+		"mode", mode, "busy", busy, "wal_pages", walPages, "checkpointed", checkpointed)
 }

--- a/internal/store/sqlite/retention_test.go
+++ b/internal/store/sqlite/retention_test.go
@@ -1,0 +1,281 @@
+// Copyright 2026 Benjamin Touchard (Kolapsis)
+//
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+// or a commercial license. You may not use this file except in compliance
+// with one of these licenses.
+//
+// AGPL-3.0: https://www.gnu.org/licenses/agpl-3.0.html
+// Commercial: See COMMERCIAL-LICENSE.md
+//
+// Source: https://github.com/kolapsis/maintenant
+
+package sqlite
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+}
+
+// seedSnapshots inserts count rows ending at the given time, one second apart,
+// via a recursive CTE — a Go loop through the serialized writer would dominate
+// the test runtime at these volumes.
+func seedSnapshots(t *testing.T, db *DB, containerID string, count int, newest time.Time) {
+	t.Helper()
+	_, err := db.Writer().Exec(context.Background(), fmt.Sprintf(`
+		WITH RECURSIVE n(i) AS (SELECT 0 UNION ALL SELECT i+1 FROM n WHERE i < %d)
+		INSERT INTO resource_snapshots
+			(id, container_id, agent_id, cpu_percent, mem_used, mem_limit,
+			 net_rx_bytes, net_tx_bytes, block_read_bytes, block_write_bytes, timestamp)
+		SELECT lower(hex(randomblob(16))), ?, (SELECT agent_id FROM containers WHERE id = ?),
+			1.0, 100, 200, 0, 0, 0, 0, ? - i
+		FROM n`, count-1),
+		containerID, containerID, newest.Unix())
+	require.NoError(t, err)
+}
+
+// seedBuckets fills resource_hourly or resource_daily with count rows.
+func seedBuckets(t *testing.T, db *DB, table, containerID string, count int, newest time.Time) {
+	t.Helper()
+	_, err := db.Writer().Exec(context.Background(), fmt.Sprintf(`
+		WITH RECURSIVE n(i) AS (SELECT 0 UNION ALL SELECT i+1 FROM n WHERE i < %d)
+		INSERT INTO %s
+			(id, container_id, bucket, avg_cpu_percent, avg_mem_used, avg_mem_limit,
+			 avg_net_rx_bytes, avg_net_tx_bytes, sample_count)
+		SELECT lower(hex(randomblob(16))), ?, ? - i*3600, 1.0, 100, 200, 0, 0, 1
+		FROM n`, count-1, table),
+		containerID, newest.Unix())
+	require.NoError(t, err)
+}
+
+func countTableRows(t *testing.T, db *DB, table string) int {
+	t.Helper()
+	var n int
+	require.NoError(t, db.ReadDB().QueryRow("SELECT COUNT(*) FROM "+table).Scan(&n))
+	return n
+}
+
+// Regression test for issue #46: one call deleted at most batchSize rows, so
+// with an hourly cleanup the purge could never keep up past ~3 containers.
+func TestDeleteSnapshotsBefore_DeletesBeyondOneBatch(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	cid := seedHostContainer(t, NewContainerStore(db), "ext-retention", "")
+	store := NewResourceStore(db)
+
+	expired := time.Now().Add(-30 * 24 * time.Hour)
+	seedSnapshots(t, db, cid, 2500, expired)
+	seedSnapshots(t, db, cid, 10, time.Now())
+	require.Equal(t, 2510, countTableRows(t, db, "resource_snapshots"))
+
+	deleted, err := store.DeleteSnapshotsBefore(ctx, time.Now().Add(-7*24*time.Hour), 1000)
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(2500), deleted, "a single call must drain the whole backlog")
+	assert.Equal(t, 10, countTableRows(t, db, "resource_snapshots"), "rows inside the window must survive")
+}
+
+func TestDeleteHourlyBefore_DeletesBeyondOneBatch(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	cid := seedHostContainer(t, NewContainerStore(db), "ext-hourly", "")
+	store := NewResourceStore(db)
+
+	// 1500 hourly buckets going back from 100 days ago: all expired.
+	seedBuckets(t, db, "resource_hourly", cid, 1500, time.Now().Add(-100*24*time.Hour))
+
+	deleted, err := store.DeleteHourlyBefore(ctx, time.Now().Add(-90*24*time.Hour), 1000)
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(1500), deleted)
+	assert.Equal(t, 0, countTableRows(t, db, "resource_hourly"))
+}
+
+func TestDeleteDailyBefore_DeletesBeyondOneBatch(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	cid := seedHostContainer(t, NewContainerStore(db), "ext-daily", "")
+	store := NewResourceStore(db)
+
+	seedBuckets(t, db, "resource_daily", cid, 1500, time.Now().Add(-400*24*time.Hour))
+
+	deleted, err := store.DeleteDailyBefore(ctx, time.Now().Add(-365*24*time.Hour), 1000)
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(1500), deleted)
+	assert.Equal(t, 0, countTableRows(t, db, "resource_daily"))
+}
+
+// A batch size of zero makes LIMIT 0 return no rows, which the "affected <
+// batchSize" exit condition alone reads as "keep going".
+func TestDeleteRowsBefore_ZeroBatchSizeDoesNotHang(t *testing.T) {
+	db := openTestDB(t)
+	cid := seedHostContainer(t, NewContainerStore(db), "ext-zero", "")
+	seedSnapshots(t, db, cid, 50, time.Now().Add(-30*24*time.Hour))
+
+	for _, batchSize := range []int{0, -1} {
+		t.Run(fmt.Sprintf("batchSize=%d", batchSize), func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				_, _, err := deleteRowsBefore(ctx, db.Writer(), batchOpts{batchSize: batchSize},
+					"resource_snapshots", "timestamp", time.Now())
+				assert.NoError(t, err)
+			}()
+
+			select {
+			case <-done:
+			case <-ctx.Done():
+				t.Fatal("deleteRowsBefore did not terminate")
+			}
+		})
+	}
+	assert.Equal(t, 0, countTableRows(t, db, "resource_snapshots"))
+}
+
+func TestDeleteRowsBefore_NoMatchingRows(t *testing.T) {
+	db := openTestDB(t)
+	cid := seedHostContainer(t, NewContainerStore(db), "ext-none", "")
+	seedSnapshots(t, db, cid, 5, time.Now())
+
+	deleted, truncated, err := deleteRowsBefore(context.Background(), db.Writer(),
+		batchOpts{batchSize: 1000}, "resource_snapshots", "timestamp", time.Now().Add(-24*time.Hour))
+
+	require.NoError(t, err)
+	assert.Zero(t, deleted)
+	assert.False(t, truncated)
+	assert.Equal(t, 5, countTableRows(t, db, "resource_snapshots"))
+}
+
+// Shutdown must not surface as an error: the writer refuses new work once the
+// context is cancelled, and the rows already deleted are committed.
+func TestDeleteRowsBefore_HonoursContextCancellation(t *testing.T) {
+	db := openTestDB(t)
+	cid := seedHostContainer(t, NewContainerStore(db), "ext-cancel", "")
+	seedSnapshots(t, db, cid, 500, time.Now().Add(-30*24*time.Hour))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	deleted, truncated, err := deleteRowsBefore(ctx, db.Writer(), batchOpts{batchSize: 100},
+		"resource_snapshots", "timestamp", time.Now())
+
+	require.NoError(t, err)
+	assert.Zero(t, deleted)
+	assert.True(t, truncated)
+	assert.Equal(t, 500, countTableRows(t, db, "resource_snapshots"))
+}
+
+func TestRunBatchedDelete_BudgetTruncates(t *testing.T) {
+	calls := 0
+	total, truncated, err := runBatchedDelete(context.Background(),
+		batchOpts{batchSize: 10, budget: time.Nanosecond},
+		func(context.Context, int) (int64, error) {
+			calls++
+			return 10, nil // always a full batch: only the budget can stop this
+		})
+
+	require.NoError(t, err)
+	assert.True(t, truncated)
+	assert.Equal(t, 1, calls, "the budget must be checked after the first batch")
+	assert.Equal(t, int64(10), total)
+}
+
+func TestRunResourceCleanup_PurgesAllThreeTables(t *testing.T) {
+	db := openTestDB(t)
+	cid := seedHostContainer(t, NewContainerStore(db), "ext-all", "")
+	store := NewResourceStore(db)
+
+	seedSnapshots(t, db, cid, 1200, time.Now().Add(-30*24*time.Hour))
+	seedSnapshots(t, db, cid, 5, time.Now())
+	seedBuckets(t, db, "resource_hourly", cid, 1200, time.Now().Add(-100*24*time.Hour))
+	seedBuckets(t, db, "resource_daily", cid, 1200, time.Now().Add(-400*24*time.Hour))
+
+	cfg := RetentionConfig{}.withDefaults(testLogger())
+	var pass retentionPass
+	runResourceCleanup(context.Background(), store, testLogger(), cfg, &pass)
+
+	assert.False(t, pass.truncated)
+	assert.Equal(t, int64(3600), pass.deleted)
+	assert.Equal(t, 5, countTableRows(t, db, "resource_snapshots"))
+	assert.Equal(t, 0, countTableRows(t, db, "resource_hourly"))
+	assert.Equal(t, 0, countTableRows(t, db, "resource_daily"))
+}
+
+// The cleanup used to wait a full interval before its first run, so an instance
+// restarting more often than that never purged anything.
+func TestStartRetentionCleanup_RunsImmediately(t *testing.T) {
+	db := openTestDB(t)
+	cid := seedHostContainer(t, NewContainerStore(db), "ext-immediate", "")
+	seedSnapshots(t, db, cid, 100, time.Now().Add(-30*24*time.Hour))
+
+	ctx := t.Context()
+
+	// An hour-long interval guarantees the timer never fires during the test:
+	// anything deleted came from the immediate first pass.
+	StartRetentionCleanupWithOpts(ctx, NewContainerStore(db), db, testLogger(), RetentionOpts{
+		ResourceStore: NewResourceStore(db),
+		Config:        RetentionConfig{Interval: time.Hour},
+	})
+
+	require.Eventually(t, func() bool {
+		return countTableRows(t, db, "resource_snapshots") == 0
+	}, 5*time.Second, 20*time.Millisecond, "the first pass must run without waiting for the interval")
+}
+
+// A pass that stopped on its budget must come back quickly; waiting a full hour
+// is what let the backlog grow in the first place.
+func TestRetentionConfig_NextDelay(t *testing.T) {
+	cfg := RetentionConfig{}.withDefaults(testLogger())
+
+	assert.Equal(t, retentionInterval, cfg.nextDelay(false))
+	assert.Equal(t, retentionCatchUpInterval, cfg.nextDelay(true))
+	assert.Less(t, cfg.nextDelay(true), cfg.nextDelay(false))
+}
+
+func TestRetentionConfig_Defaults(t *testing.T) {
+	logger := testLogger()
+
+	t.Run("zero value keeps historical behaviour", func(t *testing.T) {
+		cfg := RetentionConfig{}.withDefaults(logger)
+		assert.Equal(t, retentionInterval, cfg.Interval)
+		assert.Equal(t, retentionBatchSize, cfg.BatchSize)
+		assert.Equal(t, resourceSnapshotRetention, cfg.Snapshots)
+		assert.Equal(t, resourceHourlyRetention, cfg.Hourly)
+		assert.Equal(t, resourceDailyRetention, cfg.Daily)
+		assert.Equal(t, defaultRetention, cfg.Transitions)
+		assert.Equal(t, certCheckResultRetention, cfg.CertCheckResults)
+	})
+
+	t.Run("out of range values are clamped", func(t *testing.T) {
+		cfg := RetentionConfig{
+			Interval:       time.Second,
+			BatchSize:      1,
+			Snapshots:      time.Minute,
+			BudgetPerTable: time.Hour,
+		}.withDefaults(logger)
+
+		assert.Equal(t, time.Minute, cfg.Interval)
+		assert.Equal(t, 100, cfg.BatchSize)
+		assert.Equal(t, 24*time.Hour, cfg.Snapshots, "raw window feeds the 7-day graphs")
+		assert.Equal(t, 30*time.Minute, cfg.BudgetPerTable)
+	})
+
+	t.Run("batch size above maximum is clamped", func(t *testing.T) {
+		cfg := RetentionConfig{BatchSize: 500000}.withDefaults(logger)
+		assert.Equal(t, 100000, cfg.BatchSize)
+	})
+}


### PR DESCRIPTION
## The bug

`DeleteSnapshotsBefore`, `DeleteHourlyBefore` and `DeleteDailyBefore` ran a single
`DELETE ... LIMIT`, while every other purge in the store already looped until drained.
With an hourly cleanup that caps deletion at 1000 resource snapshots per hour, whatever the
number of monitored containers, against ~360 rows/hour/container of ingestion. Past ~3
containers the purge never catches up and `resource_snapshots` grows without bound.

Note for #46: there was **no 10min → 1h regression**. `retentionInterval` has been `1 * time.Hour`
since the file was created (2025-12-02), identical at v1.2.13 and v1.3.7.

## Changes

- Extract the batched-delete loop into a shared helper and use it for the three resource purges.
  It normalises the batch size (`LIMIT 0` made the old exit condition loop forever), honours the
  context, and stops on a per-table budget so a large backlog cannot hold the serialized writer.
- Run a first pass at startup instead of waiting a full interval, and reschedule a minute later
  while a backlog remains.
- `auto_vacuum` was set with an `Exec` after `journal_mode=WAL` had already written the file
  header, so it was silently ignored and **every** database stayed in NONE mode. Moved to the DSN.
- `journal_size_limit` and `wal_autocheckpoint` are per-connection and only reached one pooled
  connection. A `ConnectHook` applies them to all four, bounding the `-wal` file at 64 MiB.
- Retention window, interval and batch size configurable via `MAINTENANT_RETENTION_SNAPSHOTS`,
  `MAINTENANT_RETENTION_INTERVAL`, `MAINTENANT_RETENTION_BATCH_SIZE`.

Also included, since the retention work surfaced them: `ResourceCharts` and `ResourceAlertConfig`
existed but were imported nowhere, so resource history had no way into the UI. They now sit in a
Resources tab of the container panel. The charts could never draw (their elements live behind a
`v-else`, so `useChart` bailed out on mount and every `setData` hit a null chart), and the alert
block was on hardcoded Tailwind grays.

## Shorter raw retention

`GetHistory` grouped raw snapshots for every range, including 7d — the only reason a full week of
raw had to be kept, and raw is what makes the database large (~850k rows / ~300 MB for 14
containers, against 2.8 MB for the aggregates covering 90 days). The 7d range already returned
hourly granularity, so it now reads `resource_hourly` directly. Raw retention drops to 48h, which
is what the 24h range needs, and the rollup backfills over that window instead of a week of
buckets whose raw rows no longer exist.

Migration 26 adds block I/O to `resource_hourly`; without it the 7d chart would have lost its
Block I/O series. Buckets aggregated before the upgrade keep 0 there until the rollup replays
them, which it does for everything still inside the raw window.

## Verification

Measured on a live instance with a real backlog: **346,776 rows purged in 2.26 s** at startup,
where the old code would have needed 347 hours. WAL settles at ~4 MB. A fresh database now reports
`auto_vacuum: incremental`; existing ones report `none` and get a startup warning pointing at the
manual `VACUUM` documented in `docs/troubleshooting.md`.

New tests fail on the old code and pass on the new one — checked in that order.

Closes #46

