### PR TITLE
fix(nav): keep the Containers entry on a Swarm node

### DIFF
--- a/frontend/src/composables/__tests__/useFleetRuntimes.spec.ts
+++ b/frontend/src/composables/__tests__/useFleetRuntimes.spec.ts
@@ -31,7 +31,7 @@ beforeEach(() => {
   state.resources.selected = null
 })
 
-describe('useFleetRuntimes — empty Swarm keeps Docker available', () => {
+describe('useFleetRuntimes — Swarm keeps Docker available', () => {
   it('local Swarm manager with 0 services exposes both swarm and docker', () => {
     state.runtime.context = 'swarm'
     state.runtime.metadata = { service_count: 0 }
@@ -39,38 +39,51 @@ describe('useFleetRuntimes — empty Swarm keeps Docker available', () => {
     expect(runtimes()).toEqual(expect.arrayContaining(['swarm', 'docker']))
   })
 
-  it('local Swarm manager with services does NOT expose docker', () => {
+  // Issue #28: the Containers entry vanished from the sidebar as soon as one
+  // service was deployed, while /containers still worked by direct URL.
+  it('local Swarm manager with services still exposes docker', () => {
     state.runtime.context = 'swarm'
     state.runtime.metadata = { service_count: 3 }
     state.resources.selected = 'local'
-    expect(runtimes()).toEqual(['swarm'])
+    expect(runtimes()).toEqual(expect.arrayContaining(['swarm', 'docker']))
   })
 
-  it('missing service_count is treated as 0 (docker stays available)', () => {
+  it('the service count no longer decides anything', () => {
     state.runtime.context = 'swarm'
     state.runtime.metadata = {}
     state.resources.selected = 'local'
-    expect(runtimes()).toContain('docker')
+    expect(runtimes()).toEqual(expect.arrayContaining(['swarm', 'docker']))
   })
 
-  it('"all" scope on an empty Swarm includes both docker and swarm', () => {
+  it('"all" scope on a busy Swarm includes both docker and swarm', () => {
     state.runtime.context = 'swarm'
-    state.runtime.metadata = { service_count: 0 }
+    state.runtime.metadata = { service_count: 7 }
     state.resources.selected = null
     expect(runtimes()).toEqual(expect.arrayContaining(['swarm', 'docker']))
   })
 
-  it('does not apply the empty-Swarm rule to a selected remote agent', () => {
+  it('a selected Swarm agent exposes docker too', () => {
+    state.runtime.context = 'docker'
+    state.agents.agents = [{ status: 'active', agent_id: 'agent-1', detected_runtime: 'swarm' }]
+    state.resources.selected = 'agent-1'
+    expect(runtimes()).toEqual(expect.arrayContaining(['swarm', 'docker']))
+  })
+
+  it('a selected Docker agent is unaffected by the local Swarm context', () => {
     state.runtime.context = 'swarm'
-    state.runtime.metadata = { service_count: 0 }
     state.agents.agents = [{ status: 'active', agent_id: 'agent-1', detected_runtime: 'docker' }]
     state.resources.selected = 'agent-1'
     expect(runtimes()).toEqual(['docker'])
   })
 
-  it('plain docker is unaffected regardless of service_count', () => {
+  it('a Kubernetes scope does not gain docker', () => {
+    state.runtime.context = 'kubernetes'
+    state.resources.selected = 'local'
+    expect(runtimes()).toEqual(['kubernetes'])
+  })
+
+  it('plain docker stays exactly docker', () => {
     state.runtime.context = 'docker'
-    state.runtime.metadata = { service_count: 0 }
     state.resources.selected = 'local'
     expect(runtimes()).toEqual(['docker'])
   })

--- a/frontend/src/composables/useFleetRuntimes.ts
+++ b/frontend/src/composables/useFleetRuntimes.ts
@@ -13,7 +13,6 @@ import { computed } from 'vue'
 import { useRuntimeStore } from '@/stores/runtime'
 import { useAgentsStore } from '@/stores/agents'
 import { useResourcesStore } from '@/stores/resources'
-import type { SwarmMetadata } from '@/services/runtimeApi'
 
 // useFleetRuntimes derives which container runtimes are reachable for the
 // currently selected host scope, so the navigation can show the matching views.
@@ -33,14 +32,13 @@ export function useFleetRuntimes() {
   // The server's own runtime: 'docker' | 'swarm' | 'kubernetes'.
   const localRuntime = computed(() => runtimeStore.context)
 
-  // A local Swarm manager with zero deployed services still runs plain
-  // containers, so keep the Docker "Containers" view reachable alongside the
-  // (empty) Swarm views until a service is actually deployed.
-  const localSwarmNoServices = computed(() => {
-    if (runtimeStore.context !== 'swarm') return false
-    const meta = runtimeStore.metadata as Partial<SwarmMetadata>
-    return (meta.service_count ?? 0) === 0
-  })
+  // Swarm mode is an overlay on the Docker runtime, not a replacement: the host
+  // keeps running plain containers (the tasks themselves, plus anything started
+  // outside a service), and the Docker views keep working on it. So a Swarm
+  // scope offers 'docker' as well, whatever the deployed-service count — gating
+  // that on service_count == 0 hid the Containers entry on every real cluster
+  // while the page itself still worked by direct URL (issue #28).
+  const expand = (rt: string): string[] => (rt === 'swarm' ? ['swarm', 'docker'] : [rt])
 
   // The local server's runtimes, gated on the runtime status being known. Until
   // the first fetch resolves we contribute nothing, so runtime-specific nav
@@ -48,9 +46,7 @@ export function useFleetRuntimes() {
   // optimistic 'docker' default.
   const localRuntimes = (): string[] => {
     if (!runtimeStore.loaded) return []
-    const set = new Set<string>([localRuntime.value])
-    if (localSwarmNoServices.value) set.add('docker')
-    return [...set]
+    return expand(localRuntime.value)
   }
 
   const availableRuntimes = computed<string[]>(() => {
@@ -58,11 +54,13 @@ export function useFleetRuntimes() {
     if (sel === 'local') return localRuntimes()
     if (sel) {
       const agent = activeAgents.value.find((a) => a.agent_id === sel)
-      return agent ? [agent.detected_runtime] : []
+      return agent ? expand(agent.detected_runtime) : []
     }
     // "All resources": union of the local runtime and every active agent's.
     const set = new Set<string>(localRuntimes())
-    for (const a of activeAgents.value) set.add(a.detected_runtime)
+    for (const a of activeAgents.value) {
+      for (const rt of expand(a.detected_runtime)) set.add(rt)
+    }
     return [...set]
   })
 

--- a/frontend/src/stores/__tests__/runtime.spec.ts
+++ b/frontend/src/stores/__tests__/runtime.spec.ts
@@ -1,0 +1,116 @@
+// Copyright 2026 Benjamin Touchard (Kolapsis)
+//
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+// or a commercial license. See COMMERCIAL-LICENSE.md.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+
+const fetchRuntimeStatus = vi.hoisted(() => vi.fn())
+
+vi.mock('@/services/runtimeApi', () => ({ fetchRuntimeStatus }))
+vi.mock('@/services/sseBus', () => ({ sseBus: { on: vi.fn(), off: vi.fn(), connected: false } }))
+vi.mock('@/composables/useToast', () => ({ showToast: vi.fn() }))
+
+import { useRuntimeStore } from '../runtime'
+
+const OK = {
+  context: 'swarm',
+  runtime: 'docker',
+  connected: true,
+  label: 'Services',
+  detected_at: '2026-07-30T00:00:00Z',
+  metadata: { service_count: 3 },
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  fetchRuntimeStatus.mockReset()
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('runtime store — a failed status fetch does not strip the nav for good', () => {
+  it('does not reject: the caller must not see an unhandled rejection', async () => {
+    fetchRuntimeStatus.mockRejectedValue(new Error('boom'))
+    const store = useRuntimeStore()
+    await expect(store.fetchStatus()).resolves.toBeUndefined()
+    expect(store.error).toBe('boom')
+    store.stopListening()
+  })
+
+  it('leaves loaded false while failing, so the nav waits instead of guessing', async () => {
+    fetchRuntimeStatus.mockRejectedValue(new Error('boom'))
+    const store = useRuntimeStore()
+    await store.fetchStatus()
+    expect(store.loaded).toBe(false)
+    store.stopListening()
+  })
+
+  it('retries after a failure and recovers once the API answers', async () => {
+    fetchRuntimeStatus.mockRejectedValueOnce(new Error('boom')).mockResolvedValue(OK)
+    const store = useRuntimeStore()
+
+    await store.fetchStatus()
+    expect(store.loaded).toBe(false)
+
+    await vi.advanceTimersByTimeAsync(1000)
+
+    expect(fetchRuntimeStatus).toHaveBeenCalledTimes(2)
+    expect(store.loaded).toBe(true)
+    expect(store.context).toBe('swarm')
+    expect(store.error).toBeNull()
+  })
+
+  it('backs off between attempts and caps the delay', async () => {
+    fetchRuntimeStatus.mockRejectedValue(new Error('boom'))
+    const store = useRuntimeStore()
+
+    await store.fetchStatus()
+    expect(fetchRuntimeStatus).toHaveBeenCalledTimes(1)
+
+    // 1s, then 2s, then 4s — one retry in flight at a time.
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(fetchRuntimeStatus).toHaveBeenCalledTimes(2)
+    await vi.advanceTimersByTimeAsync(1999)
+    expect(fetchRuntimeStatus).toHaveBeenCalledTimes(2)
+    await vi.advanceTimersByTimeAsync(1)
+    expect(fetchRuntimeStatus).toHaveBeenCalledTimes(3)
+
+    // Far past the cap: still one attempt per 30s, not a burst.
+    await vi.advanceTimersByTimeAsync(10 * 60 * 1000)
+    expect(fetchRuntimeStatus.mock.calls.length).toBeLessThan(30)
+
+    store.stopListening()
+  })
+
+  it('stopListening cancels a pending retry', async () => {
+    fetchRuntimeStatus.mockRejectedValue(new Error('boom'))
+    const store = useRuntimeStore()
+
+    await store.fetchStatus()
+    store.stopListening()
+
+    await vi.advanceTimersByTimeAsync(60_000)
+    expect(fetchRuntimeStatus).toHaveBeenCalledTimes(1)
+  })
+
+  it('a success resets the backoff so a later failure retries fast again', async () => {
+    fetchRuntimeStatus.mockRejectedValueOnce(new Error('boom')).mockResolvedValue(OK)
+    const store = useRuntimeStore()
+
+    await store.fetchStatus()
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(store.loaded).toBe(true)
+
+    fetchRuntimeStatus.mockRejectedValueOnce(new Error('again')).mockResolvedValue(OK)
+    await store.fetchStatus()
+    const callsBefore = fetchRuntimeStatus.mock.calls.length
+
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(fetchRuntimeStatus.mock.calls.length).toBe(callsBefore + 1)
+  })
+})

--- a/frontend/src/stores/runtime.ts
+++ b/frontend/src/stores/runtime.ts
@@ -41,9 +41,29 @@ export const useRuntimeStore = defineStore('runtime', () => {
   const detectedAt = ref<string | null>(null)
   const metadata = ref<SwarmMetadata | KubernetesMetadata | DockerMetadata>({})
   const loading = ref(false)
+  const error = ref<string | null>(null)
   // false until the first successful status fetch — runtime-specific nav waits
   // for the real runtime instead of flashing the optimistic 'docker' default.
   const loaded = ref(false)
+
+  // A failed fetch used to leave `loaded` false for the rest of the session,
+  // which silently strips every runtime-specific nav entry (Containers,
+  // Services, Tasks, Workloads, Pods) — the pages still worked by direct URL,
+  // so it read as the entries never having existed. Retry with capped backoff
+  // so a transient failure repairs itself instead.
+  const RETRY_CAP_MS = 30_000
+  let retryTimer: ReturnType<typeof setTimeout> | null = null
+  let retryAttempt = 0
+
+  function scheduleRetry() {
+    if (retryTimer) return
+    const delay = Math.min(RETRY_CAP_MS, 1000 * 2 ** retryAttempt)
+    retryAttempt++
+    retryTimer = setTimeout(() => {
+      retryTimer = null
+      void fetchStatus()
+    }, delay)
+  }
 
   const isDocker = computed(() => context.value === 'docker')
   const isSwarm = computed(() => context.value === 'swarm')
@@ -60,6 +80,11 @@ export const useRuntimeStore = defineStore('runtime', () => {
       detectedAt.value = status.detected_at
       metadata.value = status.metadata
       loaded.value = true
+      error.value = null
+      retryAttempt = 0
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : 'Failed to fetch runtime status'
+      scheduleRetry()
     } finally {
       loading.value = false
     }
@@ -110,6 +135,10 @@ export const useRuntimeStore = defineStore('runtime', () => {
     sseBus.off('runtime.availability_changed', onAvailabilityChanged)
     sseBus.off('swarm.service_discovered', onServiceCountChanged)
     sseBus.off('swarm.service_removed', onServiceCountChanged)
+    if (retryTimer) {
+      clearTimeout(retryTimer)
+      retryTimer = null
+    }
   }
 
   return {
@@ -120,6 +149,7 @@ export const useRuntimeStore = defineStore('runtime', () => {
     detectedAt,
     metadata,
     loading,
+    error,
     loaded,
     isDocker,
     isSwarm,


### PR DESCRIPTION
Closes #28.

Two independent causes for the same symptom: the Containers entry missing from the sidebar while `/containers` still worked by direct URL.

**1. Swarm hid it.** Swarm mode is an overlay on the Docker runtime, not a replacement, the host still runs plain containers.
But the carve-out re-adding `docker` to a Swarm scope was gated on `service_count == 0`, true only on an empty cluster. 
A `swarm` runtime now offers the Docker views regardless of the service count, for enrolled agents as well as the local server (a Swarm agent had the same blind spot when selected as the host scope).

**2. A failed status fetch hid it permanently.** `fetchStatus` had no catch, so one failed request left `loaded` false for the session and silently stripped every runtime-specific entry; plus an unhandled rejection from the layout's `onMounted`. It now retries with backoff capped at 30s and exposes the error on the store; `loaded` stays false while failing, so the nav still waits rather than guessing a runtime.