### PR TITLE
docs(agent): document reverse-proxy read timeout cutting the agent st…

### DIFF
--- a/docs/features/multihost.md
+++ b/docs/features/multihost.md
@@ -51,6 +51,8 @@ Set `MAINTENANT_GRPC_TLS_INSECURE=true`. The listener accepts plaintext HTTP/2 (
 MAINTENANT_GRPC_TLS_INSECURE=true maintenant --mode=server
 ```
 
+The proxy must also let the stream live: it is a request whose body never ends, so any read timeout on the route (Traefik's `respondingTimeouts.readTimeout`, 60 s by default) severs it periodically. See [Agent Setup — long-lived streams](../guides/agent-setup.md#step-1-make-the-grpc-endpoint-reachable).
+
 **Direct TLS with a custom certificate**
 
 Mount a certificate/key pair covering the public hostname agents will dial:

--- a/docs/guides/agent-setup.md
+++ b/docs/guides/agent-setup.md
@@ -46,6 +46,44 @@ MAINTENANT_GRPC_URL=grpcs://agents.example.com   # the address agents will dial
     - traefik.http.services.maintenant-grpc.loadbalancer.server.scheme=h2c
     ```
 
+    !!! warning "Long-lived streams — disable the proxy's read timeout"
+        The agent stream is a single request whose body never ends. Any proxy that caps the
+        duration of a request kills it at that limit regardless of the traffic on it, and the
+        agent reconnects in a loop — remote containers then appear and disappear depending on
+        when the reconnect lands.
+
+        On **Traefik v3** the culprit is `respondingTimeouts.readTimeout`, 60 s by default.
+        It is configured **per entrypoint**, so it cannot be relaxed for gRPC alone on a shared
+        `websecure` entrypoint — use a dedicated one:
+
+        ```yaml
+        # Traefik static configuration (CLI flags)
+        - --entrypoints.grpc.address=:8443
+        - --entrypoints.grpc.transport.respondingTimeouts.readTimeout=0
+        - --entrypoints.grpc.transport.respondingTimeouts.idleTimeout=0
+        ```
+
+        ```yaml
+        # server container labels — same router, on the grpc entrypoint
+        - traefik.http.routers.maintenant-grpc.rule=Host(`agents.example.com`)
+        - traefik.http.routers.maintenant-grpc.entrypoints=grpc
+        - traefik.http.routers.maintenant-grpc.tls.certresolver=le
+        - traefik.http.routers.maintenant-grpc.service=maintenant-grpc
+        - traefik.http.services.maintenant-grpc.loadbalancer.server.port=8443
+        - traefik.http.services.maintenant-grpc.loadbalancer.server.scheme=h2c
+        ```
+
+        Two consequences of a non-443 entrypoint:
+
+        - agents must include the port: `--server=grpcs://agents.example.com:8443`;
+        - ACME `tlschallenge` requires port 443, so a hostname served only on this entrypoint
+          gets no certificate that way — keep a router for it on `websecure`, or switch to
+          `httpchallenge`.
+
+        Other proxies have the same class of setting: nginx `grpc_read_timeout`, HAProxy
+        `timeout tunnel`. The agent pushes a full inventory every 30 s, so idle timeouts
+        (Traefik's `idleTimeout`, 180 s) are normally not hit — only the read timeout is.
+
 === "Direct TLS with a custom certificate"
 
     Mount a certificate/key pair and point to them with env vars:
@@ -204,6 +242,15 @@ The full reference (server-side variables, rate limits, stale thresholds) is in 
 !!! failure "Host stays `disconnected`"
     - Confirm the gRPC port/subdomain is reachable from the agent host (firewall, DNS, reverse-proxy route).
     - If the server uses a self-signed certificate, the agent must either trust it or run with `--grpc-insecure-skip-tls-verify` (dev only). With a real (Let's Encrypt) certificate, no flag is needed.
+
+    These cause a *permanent* failure. A host that connects then drops at a fixed interval is a different problem — see below.
+
+!!! failure "The agent reconnects at a fixed interval (60 s behind Traefik)"
+    A *periodic* drop points at the reverse proxy, not at routing: the stream is one request
+    that never completes, and the proxy closes it when its read timeout expires. Nothing in the
+    agent logs names the proxy — it just looks like an unstable link. Disable the read timeout
+    on the entrypoint carrying gRPC, see
+    [Step 1 — long-lived streams](#step-1-make-the-grpc-endpoint-reachable).
 
 !!! failure "Permission denied on the Docker socket"
     The containerized agent runs unprivileged but auto-detects the mounted socket's group, so

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -117,6 +117,35 @@ As a last resort you can turn verification off for a single container endpoint w
 
 ---
 
+## An agent host flaps: connected, then disconnected, every 60 seconds
+
+**Symptom:** the host on the **Agents** page alternates between `connected` and `disconnected`
+at a regular interval, and its containers show up or vanish depending on when you look. The
+agent logs show a reconnect loop with no mention of a proxy — it reads like an unstable network
+link.
+
+**Why it happens:** the agent stream is a single gRPC request whose body never ends. A reverse
+proxy that caps the duration of a request cuts it at that limit no matter how much traffic
+flows on it. On Traefik v3 that cap is `respondingTimeouts.readTimeout`, **60 s by default** on
+every entrypoint.
+
+**Fix:** disable the read timeout on the entrypoint that carries gRPC. It is a per-entrypoint
+setting, so a dedicated entrypoint is needed to avoid dropping the protection for all HTTPS
+traffic:
+
+```yaml
+- --entrypoints.grpc.address=:8443
+- --entrypoints.grpc.transport.respondingTimeouts.readTimeout=0
+- --entrypoints.grpc.transport.respondingTimeouts.idleTimeout=0
+```
+
+Agents then need the port in their URL (`--server=grpcs://agents.example.com:8443`). The
+equivalent settings are `grpc_read_timeout` on nginx and `timeout tunnel` on HAProxy. Full
+configuration, including the ACME side effect of a non-443 entrypoint, is in the
+[Agent Setup guide](guides/agent-setup.md#step-1-make-the-grpc-endpoint-reachable).
+
+---
+
 ## The database keeps growing, or the -wal file is huge
 
 Up to and including 1.3.7, the retention cleanup deleted at most 1000 rows per hour, whatever


### PR DESCRIPTION
The agent stream is a single gRPC request whose body never ends, so a proxy that caps request duration severs it periodically. On Traefik v3 that cap is respondingTimeouts.readTimeout (60s by default), producing a reconnect loop that no existing troubleshooting entry covered — they all describe permanent failures.

Document the dedicated-entrypoint workaround in the agent setup guide, add a matching troubleshooting entry for the periodic-drop symptom, and cross-link from the multihost h2c section.