### PR TITLE
fix(k8s): keep the liveness probe from killing pods mid-migration

### DIFF
--- a/deploy/helm/maintenant/templates/deployment.yaml
+++ b/deploy/helm/maintenant/templates/deployment.yaml
@@ -76,6 +76,15 @@ spec:
               mountPath: /data
             - name: tmp
               mountPath: /tmp
+          # Migrations run before the HTTP listener starts, so /health is silent for
+          # their whole duration. Without this the liveness probe kills the pod
+          # mid-migration and leaves the schema dirty — see values.yaml.
+          startupProbe:
+            httpGet:
+              path: /api/v1/health
+              port: http
+            periodSeconds: {{ .Values.startupProbe.periodSeconds }}
+            failureThreshold: {{ .Values.startupProbe.failureThreshold }}
           livenessProbe:
             httpGet:
               path: /api/v1/health

--- a/deploy/helm/maintenant/values.yaml
+++ b/deploy/helm/maintenant/values.yaml
@@ -21,9 +21,20 @@ persistence:
   enabled: true
   storageClass: ""
   accessMode: ReadWriteOnce
-  size: 1Gi
+  ## Migrations that rebuild a table copy it before dropping the original, and
+  ## SQLite temp files are written here too (SQLITE_TMPDIR=/data). Allow several
+  ## times the expected database size or an upgrade can run the volume out of space.
+  size: 10Gi
   ## Use an existing PVC (persistence.enabled is ignored when set)
   existingClaim: ""
+
+## Schema migrations run before the HTTP listener starts, so /health does not
+## answer while they work — minutes on a large database. The startup probe holds
+## the liveness probe off for periodSeconds x failureThreshold (10 min by
+## default); raise failureThreshold if an upgrade needs longer.
+startupProbe:
+  periodSeconds: 10
+  failureThreshold: 60
 
 service:
   type: ClusterIP

--- a/deploy/kubernetes/deployment.yaml
+++ b/deploy/kubernetes/deployment.yaml
@@ -52,6 +52,18 @@ spec:
               mountPath: /data
             - name: tmp
               mountPath: /tmp
+          # Schema migrations run before the HTTP listener starts, so /health stays
+          # silent for their whole duration — minutes on a large database, and the
+          # one-time UUID conversion is slower still. Without a startupProbe the
+          # liveness probe below kills the pod ~95s in, leaving the migration
+          # half-applied and marked dirty, and it repeats on every restart.
+          # 60 x 10s = 10 minutes of grace; liveness only takes over after that.
+          startupProbe:
+            httpGet:
+              path: /api/v1/health
+              port: http
+            periodSeconds: 10
+            failureThreshold: 60
           livenessProbe:
             httpGet:
               path: /api/v1/health
@@ -87,7 +99,10 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 1Gi
+      # Table rebuilds during migration copy a table before dropping the old one,
+      # and SQLite temp files land on this volume too (SQLITE_TMPDIR=/data), so
+      # headroom of several times the database size is needed to upgrade at all.
+      storage: 10Gi
 ---
 apiVersion: v1
 kind: Service

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -100,7 +100,7 @@ Both approaches deploy:
 
 - A **ServiceAccount** with read-only RBAC (pods, logs, services, namespaces, events, deployments, statefulsets, daemonsets, replicasets, pod metrics)
 - A **Deployment** with security hardening (non-root, read-only filesystem, all capabilities dropped)
-- A **PersistentVolumeClaim** (1Gi) for the SQLite database
+- A **PersistentVolumeClaim** (10Gi) for the SQLite database
 - A **ClusterIP Service** on port 80
 
 maintenant auto-detects the in-cluster Kubernetes API. Namespace filtering and workload-level monitoring work out of the box.

--- a/docs/guides/kubernetes.md
+++ b/docs/guides/kubernetes.md
@@ -32,7 +32,7 @@ This creates:
 | **ClusterRole** | Read-only access to pods, logs, services, events, workloads, and metrics |
 | **ClusterRoleBinding** | Binds the role to the service account |
 | **Deployment** | Single replica with security hardening |
-| **PersistentVolumeClaim** | 1 Gi for SQLite storage |
+| **PersistentVolumeClaim** | 10 Gi for SQLite storage — migrations rebuild tables in place and need several times the database size |
 | **Service** | ClusterIP on port 80 |
 
 ---
@@ -155,9 +155,15 @@ env:
 
 ## Health Probes
 
-The deployment includes liveness and readiness probes:
+The deployment includes startup, liveness and readiness probes:
 
 ```yaml
+startupProbe:
+  httpGet:
+    path: /api/v1/health
+    port: http
+  periodSeconds: 10
+  failureThreshold: 60
 livenessProbe:
   httpGet:
     path: /api/v1/health
@@ -171,6 +177,15 @@ readinessProbe:
   initialDelaySeconds: 3
   periodSeconds: 10
 ```
+
+!!! warning "Do not drop the startup probe"
+    Schema migrations run **before** the HTTP listener starts, so `/api/v1/health`
+    stays silent for their whole duration — minutes on a large database, and longer
+    for the one-time UUID conversion. Without a startup probe the liveness probe
+    kills the pod about 95 s in, leaving the migration half-applied and the schema
+    marked dirty, and the same thing happens on every restart. The
+    `failureThreshold: 60` above grants 10 minutes; raise it if an upgrade needs
+    more.
 
 ---
 


### PR DESCRIPTION
Closes #42.

Migrations run before the HTTP listener starts, so `/api/v1/health` answers
nothing for their whole duration. The manifests shipped a `livenessProbe`
(`initialDelaySeconds: 5`, `periodSeconds: 30`, default `failureThreshold: 3`)
and no `startupProbe`, so kubelet kills the pod after ~95 s. Migration 21
rewrites `state_transitions`, `resource_snapshots` and `resource_alert_configs`
in full ? longer than that on any real database ? so the pod dies mid-migration,
the schema stays dirty, and every restart repeats it.

- `startupProbe` on the raw manifest and the Helm chart, 10 minutes of grace,
  configurable via `startupProbe.periodSeconds` / `.failureThreshold`.
- Default PVC 1Gi ? 10Gi: table rebuilds copy before dropping, and SQLite temp
  files share the volume (`SQLITE_TMPDIR=/data`).
- Kubernetes guide and installation page updated to match, with a warning
  explaining why the startup probe must not be removed.

`helm lint` and `helm template` pass. No application code changed.