### PR TITLE
fix(app): let server mode start under a valid license

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -200,15 +200,9 @@ func New(cfg Config, logger *slog.Logger) (*App, error) {
 	agentStore := sqlite.NewAgentStore(db)
 	a.agentStore = agentStore
 
-	// --- Mode gate: server/agent require Pro license ---
-	if cfg.Mode != "" && cfg.Mode != "embedded" {
-		// Evaluate edition now (before license manager starts) using whatever was
-		// set at binary build time or injected via a previous boot.
-		if extension.CurrentEdition() != extension.Pro {
-			logger.Error("server/agent mode requires Pro license", "mode", cfg.Mode)
-			os.Exit(1)
-		}
-	}
+	// The mode gate lives in Start(), after the license manager has resolved the
+	// edition. Evaluating it here would read the package default and reject every
+	// edition, Pro included.
 
 	// --- License manager ---
 	license.InitPublicKey(cfg.PublicKeyB64)
@@ -681,6 +675,15 @@ func (a *App) Start(ctx context.Context) error {
 	if a.licenseMgr != nil {
 		a.wireLicenseSubscriber(ctx)
 		a.licenseMgr.Start(ctx)
+	}
+
+	// Mode gate: server mode requires Pro. Checked here because licenseMgr.Start
+	// runs the initial verification synchronously, so the edition is settled —
+	// NewManager has already loaded the disk cache and Start has refreshed it.
+	if a.cfg.Mode != "" && a.cfg.Mode != "embedded" {
+		if edition := extension.CurrentEdition(); edition != extension.Pro {
+			return fmt.Errorf("%s mode requires the Pro edition (current edition: %s)", a.cfg.Mode, edition)
+		}
 	}
 
 	a.alertEngine.Start(ctx)

--- a/internal/app/mode_gate_test.go
+++ b/internal/app/mode_gate_test.go
@@ -1,0 +1,152 @@
+package app_test
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kolapsis/maintenant/internal/app"
+	"github.com/kolapsis/maintenant/internal/extension"
+)
+
+// gateErrFragment is the part of the mode-gate error these tests key on.
+const gateErrFragment = "requires the Pro edition"
+
+func withEdition(t *testing.T, e extension.Edition) {
+	t.Helper()
+	prev := extension.CurrentEdition
+	extension.CurrentEdition = func() extension.Edition { return e }
+	t.Cleanup(func() { extension.CurrentEdition = prev })
+}
+
+func freePort(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := ln.Addr().String()
+	require.NoError(t, ln.Close())
+	return addr
+}
+
+func modeGateCfg(t *testing.T, mode string) (app.Config, *slog.Logger) {
+	t.Helper()
+	t.Setenv("MAINTENANT_RUNTIME", "docker")
+	t.Setenv("DOCKER_HOST", "unix:///nonexistent-test-socket-abc123.sock")
+	t.Setenv("KUBERNETES_SERVICE_HOST", "")
+	t.Setenv("KUBECONFIG", "")
+
+	cfg := app.Config{
+		DBPath: filepath.Join(t.TempDir(), "test.db"),
+		Addr:   freePort(t),
+		Mode:   mode,
+	}
+	cfg.MultiHost.GRPCListen = freePort(t)
+	cfg.MultiHost.InsecureGRPC = true // skip TLS material generation in tests
+	return cfg, slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// startAndCollect runs Start with a bounded context and returns its error.
+func startAndCollect(t *testing.T, a *app.App, grace time.Duration) error {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- a.Start(ctx) }()
+
+	select {
+	case err := <-done:
+		return err // Start returned on its own (the gate rejected it)
+	case <-time.After(grace):
+		cancel() // it got past the gate and is running — shut it down
+	}
+
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(10 * time.Second):
+		t.Fatal("Start() did not return after context cancellation")
+		return nil
+	}
+}
+
+// TestNew_ServerMode_DoesNotGateOnEdition is the regression guard.
+//
+// The gate used to sit in New(), *before* extension.CurrentEdition was wired to
+// the license manager. At that point it read the package default — community —
+// so `--mode=server` called os.Exit(1) for every edition, Pro included: a paying
+// customer following the multi-host guide could never boot.
+//
+// The edition is deliberately NOT overridden here. Overriding it to Pro is what
+// hid the bug in the first place: it makes the old in-New() check pass and tests
+// nothing. Left at the package default, this test kills the test binary against
+// the old code (os.Exit) and passes against the fix.
+func TestNew_ServerMode_DoesNotGateOnEdition(t *testing.T) {
+	require.Equal(t, extension.Community, extension.CurrentEdition(),
+		"precondition: this test must run at the package default edition")
+
+	cfg, logger := modeGateCfg(t, "server")
+
+	a, err := app.New(cfg, logger)
+	require.NoError(t, err, "New() must not gate on edition — the license is not loaded yet")
+	require.NotNil(t, a)
+}
+
+// TestStart_ServerMode_RejectedOutsidePro: the gate still guards, and reports
+// rather than calling os.Exit — the caller decides what to do with the error.
+func TestStart_ServerMode_RejectedOutsidePro(t *testing.T) {
+	withEdition(t, extension.Community)
+	cfg, logger := modeGateCfg(t, "server")
+
+	a, err := app.New(cfg, logger)
+	require.NoError(t, err)
+
+	err = startAndCollect(t, a, 5*time.Second)
+	require.Error(t, err, "server mode must be refused outside Pro")
+	assert.Contains(t, err.Error(), gateErrFragment)
+	assert.Contains(t, err.Error(), string(extension.Community),
+		"the refusal must name the edition actually in force")
+}
+
+// TestStart_ServerMode_AllowedInPro is the case that never worked: a valid Pro
+// license must let server mode boot.
+func TestStart_ServerMode_AllowedInPro(t *testing.T) {
+	withEdition(t, extension.Pro)
+	cfg, logger := modeGateCfg(t, "server")
+
+	a, err := app.New(cfg, logger)
+	require.NoError(t, err)
+
+	err = startAndCollect(t, a, 2*time.Second)
+	if err != nil {
+		assert.NotContains(t, err.Error(), gateErrFragment,
+			"server mode must not be refused under a Pro edition")
+	}
+}
+
+// TestStart_EmbeddedMode_NotGated: the default mode is never subject to the gate.
+func TestStart_EmbeddedMode_NotGated(t *testing.T) {
+	for _, mode := range []string{"", "embedded"} {
+		t.Run("mode="+mode, func(t *testing.T) {
+			withEdition(t, extension.Community)
+			cfg, logger := modeGateCfg(t, mode)
+
+			a, err := app.New(cfg, logger)
+			require.NoError(t, err)
+
+			err = startAndCollect(t, a, 2*time.Second)
+			if err != nil {
+				assert.False(t, strings.Contains(err.Error(), gateErrFragment),
+					"embedded mode must never hit the mode gate")
+			}
+		})
+	}
+}


### PR DESCRIPTION
`--mode=server` exited at boot whatever the license said, so the multi-host setup the documentation describes could not be started. It kept working only through the embedded mode, which wires the same gRPC server by another path.

The check now runs in Start(), after the license manager has resolved the edition, and returns an error instead of exiting so the caller decides what to do with it. `--mode=agent` is unaffected: the agent binary carries no license of its own.