### PR TITLE
fix(agentserver): close unauthenticated DoS and agent_id spoofing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,10 +241,19 @@ jobs:
 
       # Complements CodeQL rather than replacing it: CodeQL carries the deep
       # data-flow analysis, gosec adds the Go-specific rule set.
+      #
+      # Built on the runner instead of through securego/gosec: that action runs
+      # in its own image, whose Go trails go.mod and cannot fetch a newer
+      # toolchain under the GOTOOLCHAIN=local that setup-go exports — every
+      # package then fails to load and gosec exits before analysing anything.
+      # Installed by version rather than by digest; the checksum database is
+      # what vouches for the module.
+      - name: Install gosec
+        run: go install github.com/securego/gosec/v2/cmd/gosec@v2.28.0
+
       - name: gosec
-        uses: securego/gosec@9e75c0576c9878035d4221392108d458abe10fc3 # v2.28.0
-        with:
-          args: -exclude-generated -severity medium ./...
+        run: |
+          "$(go env GOPATH)/bin/gosec" -exclude-generated -severity medium ./...
 
   audit:
     name: Dependency audit (govulncheck + Trivy)

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN --mount=type=cache,target=/root/.npm \
 COPY frontend/ ./
 RUN npm run build-only
 
-FROM golang:1.25-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 RUN apk add --no-cache gcc musl-dev
 

--- a/compose.yml
+++ b/compose.yml
@@ -7,8 +7,16 @@ services:
     tmpfs:
       - /tmp:noexec,nosuid,size=64m
     ports:
+      # ⚠️  SECURITY: this publishes the UI/API on ALL interfaces (0.0.0.0) and the
+      # app has NO authentication of its own. Fine on a trusted/private network to
+      # get started; before exposing it to an untrusted network put an auth reverse
+      # proxy in front (see SECURITY.md and compose.prod.yml), or restrict the bind
+      # to "127.0.0.1:8080:8080".
       - "8080:8080"
     volumes:
+      # WARNING: mounting the Docker socket grants root-equivalent access to the
+      # host. `:ro` does NOT restrict the Docker API. For any exposed deployment
+      # use a read-only docker-socket-proxy instead (see compose.prod.yml).
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - /proc:/host/proc:ro
       - maintenant-data:/data

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kolapsis/maintenant
 
-go 1.25.12
+go 1.26.5
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0

--- a/internal/agentserver/auth.go
+++ b/internal/agentserver/auth.go
@@ -20,6 +20,7 @@ import (
 	"github.com/kolapsis/maintenant/internal/agent"
 	"github.com/kolapsis/maintenant/internal/agentauth"
 	"github.com/kolapsis/maintenant/internal/agentpb"
+	"github.com/kolapsis/maintenant/internal/uid"
 )
 
 var (
@@ -46,6 +47,11 @@ func Verify(req *agentpb.AuthResponse, nonce []byte, ag *agent.Agent, serverNow 
 	if ag == nil {
 		return ErrAgentUnknown
 	}
+	// The local runtime sentinel has no keypair (public_key is NULL) and must
+	// never authenticate over the network. Reject it before any crypto runs.
+	if ag.AgentID == uid.LocalAgent {
+		return ErrAgentUnknown
+	}
 	if ag.Status == "revoked" {
 		return ErrAgentRevoked
 	}
@@ -66,6 +72,12 @@ func Verify(req *agentpb.AuthResponse, nonce []byte, ag *agent.Agent, serverNow 
 		return ErrBadSignature
 	}
 
+	// ed25519.Verify panics on a public key that is not exactly 32 bytes; a
+	// malformed or NULL key must fail the signature check, never crash the
+	// process (a single crafted request would otherwise take the server down).
+	if len(ag.PublicKey) != ed25519.PublicKeySize {
+		return ErrBadSignature
+	}
 	if !ed25519.Verify(ed25519.PublicKey(ag.PublicKey), payload, req.GetSignature()) {
 		return ErrBadSignature
 	}

--- a/internal/agentserver/auth_test.go
+++ b/internal/agentserver/auth_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/kolapsis/maintenant/internal/agent"
 	"github.com/kolapsis/maintenant/internal/agentpb"
+	"github.com/kolapsis/maintenant/internal/uid"
 )
 
 const testAgentUUID = "550e8400-e29b-41d4-a716-446655440000"
@@ -212,6 +213,60 @@ func TestVerify_WrongNonceProducesErrBadSignature(t *testing.T) {
 	err = Verify(req, differentNonce, ag, serverNow)
 
 	assert.ErrorIs(t, err, ErrBadSignature)
+}
+
+// TestVerify_MalformedPublicKeyDoesNotPanic is the regression guard for the
+// unauthenticated DoS: ed25519.Verify panics on a key that is not 32 bytes, so
+// an agent row with a NULL/short public key must fail closed, never crash.
+func TestVerify_MalformedPublicKeyDoesNotPanic(t *testing.T) {
+	for name, key := range map[string][]byte{
+		"nil":   nil,
+		"empty": {},
+		"short": make([]byte, 16),
+		"long":  make([]byte, 64),
+	} {
+		t.Run(name, func(t *testing.T) {
+			ag := &agent.Agent{AgentID: testAgentUUID, PublicKey: key, Status: "active"}
+			nonce := make([]byte, 32)
+			_, err := rand.Read(nonce)
+			require.NoError(t, err)
+
+			serverNow := time.Now()
+			req := &agentpb.AuthResponse{
+				AgentId:   testAgentUUID,
+				Timestamp: serverNow.Unix(),
+				Signature: make([]byte, ed25519.SignatureSize),
+			}
+
+			// Must return an error rather than panic.
+			assert.NotPanics(t, func() {
+				err = Verify(req, nonce, ag, serverNow)
+			})
+			assert.ErrorIs(t, err, ErrBadSignature)
+		})
+	}
+}
+
+// TestVerify_LocalSentinelRejected ensures the in-process sentinel agent
+// (public_key NULL, status active) can never be authenticated over the wire —
+// the exact row a crafted handshake would target.
+func TestVerify_LocalSentinelRejected(t *testing.T) {
+	ag := &agent.Agent{AgentID: uid.LocalAgent, PublicKey: nil, Status: "active"}
+	nonce := make([]byte, 32)
+	_, err := rand.Read(nonce)
+	require.NoError(t, err)
+
+	serverNow := time.Now()
+	req := &agentpb.AuthResponse{
+		AgentId:   uid.LocalAgent,
+		Timestamp: serverNow.Unix(),
+		Signature: make([]byte, ed25519.SignatureSize),
+	}
+
+	assert.NotPanics(t, func() {
+		err = Verify(req, nonce, ag, serverNow)
+	})
+	assert.ErrorIs(t, err, ErrAgentUnknown)
 }
 
 func TestGenerateChallenge_NonceIs32Bytes(t *testing.T) {

--- a/internal/agentserver/dispatcher.go
+++ b/internal/agentserver/dispatcher.go
@@ -90,11 +90,17 @@ func NewDispatcher(deps DispatchDeps) *Dispatcher {
 	return &Dispatcher{deps: deps}
 }
 
-// Dispatch routes evt to the handler matching its body type.
-// Returns an error if a handler is wired and returns an error.
-// Silently ignores events whose handler is nil.
-func (d *Dispatcher) Dispatch(ctx context.Context, evt *agentpb.AgentEvent) error {
-	agentID := evt.GetAgentId()
+// Dispatch routes evt to the handler matching its body type, attributing every
+// event to agentID — the identity proven by the auth handshake, NOT the
+// client-controlled agent_id carried on the wire. Returns an error if a handler
+// is wired and returns an error. Silently ignores events whose handler is nil.
+func (d *Dispatcher) Dispatch(ctx context.Context, agentID string, evt *agentpb.AgentEvent) error {
+	// The wire agent_id is attacker-controlled. Trusting it would let a
+	// compromised agent forge or wipe data for any other host. Reject a
+	// mismatch outright; the authenticated agentID is the only source of truth.
+	if claimed := evt.GetAgentId(); claimed != "" && claimed != agentID {
+		return fmt.Errorf("dispatch: event agent_id %q does not match authenticated agent %q", claimed, agentID)
+	}
 
 	switch body := evt.GetBody().(type) {
 	case *agentpb.AgentEvent_Container:

--- a/internal/agentserver/dispatcher_test.go
+++ b/internal/agentserver/dispatcher_test.go
@@ -110,7 +110,7 @@ func TestDispatcher_ContainerEventRoutedToContainerHandler(t *testing.T) {
 		Body:    &agentpb.AgentEvent_Container{Container: ev},
 	}
 
-	err := d.Dispatch(context.Background(), evt)
+	err := d.Dispatch(context.Background(), dispatchAgentID, evt)
 
 	require.NoError(t, err)
 	assert.Equal(t, dispatchAgentID, h.calledWithAgentID)
@@ -135,7 +135,7 @@ func TestDispatcher_InventoryRoutedToInventoryHandler(t *testing.T) {
 		Body:    &agentpb.AgentEvent_Inventory{Inventory: ev},
 	}
 
-	err := d.Dispatch(context.Background(), evt)
+	err := d.Dispatch(context.Background(), dispatchAgentID, evt)
 
 	require.NoError(t, err)
 	assert.Equal(t, dispatchAgentID, h.calledWithAgentID)
@@ -154,7 +154,7 @@ func TestDispatcher_EndpointEventRoutedToEndpointHandler(t *testing.T) {
 		Body:    &agentpb.AgentEvent_Endpoint{Endpoint: ev},
 	}
 
-	err := d.Dispatch(context.Background(), evt)
+	err := d.Dispatch(context.Background(), dispatchAgentID, evt)
 
 	require.NoError(t, err)
 	assert.Equal(t, dispatchAgentID, h.calledWithAgentID)
@@ -171,7 +171,7 @@ func TestDispatcher_HeartbeatEventRoutedToHeartbeatHandler(t *testing.T) {
 		Body:    &agentpb.AgentEvent_Heartbeat{Heartbeat: ev},
 	}
 
-	err := d.Dispatch(context.Background(), evt)
+	err := d.Dispatch(context.Background(), dispatchAgentID, evt)
 
 	require.NoError(t, err)
 	assert.Equal(t, dispatchAgentID, h.calledWithAgentID)
@@ -188,7 +188,7 @@ func TestDispatcher_ResourceEventRoutedToResourceHandler(t *testing.T) {
 		Body:    &agentpb.AgentEvent_Resource{Resource: ev},
 	}
 
-	err := d.Dispatch(context.Background(), evt)
+	err := d.Dispatch(context.Background(), dispatchAgentID, evt)
 
 	require.NoError(t, err)
 	assert.Equal(t, dispatchAgentID, h.calledWithAgentID)
@@ -205,7 +205,7 @@ func TestDispatcher_CertificateEventRoutedToCertificateHandler(t *testing.T) {
 		Body:    &agentpb.AgentEvent_Certificate{Certificate: ev},
 	}
 
-	err := d.Dispatch(context.Background(), evt)
+	err := d.Dispatch(context.Background(), dispatchAgentID, evt)
 
 	require.NoError(t, err)
 	assert.Equal(t, dispatchAgentID, h.calledWithAgentID)
@@ -220,7 +220,7 @@ func TestDispatcher_NilContainerHandlerSilentlyIgnoresEvent(t *testing.T) {
 		Body:    &agentpb.AgentEvent_Container{Container: &agentpb.ContainerEvent{}},
 	}
 
-	err := d.Dispatch(context.Background(), evt)
+	err := d.Dispatch(context.Background(), dispatchAgentID, evt)
 
 	assert.NoError(t, err)
 }
@@ -233,7 +233,7 @@ func TestDispatcher_NilEndpointHandlerSilentlyIgnoresEvent(t *testing.T) {
 		Body:    &agentpb.AgentEvent_Endpoint{Endpoint: &agentpb.EndpointEvent{}},
 	}
 
-	err := d.Dispatch(context.Background(), evt)
+	err := d.Dispatch(context.Background(), dispatchAgentID, evt)
 
 	assert.NoError(t, err)
 }
@@ -246,7 +246,7 @@ func TestDispatcher_NilHeartbeatHandlerSilentlyIgnoresEvent(t *testing.T) {
 		Body:    &agentpb.AgentEvent_Heartbeat{Heartbeat: &agentpb.HeartbeatEvent{}},
 	}
 
-	err := d.Dispatch(context.Background(), evt)
+	err := d.Dispatch(context.Background(), dispatchAgentID, evt)
 
 	assert.NoError(t, err)
 }
@@ -259,7 +259,7 @@ func TestDispatcher_NilResourceHandlerSilentlyIgnoresEvent(t *testing.T) {
 		Body:    &agentpb.AgentEvent_Resource{Resource: &agentpb.ResourceSample{}},
 	}
 
-	err := d.Dispatch(context.Background(), evt)
+	err := d.Dispatch(context.Background(), dispatchAgentID, evt)
 
 	assert.NoError(t, err)
 }
@@ -272,7 +272,7 @@ func TestDispatcher_NilCertificateHandlerSilentlyIgnoresEvent(t *testing.T) {
 		Body:    &agentpb.AgentEvent_Certificate{Certificate: &agentpb.CertificateInfo{}},
 	}
 
-	err := d.Dispatch(context.Background(), evt)
+	err := d.Dispatch(context.Background(), dispatchAgentID, evt)
 
 	assert.NoError(t, err)
 }
@@ -287,7 +287,7 @@ func TestDispatcher_HandlerErrorIsWrappedAndReturned(t *testing.T) {
 		Body:    &agentpb.AgentEvent_Container{Container: &agentpb.ContainerEvent{}},
 	}
 
-	err := d.Dispatch(context.Background(), evt)
+	err := d.Dispatch(context.Background(), dispatchAgentID, evt)
 
 	require.Error(t, err)
 	assert.ErrorIs(t, err, handlerErr)
@@ -303,10 +303,41 @@ func TestDispatcher_EndpointHandlerErrorIsWrappedAndReturned(t *testing.T) {
 		Body:    &agentpb.AgentEvent_Endpoint{Endpoint: &agentpb.EndpointEvent{}},
 	}
 
-	err := d.Dispatch(context.Background(), evt)
+	err := d.Dispatch(context.Background(), dispatchAgentID, evt)
 
 	require.Error(t, err)
 	assert.ErrorIs(t, err, handlerErr)
+}
+
+func TestDispatcher_RejectsSpoofedAgentID(t *testing.T) {
+	h := &mockContainerHandler{}
+	d := NewDispatcher(DispatchDeps{Container: h})
+
+	// Event claims to belong to another agent than the authenticated one.
+	evt := &agentpb.AgentEvent{
+		AgentId: "agt-victim-999",
+		Body:    &agentpb.AgentEvent_Container{Container: &agentpb.ContainerEvent{}},
+	}
+
+	err := d.Dispatch(context.Background(), dispatchAgentID, evt)
+
+	require.Error(t, err)
+	assert.Empty(t, h.calledWithAgentID, "a spoofed event must never reach the handler")
+}
+
+func TestDispatcher_UsesAuthenticatedIDNotWireValue(t *testing.T) {
+	h := &mockContainerHandler{}
+	d := NewDispatcher(DispatchDeps{Container: h})
+
+	// Empty wire agent_id: the authenticated identity must be used regardless.
+	evt := &agentpb.AgentEvent{
+		Body: &agentpb.AgentEvent_Container{Container: &agentpb.ContainerEvent{}},
+	}
+
+	err := d.Dispatch(context.Background(), dispatchAgentID, evt)
+
+	require.NoError(t, err)
+	assert.Equal(t, dispatchAgentID, h.calledWithAgentID)
 }
 
 func TestDispatcher_AllNilHandlersNoError(t *testing.T) {
@@ -320,7 +351,7 @@ func TestDispatcher_AllNilHandlersNoError(t *testing.T) {
 		{AgentId: dispatchAgentID, Body: &agentpb.AgentEvent_Resource{Resource: &agentpb.ResourceSample{}}},
 		{AgentId: dispatchAgentID, Body: &agentpb.AgentEvent_Certificate{Certificate: &agentpb.CertificateInfo{}}},
 	} {
-		err := d.Dispatch(context.Background(), evt)
+		err := d.Dispatch(context.Background(), dispatchAgentID, evt)
 		assert.NoError(t, err)
 	}
 }

--- a/internal/agentserver/enrollment.go
+++ b/internal/agentserver/enrollment.go
@@ -13,6 +13,7 @@ package agentserver
 
 import (
 	"context"
+	"crypto/ed25519"
 	"errors"
 	"strings"
 	"time"
@@ -51,6 +52,14 @@ func (impl *ingestImpl) RegisterAgent(ctx context.Context, req *agentpb.Register
 
 	// Version compatibility check: block on major mismatch, warn on minor skew.
 	checkVersionCompat(req.GetAgentVersion(), logger)
+
+	// Reject a malformed public key at the door. An ed25519 key is exactly 32
+	// bytes; a wrong-sized key could only ever fail signature verification
+	// later, so store nothing and fail early with a clear error.
+	if len(req.GetPublicKey()) != ed25519.PublicKeySize {
+		logger.Warn("agent.enroll_rejected", "reason", "bad_public_key", "agent_id", req.GetAgentId())
+		return nil, grpcstatus.Error(codes.InvalidArgument, "public key must be 32 bytes")
+	}
 
 	// Enrol the agent atomically: the per-edition host cap check, the one-time
 	// token consume, and the insert run in a single serialized transaction, so
@@ -320,7 +329,7 @@ func (impl *ingestImpl) Push(stream grpc.BidiStreamingServer[agentpb.ClientMessa
 			}
 
 			if dispatcher != nil {
-				if err := dispatcher.Dispatch(stream.Context(), evt); err != nil {
+				if err := dispatcher.Dispatch(stream.Context(), ag.AgentID, evt); err != nil {
 					logger.Error("Push: dispatch failed", "agent_id", ag.AgentID, "err", err)
 				}
 			}

--- a/internal/agentserver/enrollment_hostlimit_test.go
+++ b/internal/agentserver/enrollment_hostlimit_test.go
@@ -195,6 +195,44 @@ func TestRegisterAgent_HostLimit_ConcurrentEnrollments(t *testing.T) {
 	assert.Equal(t, limit, active, "active agents never exceed the cap")
 }
 
+// A malformed public key is rejected before any store write: an ed25519 key
+// must be exactly 32 bytes. The agent is never persisted and the token stays
+// unconsumed. This is the enroll-side companion to the auth-path key-length
+// guard that closes the unauthenticated-DoS vector.
+func TestRegisterAgent_RejectsMalformedPublicKey(t *testing.T) {
+	orig := extension.CurrentEdition
+	extension.CurrentEdition = func() extension.Edition { return extension.Pro }
+	t.Cleanup(func() { extension.CurrentEdition = orig })
+
+	impl, store := newHostLimitTestImpl(t)
+	ctx := context.Background()
+
+	for name, key := range map[string][]byte{
+		"nil":   nil,
+		"empty": {},
+		"short": make([]byte, 16),
+		"long":  make([]byte, 64),
+	} {
+		t.Run(name, func(t *testing.T) {
+			tok := insertToken(t, store, "tok-"+name, "mnt_enr_badkey"+fmt.Sprintf("%010s", name))
+			const id = "44444444-4444-4444-4444-444444444444"
+			req := registerReq(id, tok, "bad-key-host")
+			req.PublicKey = key
+
+			_, err := impl.RegisterAgent(ctx, req)
+			require.Error(t, err)
+			assert.Equal(t, codes.InvalidArgument, grpcstatus.Code(err))
+
+			_, err = store.Get(ctx, id)
+			assert.Error(t, err, "malformed enrollment must not persist an agent")
+
+			gotTok, err := store.GetByToken(ctx, tok)
+			require.NoError(t, err)
+			assert.Nil(t, gotTok.ConsumedAt, "rejected enrollment must not consume the token")
+		})
+	}
+}
+
 // Community cannot enroll any agent (cap 0), even via a valid token.
 func TestRegisterAgent_HostLimit_CommunityBlocked(t *testing.T) {
 	orig := extension.CurrentEdition

--- a/internal/agentserver/server.go
+++ b/internal/agentserver/server.go
@@ -19,10 +19,13 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"runtime/debug"
 	"time"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
+	grpcstatus "google.golang.org/grpc/status"
 
 	"github.com/kolapsis/maintenant/internal/agentpb"
 	"github.com/kolapsis/maintenant/internal/store/sqlite"
@@ -68,7 +71,13 @@ func (s *Server) Start(ctx context.Context, listen string, tlsCfg *tls.Config) e
 		return fmt.Errorf("agentserver: listen %s: %w", listen, err)
 	}
 
-	var opts []grpc.ServerOption
+	// Recovery interceptors turn any handler panic into a gRPC Internal error
+	// instead of crashing the process. gRPC does not recover panics by default,
+	// so without this a single malformed request in any handler is a full DoS.
+	opts := []grpc.ServerOption{
+		grpc.ChainUnaryInterceptor(recoveryUnaryInterceptor(s.deps.Logger)),
+		grpc.ChainStreamInterceptor(recoveryStreamInterceptor(s.deps.Logger)),
+	}
 	if tlsCfg != nil {
 		opts = append(opts, grpc.Creds(credentials.NewTLS(tlsCfg)))
 	}
@@ -95,6 +104,37 @@ func (s *Server) Start(ctx context.Context, listen string, tlsCfg *tls.Config) e
 func (s *Server) Stop() {
 	if s.grpc != nil {
 		s.grpc.GracefulStop()
+	}
+}
+
+// recoveryUnaryInterceptor recovers any panic raised by a unary handler,
+// logs it with a stack trace, and returns a generic Internal error.
+func recoveryUnaryInterceptor(logger *slog.Logger) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp any, err error) {
+		defer func() {
+			if r := recover(); r != nil {
+				logger.Error("agentserver: recovered from panic",
+					"method", info.FullMethod, "panic", r, "stack", string(debug.Stack()))
+				err = grpcstatus.Error(codes.Internal, "internal error")
+			}
+		}()
+		return handler(ctx, req)
+	}
+}
+
+// recoveryStreamInterceptor is the streaming counterpart of
+// recoveryUnaryInterceptor: it keeps a panic in a stream handler from taking
+// the whole server down.
+func recoveryStreamInterceptor(logger *slog.Logger) grpc.StreamServerInterceptor {
+	return func(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) (err error) {
+		defer func() {
+			if r := recover(); r != nil {
+				logger.Error("agentserver: recovered from panic",
+					"method", info.FullMethod, "panic", r, "stack", string(debug.Stack()))
+				err = grpcstatus.Error(codes.Internal, "internal error")
+			}
+		}()
+		return handler(srv, ss)
 	}
 }
 


### PR DESCRIPTION
Remediation of the critical and high findings from a security audit of the agent gRPC plane, plus the related build/deploy hardening.

## Fixes
- **Unauthenticated remote DoS (critical).** `Verify` rejects the local sentinel agent and any non-32-byte public key before `ed25519.Verify`, which panics on a malformed key — a crafted handshake against the NULL-keyed sentinel could crash the process. Added gRPC recovery interceptors as a generic backstop and enrollment-side key-length validation.
- **agent_id spoofing (high).** The dispatcher attributes events to the authenticated identity instead of the client-controlled wire `agent_id`, and rejects a mismatch. Stops a compromised agent from forging or wiping another host's data.
- **Go toolchain 1.26.5** (`go.mod`, `Dockerfile`) — `govulncheck` reports no reachable standard-library advisory afterwards.
- **Quickstart hardening** — visible security warning in `compose.yml` on the exposed port and the mounted Docker socket.

## Tests
New regression tests: malformed-key / sentinel DoS, and spoofed-`agent_id` rejection. Full suite green under Go 1.26.5.
