### PR TITLE
fix(updates): drop findings for containers the runtime no longer reports

### DIFF
--- a/internal/store/sqlite/containers.go
+++ b/internal/store/sqlite/containers.go
@@ -332,9 +332,32 @@ func (s *ContainerStore) deleteTransitionsBefore(ctx context.Context, before tim
 }
 
 func (s *ContainerStore) DeleteArchivedContainersBefore(ctx context.Context, before time.Time) (int64, error) {
+	cutoff := before.Unix()
+
+	// Tables keyed by external_id have no FK to cascade through, so they must go
+	// first: once the container row is gone, nothing ties them back to anything
+	// and they stay in the database for good.
+	for _, q := range []struct {
+		sql  string
+		desc string
+	}{
+		{`DELETE FROM image_updates WHERE container_id IN (
+			SELECT external_id FROM containers WHERE archived=1 AND archived_at<? AND archived_at IS NOT NULL)`, "image updates"},
+		{`DELETE FROM container_cves WHERE container_id IN (
+			SELECT external_id FROM containers WHERE archived=1 AND archived_at<? AND archived_at IS NOT NULL)`, "container cves"},
+		{`DELETE FROM version_pins WHERE container_id IN (
+			SELECT external_id FROM containers WHERE archived=1 AND archived_at<? AND archived_at IS NOT NULL)`, "version pins"},
+		{`DELETE FROM risk_score_history WHERE container_id IN (
+			SELECT external_id FROM containers WHERE archived=1 AND archived_at<? AND archived_at IS NOT NULL)`, "risk score history"},
+	} {
+		if _, err := s.writer.Exec(ctx, q.sql, cutoff); err != nil {
+			return 0, fmt.Errorf("delete archived containers %s: %w", q.desc, err)
+		}
+	}
+
 	res, err := s.writer.Exec(ctx,
 		`DELETE FROM containers WHERE archived=1 AND archived_at<? AND archived_at IS NOT NULL`,
-		before.Unix(),
+		cutoff,
 	)
 	if err != nil {
 		return 0, fmt.Errorf("delete archived containers: %w", err)

--- a/internal/store/sqlite/migrations/27_containers_external_id_index.down.sql
+++ b/internal/store/sqlite/migrations/27_containers_external_id_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_containers_external_id;

--- a/internal/store/sqlite/migrations/27_containers_external_id_index.up.sql
+++ b/internal/store/sqlite/migrations/27_containers_external_id_index.up.sql
@@ -1,0 +1,5 @@
+-- The update intelligence tables (image_updates, container_cves, version_pins,
+-- risk_score_history) reference containers by external_id, which so far only
+-- existed as the second column of the (agent_id, external_id) unique index —
+-- unusable for a lookup by external_id alone.
+CREATE INDEX IF NOT EXISTS idx_containers_external_id ON containers(external_id);

--- a/internal/store/sqlite/updates.go
+++ b/internal/store/sqlite/updates.go
@@ -84,6 +84,21 @@ func (s *UpdateStore) GetLatestScanRecord(ctx context.Context) (*update.ScanReco
 
 // --- Image updates ---
 
+// liveContainerFilter keeps only the findings whose container a runtime still
+// reports. image_updates.container_id holds the container external_id with no
+// foreign key behind it, so a finding outlives its container: Swarm gives a
+// redeployed task a brand new id and name, which would otherwise leave the
+// pre-upgrade finding on the Updates page for good.
+const liveContainerFilter = `EXISTS (
+		SELECT 1 FROM containers c
+		WHERE c.external_id = image_updates.container_id AND c.archived = 0)`
+
+// liveContainerCVEFilter is the same guard for the CVE findings, which the
+// Updates page counts alongside the image updates.
+const liveContainerCVEFilter = `EXISTS (
+		SELECT 1 FROM containers c
+		WHERE c.external_id = container_cves.container_id AND c.archived = 0)`
+
 func (s *UpdateStore) InsertImageUpdate(ctx context.Context, u *update.ImageUpdate) (string, error) {
 	var publishedAt *int64
 	if u.PublishedAt != nil {
@@ -173,7 +188,7 @@ func (s *UpdateStore) ListImageUpdates(ctx context.Context, opts update.ListImag
 		 latest_tag, latest_digest, update_type, risk_score, published_at,
 		 changelog_url, changelog_summary, has_breaking_changes, previous_digest, source_url,
 		 status, detected_at
-		FROM image_updates WHERE 1=1`
+		FROM image_updates WHERE ` + liveContainerFilter
 	var args []interface{}
 
 	if opts.Status != "" {
@@ -203,7 +218,8 @@ func (s *UpdateStore) ListImageUpdates(ctx context.Context, opts update.ListImag
 func (s *UpdateStore) GetUpdateSummary(ctx context.Context) (*update.UpdateSummary, error) {
 	summary := &update.UpdateSummary{}
 
-	rows, err := s.db.QueryContext(ctx, `SELECT status, risk_score FROM image_updates`)
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT status, risk_score FROM image_updates WHERE `+liveContainerFilter)
 	if err != nil {
 		return nil, fmt.Errorf("get update summary: %w", err)
 	}
@@ -237,10 +253,12 @@ func (s *UpdateStore) GetUpdateSummary(ctx context.Context) (*update.UpdateSumma
 		return nil, err
 	}
 
-	// Count active containers that have no pending update (up to date).
+	// Count active containers that have no pending update (up to date). Archiving
+	// leaves the state untouched, so an archived Swarm task stays 'running' and
+	// would inflate the count on every deploy.
 	var totalContainers int
 	err = s.db.QueryRowContext(ctx,
-		`SELECT COUNT(*) FROM containers WHERE state = 'running'`).Scan(&totalContainers)
+		`SELECT COUNT(*) FROM containers WHERE state = 'running' AND archived = 0`).Scan(&totalContainers)
 	if err != nil {
 		return nil, fmt.Errorf("count containers for up_to_date: %w", err)
 	}
@@ -317,6 +335,41 @@ func (s *UpdateStore) ListStaleImageUpdates(ctx context.Context, scanID string, 
 		stale = append(stale, su)
 	}
 	return stale, rows.Err()
+}
+
+// ListOrphanImageUpdates returns the findings whose container no runtime reports
+// anymore — archived or deleted. Name-based staleness can never catch those on
+// Swarm, where `docker stack deploy` replaces the task with one under a new id
+// and a new name. The container uid comes along when the archived row is still
+// there, so the recovery event resolves the alert by its real entity id.
+func (s *UpdateStore) ListOrphanImageUpdates(ctx context.Context) ([]update.StaleImageUpdate, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT DISTINCT container_id, container_name,
+			COALESCE((SELECT c.id FROM containers c
+				WHERE c.external_id = image_updates.container_id LIMIT 1), '')
+		FROM image_updates WHERE NOT `+liveContainerFilter)
+	if err != nil {
+		return nil, fmt.Errorf("list orphan image updates: %w", err)
+	}
+	defer func(rows *sql.Rows) { _ = rows.Close() }(rows)
+	var orphans []update.StaleImageUpdate
+	for rows.Next() {
+		var su update.StaleImageUpdate
+		if err := rows.Scan(&su.ContainerID, &su.ContainerName, &su.ContainerUID); err != nil {
+			return nil, err
+		}
+		orphans = append(orphans, su)
+	}
+	return orphans, rows.Err()
+}
+
+// DeleteOrphanImageUpdates removes the findings listed by ListOrphanImageUpdates.
+func (s *UpdateStore) DeleteOrphanImageUpdates(ctx context.Context) (int64, error) {
+	res, err := s.writer.Exec(ctx, `DELETE FROM image_updates WHERE NOT `+liveContainerFilter)
+	if err != nil {
+		return 0, fmt.Errorf("delete orphan image updates: %w", err)
+	}
+	return res.RowsAffected, nil
 }
 
 // --- CVE cache ---
@@ -418,7 +471,7 @@ func (s *UpdateStore) ListContainerCVEs(ctx context.Context, containerID string)
 
 func (s *UpdateStore) ListAllActiveCVEs(ctx context.Context, opts update.ListCVEsOpts) ([]*update.ContainerCVE, error) {
 	query := `SELECT id, container_id, cve_id, severity, cvss_score, summary, fixed_in, first_detected_at, resolved_at
-		FROM container_cves WHERE resolved_at IS NULL`
+		FROM container_cves WHERE resolved_at IS NULL AND ` + liveContainerCVEFilter
 	var args []interface{}
 
 	if opts.Severity != "" {
@@ -463,7 +516,8 @@ func (s *UpdateStore) DeleteContainerCVEs(ctx context.Context, containerID strin
 func (s *UpdateStore) GetCVESummaryCounts(ctx context.Context) (map[string]int, error) {
 	counts := map[string]int{"critical": 0, "high": 0, "medium": 0, "low": 0}
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT severity, COUNT(*) FROM container_cves WHERE resolved_at IS NULL GROUP BY severity`)
+		`SELECT severity, COUNT(*) FROM container_cves
+		WHERE resolved_at IS NULL AND `+liveContainerCVEFilter+` GROUP BY severity`)
 	if err != nil {
 		return nil, fmt.Errorf("get cve summary counts: %w", err)
 	}

--- a/internal/store/sqlite/updates_orphan_test.go
+++ b/internal/store/sqlite/updates_orphan_test.go
@@ -1,0 +1,261 @@
+// Copyright 2026 Benjamin Touchard (Kolapsis)
+//
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+// or a commercial license. You may not use this file except in compliance
+// with one of these licenses.
+//
+// AGPL-3.0: https://www.gnu.org/licenses/agpl-3.0.html
+// Commercial: See COMMERCIAL-LICENSE.md
+//
+// Source: https://github.com/kolapsis/maintenant
+
+package sqlite
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kolapsis/maintenant/internal/container"
+	"github.com/kolapsis/maintenant/internal/update"
+)
+
+// seedScannedContainer inserts a running container and, when archivedAt is set,
+// archives it the way a destroy event or an agent inventory would.
+func seedScannedContainer(t *testing.T, cs *ContainerStore, externalID, name string, archivedAt *time.Time) string {
+	t.Helper()
+	ctx := context.Background()
+	now := time.Now()
+
+	id, err := cs.InsertContainer(ctx, &container.Container{
+		ExternalID:        externalID,
+		Name:              name,
+		Image:             "ghcr.io/acme/api:1.0.0",
+		State:             container.StateRunning,
+		AlertSeverity:     container.SeverityWarning,
+		RestartThreshold:  3,
+		RuntimeType:       "docker",
+		FirstSeenAt:       now,
+		LastStateChangeAt: now,
+	})
+	require.NoError(t, err)
+
+	if archivedAt != nil {
+		require.NoError(t, cs.ArchiveContainer(ctx, externalID, *archivedAt))
+	}
+	return id
+}
+
+func seedImageUpdate(t *testing.T, us *UpdateStore, scanID, externalID, name string) {
+	t.Helper()
+	_, err := us.InsertImageUpdate(context.Background(), &update.ImageUpdate{
+		ScanID:        scanID,
+		ContainerID:   externalID,
+		ContainerName: name,
+		Image:         "ghcr.io/acme/api",
+		CurrentTag:    "1.0.0",
+		Registry:      "ghcr.io",
+		LatestTag:     "2.0.0",
+		UpdateType:    update.UpdateTypeMajor,
+		RiskScore:     update.BaseRiskScore(update.UpdateTypeMajor),
+		Status:        update.StatusAvailable,
+		DetectedAt:    time.Now(),
+	})
+	require.NoError(t, err)
+}
+
+func seedScan(t *testing.T, us *UpdateStore) string {
+	t.Helper()
+	scanID, err := us.InsertScanRecord(context.Background(), &update.ScanRecord{
+		StartedAt: time.Now(),
+		Status:    update.ScanStatusCompleted,
+	})
+	require.NoError(t, err)
+	return scanID
+}
+
+// Issue #50: `docker stack deploy` replaces a Swarm task with one under a new id
+// and a new name (`stack_api.1.<task-id>`), so the finding attached to the old
+// task is never matched by the name-based staleness check and stays on the
+// Updates page for good.
+func TestOrphanImageUpdates_SwarmTaskReplacedByDeploy(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	cs := NewContainerStore(db)
+	us := NewUpdateStore(db)
+
+	archivedAt := time.Now().Add(-time.Hour)
+	oldUID := seedScannedContainer(t, cs, "task-old", "stack_api.1.oldtask", &archivedAt)
+	seedScannedContainer(t, cs, "task-new", "stack_api.1.newtask", nil)
+
+	oldScan := seedScan(t, us)
+	newScan := seedScan(t, us)
+	seedImageUpdate(t, us, oldScan, "task-old", "stack_api.1.oldtask")
+	seedImageUpdate(t, us, newScan, "task-new", "stack_api.1.newtask")
+
+	// The name-based cleanup cannot see the replaced task: its name is gone from
+	// the scan set, so it is neither listed nor deleted.
+	stale, err := us.ListStaleImageUpdates(ctx, newScan, []string{"stack_api.1.newtask"})
+	require.NoError(t, err)
+	assert.Empty(t, stale, "the old task name is no longer scanned, so it never matches")
+
+	// The Updates page must not serve the replaced task in the meantime.
+	listed, err := us.ListImageUpdates(ctx, update.ListImageUpdatesOpts{})
+	require.NoError(t, err)
+	require.Len(t, listed, 1, "only the running task has a finding to show")
+	assert.Equal(t, "task-new", listed[0].ContainerID)
+
+	orphans, err := us.ListOrphanImageUpdates(ctx)
+	require.NoError(t, err)
+	require.Len(t, orphans, 1)
+	assert.Equal(t, "task-old", orphans[0].ContainerID)
+	assert.Equal(t, "stack_api.1.oldtask", orphans[0].ContainerName)
+	assert.Equal(t, oldUID, orphans[0].ContainerUID,
+		"the uid must come along so the recovery event resolves the right alert")
+
+	deleted, err := us.DeleteOrphanImageUpdates(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), deleted)
+
+	remaining, err := us.ListImageUpdates(ctx, update.ListImageUpdatesOpts{})
+	require.NoError(t, err)
+	require.Len(t, remaining, 1, "the running task keeps its finding")
+	assert.Equal(t, "task-new", remaining[0].ContainerID)
+
+	orphans, err = us.ListOrphanImageUpdates(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, orphans)
+}
+
+// A finding whose container row was deleted outright (no archived row left to
+// join) is still shed — with an empty uid, which the caller falls back on.
+func TestOrphanImageUpdates_ContainerRowGone(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	us := NewUpdateStore(db)
+
+	seedImageUpdate(t, us, seedScan(t, us), "task-vanished", "stack_api.1.vanished")
+
+	orphans, err := us.ListOrphanImageUpdates(ctx)
+	require.NoError(t, err)
+	require.Len(t, orphans, 1)
+	assert.Equal(t, "task-vanished", orphans[0].ContainerID)
+	assert.Empty(t, orphans[0].ContainerUID)
+
+	deleted, err := us.DeleteOrphanImageUpdates(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), deleted)
+}
+
+// Archiving leaves the container state untouched, so a replaced Swarm task stays
+// 'running' in the table: it must count neither as tracked nor as up to date.
+func TestGetUpdateSummary_SkipsArchivedContainers(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	cs := NewContainerStore(db)
+	us := NewUpdateStore(db)
+
+	archivedAt := time.Now().Add(-time.Hour)
+	seedScannedContainer(t, cs, "task-old", "stack_api.1.oldtask", &archivedAt)
+	seedScannedContainer(t, cs, "task-new", "stack_api.1.newtask", nil)
+
+	scanID := seedScan(t, us)
+	seedImageUpdate(t, us, scanID, "task-old", "stack_api.1.oldtask")
+	seedImageUpdate(t, us, scanID, "task-new", "stack_api.1.newtask")
+
+	summary, err := us.GetUpdateSummary(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, summary.Critical, "only the running task has a pending major update")
+	assert.Equal(t, 0, summary.UpToDate, "the archived task is not a container waiting to be scanned")
+}
+
+// The Updates page counts CVEs next to the image updates, so they must be shed
+// with the task they belong to.
+func TestListCVEs_SkipsContainersThatNoLongerExist(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	cs := NewContainerStore(db)
+	us := NewUpdateStore(db)
+
+	archivedAt := time.Now().Add(-time.Hour)
+	seedScannedContainer(t, cs, "task-old", "stack_api.1.oldtask", &archivedAt)
+	seedScannedContainer(t, cs, "task-new", "stack_api.1.newtask", nil)
+
+	for _, externalID := range []string{"task-old", "task-new"} {
+		require.NoError(t, us.UpsertContainerCVE(ctx, &update.ContainerCVE{
+			ContainerID:     externalID,
+			CVEID:           "CVE-2026-0001",
+			Severity:        update.CVESeverityHigh,
+			CVSSScore:       8.1,
+			FirstDetectedAt: time.Now(),
+		}))
+	}
+
+	cves, err := us.ListAllActiveCVEs(ctx, update.ListCVEsOpts{})
+	require.NoError(t, err)
+	require.Len(t, cves, 1)
+	assert.Equal(t, "task-new", cves[0].ContainerID)
+
+	counts, err := us.GetCVESummaryCounts(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, counts["high"], "the replaced task must not be counted twice")
+}
+
+// Purging archived containers used to leave their update artifacts behind: the
+// tables keyed by external_id have no FK, so nothing could ever reclaim them.
+func TestDeleteArchivedContainersBefore_RemovesUpdateArtifacts(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	cs := NewContainerStore(db)
+	us := NewUpdateStore(db)
+
+	longGone := time.Now().Add(-40 * 24 * time.Hour)
+	seedScannedContainer(t, cs, "task-old", "stack_api.1.oldtask", &longGone)
+	seedScannedContainer(t, cs, "task-new", "stack_api.1.newtask", nil)
+
+	scanID := seedScan(t, us)
+	for _, externalID := range []string{"task-old", "task-new"} {
+		seedImageUpdate(t, us, scanID, externalID, "stack_api.1."+externalID)
+
+		_, err := us.InsertVersionPin(ctx, &update.VersionPin{
+			ContainerID: externalID,
+			Image:       "ghcr.io/acme/api",
+			PinnedTag:   "1.0.0",
+			PinnedAt:    time.Now(),
+		})
+		require.NoError(t, err)
+
+		require.NoError(t, us.UpsertContainerCVE(ctx, &update.ContainerCVE{
+			ContainerID:     externalID,
+			CVEID:           "CVE-2026-0001",
+			Severity:        update.CVESeverityHigh,
+			CVSSScore:       8.1,
+			FirstDetectedAt: time.Now(),
+		}))
+
+		_, err = us.InsertRiskScoreRecord(ctx, &update.RiskScoreRecord{
+			ContainerID: externalID,
+			Score:       85,
+			FactorsJSON: "[]",
+			RecordedAt:  time.Now(),
+		})
+		require.NoError(t, err)
+	}
+
+	purged, err := cs.DeleteArchivedContainersBefore(ctx, time.Now().Add(-30*24*time.Hour))
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), purged)
+
+	for _, table := range []string{"image_updates", "container_cves", "version_pins", "risk_score_history"} {
+		assert.Equal(t, 1, countRows(t, db.ReadDB(), table),
+			"%s must keep the live container's row and only that one", table)
+	}
+
+	var leftover int
+	require.NoError(t, db.ReadDB().QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM image_updates WHERE container_id = 'task-old'`).Scan(&leftover))
+	assert.Zero(t, leftover, "the purged container must not leave a finding behind")
+}

--- a/internal/store/sqlite/uuid_schema.sql
+++ b/internal/store/sqlite/uuid_schema.sql
@@ -80,6 +80,7 @@ CREATE TABLE containers (
     UNIQUE(agent_id, external_id)
 );
 CREATE INDEX idx_containers_agent_id ON containers(agent_id);
+CREATE INDEX idx_containers_external_id ON containers(external_id);
 CREATE INDEX idx_container_group ON containers(custom_group, orchestration_group) WHERE archived = 0;
 CREATE INDEX idx_container_archived ON containers(archived, last_state_change_at DESC);
 CREATE INDEX idx_containers_swarm_service ON containers(swarm_service_id) WHERE swarm_service_id != '';

--- a/internal/update/model.go
+++ b/internal/update/model.go
@@ -166,6 +166,10 @@ type ScanError struct {
 type StaleImageUpdate struct {
 	ContainerID   string
 	ContainerName string
+	// ContainerUID is the maintenant id, filled for findings whose container is
+	// gone from the scan set and can no longer be looked up by the caller. Empty
+	// when the container row itself has been deleted.
+	ContainerUID string
 }
 
 // CVESeverity classifies the severity of a CVE.

--- a/internal/update/scanner_test.go
+++ b/internal/update/scanner_test.go
@@ -74,6 +74,10 @@ func (s *stubStore) DeleteStaleImageUpdates(_ context.Context, _ string, _ []str
 func (s *stubStore) ListStaleImageUpdates(_ context.Context, _ string, _ []string) ([]StaleImageUpdate, error) {
 	return nil, nil
 }
+func (s *stubStore) ListOrphanImageUpdates(_ context.Context) ([]StaleImageUpdate, error) {
+	return nil, nil
+}
+func (s *stubStore) DeleteOrphanImageUpdates(_ context.Context) (int64, error) { return 0, nil }
 func (s *stubStore) InsertVersionPin(_ context.Context, _ *VersionPin) (string, error) {
 	return "", nil
 }

--- a/internal/update/service.go
+++ b/internal/update/service.go
@@ -444,10 +444,36 @@ func (s *Service) runScan(ctx context.Context) {
 	} else if deleted > 0 {
 		s.logger.Info("update scan: removed stale updates", "deleted", deleted)
 	}
+
+	// Same for the findings whose container is gone entirely: matching on the
+	// name never sheds those, because Swarm renames the task container on every
+	// deploy. Skipped when the scan saw nothing, so a runtime that is momentarily
+	// unreachable doesn't wipe the whole page.
+	if len(containers) > 0 {
+		// Deleting without the list would strand the matching alerts, with
+		// nothing left to announce their recovery — so leave them to the next
+		// scan. The Updates page already hides them in the meantime.
+		orphans, err := s.store.ListOrphanImageUpdates(ctx)
+		if err != nil {
+			s.logger.Warn("update scan: list orphan updates", "error", err)
+		} else {
+			if deleted, err := s.store.DeleteOrphanImageUpdates(ctx); err != nil {
+				s.logger.Warn("update scan: cleanup orphan updates", "error", err)
+			} else if deleted > 0 {
+				s.logger.Info("update scan: removed updates for containers that no longer exist", "deleted", deleted)
+			}
+			staleUpdates = append(staleUpdates, orphans...)
+		}
+	}
+
 	for _, su := range staleUpdates {
+		containerUID := su.ContainerUID
+		if containerUID == "" {
+			containerUID = containerByID[su.ContainerID].UID
+		}
 		s.emitEvent(event.UpdateResolved, map[string]interface{}{
 			"container_id":   su.ContainerID,
-			"container_uid":  containerByID[su.ContainerID].UID,
+			"container_uid":  containerUID,
 			"container_name": su.ContainerName,
 		})
 	}

--- a/internal/update/service_orphan_test.go
+++ b/internal/update/service_orphan_test.go
@@ -1,0 +1,114 @@
+// Copyright 2026 Benjamin Touchard (kOlapsis)
+//
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+// or a commercial license. You may not use this file except in compliance
+// with one of these licenses.
+//
+// AGPL-3.0: https://www.gnu.org/licenses/agpl-3.0.html
+// Commercial: See COMMERCIAL-LICENSE.md
+//
+// Source: https://github.com/kolapsis/maintenant
+
+package update
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kolapsis/maintenant/internal/event"
+)
+
+// orphanStore records the orphan cleanup calls a scan makes.
+type orphanStore struct {
+	*stubStore
+	orphans     []StaleImageUpdate
+	listCalls   int
+	deleteCalls int
+}
+
+func (s *orphanStore) ListOrphanImageUpdates(_ context.Context) ([]StaleImageUpdate, error) {
+	s.listCalls++
+	return s.orphans, nil
+}
+
+func (s *orphanStore) DeleteOrphanImageUpdates(_ context.Context) (int64, error) {
+	s.deleteCalls++
+	return int64(len(s.orphans)), nil
+}
+
+type stubLister struct {
+	containers []ContainerInfo
+}
+
+func (l stubLister) ListContainerInfos(_ context.Context) ([]ContainerInfo, error) {
+	return l.containers, nil
+}
+
+func newOrphanTestService(store UpdateStore, containers []ContainerInfo, onEvent EventCallback) *Service {
+	return NewService(Deps{
+		Store:         store,
+		Scanner:       newTestScanner(&stubRegistry{}, store),
+		Containers:    stubLister{containers: containers},
+		Logger:        testLogger(),
+		EventCallback: onEvent,
+	})
+}
+
+// Issue #50: a scan must shed the findings of containers no runtime reports
+// anymore, and announce each one so the alert engine resolves its alert. The
+// entity id comes from the store, since the container is gone from the scan set
+// and cannot be looked up there.
+func TestRunScan_DropsFindingsOfContainersThatNoLongerExist(t *testing.T) {
+	store := &orphanStore{
+		stubStore: &stubStore{},
+		orphans: []StaleImageUpdate{{
+			ContainerID:   "task-old",
+			ContainerName: "stack_api.1.oldtask",
+			ContainerUID:  "uid-old",
+		}},
+	}
+
+	var resolved []map[string]interface{}
+	svc := newOrphanTestService(store, []ContainerInfo{{
+		UID:        "uid-new",
+		ExternalID: "task-new",
+		Name:       "stack_api.1.newtask",
+		Image:      "ghcr.io/acme/api:1.0.0",
+	}}, func(eventType string, data interface{}) {
+		if eventType != event.UpdateResolved {
+			return
+		}
+		m, ok := data.(map[string]interface{})
+		require.True(t, ok)
+		resolved = append(resolved, m)
+	})
+
+	svc.runScan(context.Background())
+
+	assert.Equal(t, 1, store.deleteCalls, "the scan must purge the orphan findings")
+	require.Len(t, resolved, 1, "each dropped finding must announce its recovery")
+	assert.Equal(t, "task-old", resolved[0]["container_id"])
+	assert.Equal(t, "uid-old", resolved[0]["container_uid"])
+	assert.Equal(t, "stack_api.1.oldtask", resolved[0]["container_name"])
+}
+
+// A runtime that reports nothing must not be read as "every container is gone".
+func TestRunScan_KeepsFindingsWhenTheScanSeesNoContainer(t *testing.T) {
+	store := &orphanStore{
+		stubStore: &stubStore{},
+		orphans: []StaleImageUpdate{{
+			ContainerID:   "task-old",
+			ContainerName: "stack_api.1.oldtask",
+			ContainerUID:  "uid-old",
+		}},
+	}
+
+	svc := newOrphanTestService(store, nil, nil)
+	svc.runScan(context.Background())
+
+	assert.Zero(t, store.listCalls)
+	assert.Zero(t, store.deleteCalls, "an empty scan must not wipe the Updates page")
+}

--- a/internal/update/store.go
+++ b/internal/update/store.go
@@ -34,6 +34,8 @@ type UpdateStore interface {
 	DeleteImageUpdatesByContainer(ctx context.Context, containerID string) error
 	DeleteStaleImageUpdates(ctx context.Context, scanID string, scannedContainerNames []string) (int64, error)
 	ListStaleImageUpdates(ctx context.Context, scanID string, scannedContainerNames []string) ([]StaleImageUpdate, error)
+	ListOrphanImageUpdates(ctx context.Context) ([]StaleImageUpdate, error)
+	DeleteOrphanImageUpdates(ctx context.Context) (int64, error)
 
 	// Version pins
 	InsertVersionPin(ctx context.Context, p *VersionPin) (string, error)


### PR DESCRIPTION
Closes #50.

Stale cleanup only matched findings whose `container_name` appeared in the current scan. Swarm renames the task container on every `docker stack deploy` (`svc.1.<task-id>`), so a replaced task never matches — one dead row per service per upgrade, outranking the live findings on severity.

## Fixes
- **Shed by identity, not by name.** A scan now deletes the findings whose container no runtime reports anymore and emits `update.resolved` for each, carrying the container uid so the alert engine resolves the right alert. Skipped when the scan saw no container, so an unreachable runtime cannot wipe the page.
- **Reads filtered too**, so the page is right immediately after a deploy instead of at the next scan (24 h by default). Same guard on the CVE findings and on the up-to-date count — archiving leaves the state untouched, so a replaced task stayed `running`.
- **Retention purge cascades.** Deleting archived containers now clears `image_updates`, `container_cves`, `version_pins` and `risk_score_history`; they are keyed by `external_id` with no FK, and were unreachable once the container row was gone.
- **Migration 27** indexes `containers(external_id)`, which only existed as the second column of the `(agent_id, external_id)` unique index.

Containers that are merely stopped keep their findings — only what the runtime no longer knows about is dropped.

## Tests
`internal/store/sqlite/updates_orphan_test.go` covers the Swarm scenario, the deleted-container case, the summary counts, the CVE list and the retention cascade. `internal/update/service_orphan_test.go` covers the scan emitting the recovery events, and refusing to purge on an empty scan.

Full suite green, golangci-lint and gosec clean.
