### PR TITLE
fix(security): hash enrollment tokens, fail MCP closed, add security …

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,10 @@ MAINTENANT_DB=./maintenant.db
 # MAINTENANT_LICENSE_KEY=your-license-key
 
 # MCP Server (Model Context Protocol for AI assistants)
+# Both credentials are required: /mcp bypasses the reverse-proxy auth, so
+# without them maintenant refuses to start rather than serving your monitoring
+# data to anyone. Set MAINTENANT_MCP_ALLOW_UNAUTHENTICATED=true to accept that
+# on a trusted network.
 # MAINTENANT_MCP=true
 # MAINTENANT_MCP_CLIENT_ID=maintenant-mcp
 # MAINTENANT_MCP_CLIENT_SECRET=your-secret-here

--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ Built-in [Model Context Protocol](https://modelcontextprotocol.io/) server. Quer
 | `MAINTENANT_MCP_CLIENT_ID`          | —                       | OAuth2 client ID for MCP authentication         |
 | `MAINTENANT_MCP_CLIENT_SECRET`      | —                       | OAuth2 client secret for MCP authentication     |
 | `MAINTENANT_MCP_ALLOWED_REDIRECT_URIS` | —                    | Comma-separated allowlist of OAuth2 `redirect_uri` values. Required when `MAINTENANT_MCP_CLIENT_*` are set. |
+| `MAINTENANT_MCP_ALLOW_UNAUTHENTICATED` | `false`              | Serve `/mcp` unauthenticated. Without it, MCP without OAuth credentials refuses to start. |
 | `MAINTENANT_K8S_NAMESPACES`         | all                     | Namespace allowlist (comma-separated)           |
 | `MAINTENANT_K8S_EXCLUDE_NAMESPACES` | none                    | Namespace blocklist                             |
 | `MAINTENANT_DISABLE_TELEMETRY`      | unset (telemetry on)    | Set to `1`/`true`/`yes` to disable telemetry    |

--- a/docs/features/mcp.md
+++ b/docs/features/mcp.md
@@ -106,6 +106,7 @@ When the OAuth2 variables are absent, the HTTP transport is open. Use your rever
 | `MAINTENANT_MCP_CLIENT_ID` | — | OAuth2 client identifier. Required for authentication. |
 | `MAINTENANT_MCP_CLIENT_SECRET` | — | OAuth2 client secret. Required for authentication. |
 | `MAINTENANT_MCP_ALLOWED_REDIRECT_URIS` | — | Comma-separated allowlist of OAuth2 `redirect_uri` values. Required when client credentials are set. |
+| `MAINTENANT_MCP_ALLOW_UNAUTHENTICATED` | `false` | Serve `/mcp` with no authentication at all. Without it, `MAINTENANT_MCP=true` with no client credentials refuses to start. Trusted networks only; `--mcp-stdio` never needs it. |
 | `MAINTENANT_BASE_URL` | `http://localhost:8080` | Public-facing URL. Used as OAuth2 issuer and in metadata endpoints. |
 
 `MAINTENANT_MCP_ALLOWED_REDIRECT_URIS` accepts an exact list of full URIs. Any `redirect_uri` submitted to `/oauth/authorize` is matched against the list with simple string comparison ([RFC 6749 §3.1.2.3](https://www.rfc-editor.org/rfc/rfc6749#section-3.1.2.3)); anything that does not match an entry exactly is rejected, closing the open-redirect path. Use the full callback URI, not just the origin.

--- a/docs/features/multihost.md
+++ b/docs/features/multihost.md
@@ -100,6 +100,11 @@ The response contains:
 
 > The token cannot be retrieved again after creation. If lost, delete it and generate a new one.
 
+!!! note "Only the hash is stored"
+    The database keeps `sha256(token)` plus the first 14 characters, which is what every list and detail view displays (`mnt_enr_ab12cd...***`). The cleartext exists in the creation response and nowhere else, so a copy of the database file taken from here on — a backup, the data volume, a `.db` grabbed for debugging — carries nothing replayable.
+
+    Upgrading an existing install rewrites the table in place on first boot and keeps outstanding tokens valid: nothing has to be reissued. Copies of the database made *before* that upgrade still contain the cleartext, and no migration can reach them. If one of those copies may have leaked, delete the affected tokens and issue new ones; otherwise their 7-day maximum TTL retires them on its own.
+
 ### 2. Run the install command on the remote host
 
 Pick the snippet matching the host environment (the UI exposes these as tabs in the modal). For a bare-metal/VM host, the standalone snippet is:

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -24,6 +24,7 @@ maintenant is configured entirely through environment variables. No configuratio
 | `MAINTENANT_MCP_CLIENT_ID` | — | OAuth2 client ID for MCP authentication. |
 | `MAINTENANT_MCP_CLIENT_SECRET` | — | OAuth2 client secret for MCP authentication. |
 | `MAINTENANT_MCP_ALLOWED_REDIRECT_URIS` | — | Comma-separated allowlist of OAuth2 `redirect_uri` values accepted by `/oauth/authorize`. Required when MCP credentials are set. |
+| `MAINTENANT_MCP_ALLOW_UNAUTHENTICATED` | `false` | Serve `/mcp` with no authentication. Without it, enabling MCP without OAuth credentials refuses to start. Trusted networks only. |
 | `MAINTENANT_ORGANISATION_NAME` | `Maintenant` | Organisation name displayed on the public status page. |
 | `MAINTENANT_SMTP_HOST` | — | SMTP server hostname for email notifications. |
 | `MAINTENANT_SMTP_PORT` | `587` | SMTP server port. |
@@ -74,6 +75,10 @@ MAINTENANT_BASE_URL=https://maintenant.example.com
 # MAINTENANT_ORGANISATION_NAME=Acme Corp
 
 # MCP Server (Model Context Protocol for AI assistants)
+# Both credentials are required: /mcp bypasses the reverse-proxy auth, so
+# without them maintenant refuses to start rather than serving your monitoring
+# data to anyone. Set MAINTENANT_MCP_ALLOW_UNAUTHENTICATED=true to accept that
+# on a trusted network.
 # MAINTENANT_MCP=true
 # MAINTENANT_MCP_CLIENT_ID=maintenant-mcp
 # MAINTENANT_MCP_CLIENT_SECRET=your-secret-here

--- a/docs/security.md
+++ b/docs/security.md
@@ -50,8 +50,10 @@ Only registered when `MAINTENANT_MCP=true`. If MCP uses OAuth2 (recommended), th
 | `/oauth/authorize` | Authorization endpoint (PKCE S256 mandatory) |
 | `/oauth/token` | Token exchange and refresh |
 
-!!! warning "Open MCP"
-    When `MAINTENANT_MCP=true` is set **without** `MAINTENANT_MCP_CLIENT_ID` and `MAINTENANT_MCP_CLIENT_SECRET`, the `/mcp` endpoint is open — anyone can query your monitoring data. Either configure OAuth2 credentials or protect `/mcp` with your reverse proxy.
+!!! warning "MCP without credentials refuses to start"
+    `MAINTENANT_MCP=true` **without** `MAINTENANT_MCP_CLIENT_ID` and `MAINTENANT_MCP_CLIENT_SECRET` used to serve `/mcp` to anyone. Since `/mcp` is documented above as bypassing proxy auth, an incomplete `.env` published your monitoring data. maintenant now refuses to listen and names the missing variables.
+
+    To run MCP unauthenticated anyway — a local instance on a trusted network — set `MAINTENANT_MCP_ALLOW_UNAUTHENTICATED=true`. The startup log then carries a `WARN` for as long as it stays that way. `--mcp-stdio` is unaffected: it never listens on the network and needs no credentials.
 
 ### Protected Routes
 
@@ -178,15 +180,16 @@ server {
 
 ### Rate Limiting
 
-Per-IP token bucket rate limiter applied to all public-facing routes:
+Two per-IP token bucket rate limiters, one tight for the public surfaces and one loose for the admin API:
 
-| Setting | Value |
-|---------|-------|
-| Rate | 10 requests/second per IP |
-| Burst | 20 requests |
-| Applied to | `/ping/`, `/status/*`, `/mcp` |
-| Not applied to | `/api/v1/*` (expected behind auth) |
-| 429 response | `{"error":{"code":"rate_limited","message":"Too many requests"}}` with `Retry-After: 1` |
+| Setting | Public routes | Admin API |
+|---------|---------------|-----------|
+| Applied to | `/ping/`, `/status/*`, `/mcp` | `/api/v1/*` |
+| Rate | 10 requests/second per IP | 50 requests/second per IP |
+| Burst | 20 requests | 200 requests |
+| 429 response | `{"error":{"code":"rate_limited","message":"Too many requests"}}` with `Retry-After: 1` | Same |
+
+The admin API limit is a flood ceiling, not a quota. A dashboard page load fans out dozens of parallel calls, so the public bucket would reject ordinary use; at 50/s with a burst of 200 the interface never reaches it. It exists so an unauthenticated surface, or a stolen session, cannot hammer expensive routes for free.
 
 IP detection priority: `X-Real-IP` header → first entry in `X-Forwarded-For` → `RemoteAddr`.
 
@@ -194,6 +197,24 @@ The `/status/subscribe` endpoint has an additional rate limit of 5 requests per 
 
 !!! tip "Trusted proxies"
     Make sure your reverse proxy sets `X-Real-IP` or `X-Forwarded-For` correctly. Without it, all requests appear to come from the proxy's IP and share a single rate limit bucket.
+
+### Security Headers
+
+Every response carries:
+
+| Header | Value | Purpose |
+|--------|-------|---------|
+| `X-Content-Type-Options` | `nosniff` | Stops the browser from re-guessing a declared content type |
+| `Referrer-Policy` | `strict-origin-when-cross-origin` | Keeps paths (which can carry heartbeat UUIDs) out of cross-origin referrers |
+| `X-Frame-Options` | `DENY` | Clickjacking defence for browsers that ignore CSP |
+| `Content-Security-Policy` | see below | Defence in depth if an XSS ever lands |
+
+The policy is `default-src 'self'` with `object-src 'none'`, `base-uri 'self'` and `form-action 'self'`. `script-src` is `'self'` plus the SHA-256 of the inline theme bootstrap in `index.html`, computed at startup from the embedded asset — never `'unsafe-inline'`. `style-src` does allow `'unsafe-inline'`, because Vue and uPlot both set element styles at runtime. `img-src` allows `data:` for status page logos and hero images.
+
+!!! note "The public status page stays embeddable"
+    `/status` and `/status/*` are served with `frame-ancestors *` and no `X-Frame-Options`, so you can keep iframing the status page. Every other route — the dashboard and `/api/v1/*` — gets `frame-ancestors 'none'` and `X-Frame-Options: DENY`.
+
+HSTS is deliberately **not** set by the application. TLS terminates at your reverse proxy, and the app would have to infer "this was HTTPS" from a forwarded header a client can forge. Set `Strict-Transport-Security` in the proxy.
 
 ### Request Size Limits
 
@@ -240,6 +261,21 @@ The stdio transport (`--mcp-stdio`) requires no authentication — it is a local
 See [MCP Server](features/mcp.md) for full configuration and usage details.
 
 ---
+
+## Secrets at Rest
+
+Everything the database holds that could be replayed is stored hashed, so a copy of the file is not a copy of your credentials:
+
+| Secret | Stored as |
+|--------|-----------|
+| Agent enrollment tokens | `sha256(token)` + a 14-character display prefix |
+| MCP OAuth authorization codes | `sha256(code)` |
+| MCP access and refresh tokens | `sha256(token)` |
+| MCP client secret | `sha256(secret)`, compared in constant time |
+| Agent identity | Ed25519 **public** key only — the private key never leaves the agent host |
+| License key | Signature verified with a build-injected public key; disk cache is `0600` |
+
+Status page subscriber tokens (`confirm_token`, `unsub_token`) are still stored in the clear. They only confirm or cancel an email subscription, and the same table holds the subscriber addresses in the clear by nature, so hashing them would not protect the sensitive part of that table.
 
 ## Deployment Hardening
 
@@ -394,7 +430,9 @@ A quick reference for securing your deployment:
 - [ ] `/ping`, `/status` (prefix, no trailing slash) and `/manifest.webmanifest` bypass authentication
 - [ ] If MCP is enabled: OAuth2 credentials configured (`MAINTENANT_MCP_CLIENT_ID` + `MAINTENANT_MCP_CLIENT_SECRET`)
 - [ ] If MCP is enabled: `/mcp`, `/oauth/*`, `/.well-known/*` bypass proxy auth (MCP handles its own)
+- [ ] `MAINTENANT_MCP_ALLOW_UNAUTHENTICATED` **not** set (it is only for a local instance on a trusted network)
 - [ ] HTTPS termination at the proxy level
+- [ ] `Strict-Transport-Security` set at the proxy (the app cannot set it safely)
 - [ ] `MAINTENANT_BASE_URL` set to your public HTTPS URL
 - [ ] Database file has restrictive permissions
 - [ ] Heartbeat UUIDs not exposed in public repositories or logs

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4900,9 +4900,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -6099,9 +6099,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -7249,9 +7249,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -7939,9 +7939,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "funding": [
         {
           "type": "github",
@@ -8452,9 +8452,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.22",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.22.tgz",
-      "integrity": "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -8471,7 +8471,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.16",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -9890,9 +9890,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/internal/agent/token.go
+++ b/internal/agent/token.go
@@ -1,0 +1,78 @@
+// Copyright 2026 Benjamin Touchard (Kolapsis)
+//
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+// or a commercial license. You may not use this file except in compliance
+// with one of these licenses.
+//
+// AGPL-3.0: https://www.gnu.org/licenses/agpl-3.0.html
+// Commercial: See COMMERCIAL-LICENSE.md
+//
+// Source: https://github.com/kolapsis/maintenant
+
+package agent
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base32"
+	"encoding/hex"
+	"strings"
+)
+
+// TokenPrefixLen is how much of a token is kept in the clear for display. The
+// prefix is `mnt_enr_` plus six base32 characters: enough for an operator to
+// tell two tokens apart in a list, and 30 bits out of 256 — worthless to
+// someone holding only the hash, which is the whole point of storing it.
+const TokenPrefixLen = 14
+
+// tokenScheme prefixes every enrollment token so one is recognisable on sight
+// in a log, a shell history or a support paste.
+const tokenScheme = "mnt_enr_" // #nosec G101 -- a fixed scheme prefix, not a credential.
+
+// NewToken mints an enrollment token and returns its cleartext, the hash that
+// gets persisted, the id derived from that hash, and the display prefix.
+//
+// The cleartext is returned once and never stored: it exists in the creation
+// response and nowhere else. Everything the server needs afterwards to accept,
+// list or revoke the token is derivable from the hash.
+func NewToken() (cleartext, hash, id, prefix string, err error) {
+	raw := make([]byte, 32)
+	if _, err = rand.Read(raw); err != nil {
+		return "", "", "", "", err
+	}
+	cleartext = tokenScheme + strings.ToLower(strings.TrimRight(
+		base32.StdEncoding.EncodeToString(raw), "="))
+	hash = HashToken(cleartext)
+	return cleartext, hash, TokenIDFromHash(hash), TokenPrefix(cleartext), nil
+}
+
+// HashToken returns the hex-encoded SHA-256 of an enrollment token. This is the
+// only form of the token the database ever sees.
+func HashToken(token string) string {
+	sum := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(sum[:])
+}
+
+// TokenIDFromHash derives the opaque id used in API paths from the token hash.
+// Truncating is safe: the id identifies a row, it never authorises anything —
+// enrollment matches on the full hash.
+func TokenIDFromHash(hash string) string {
+	if len(hash) < 16 {
+		return hash
+	}
+	return hash[:16]
+}
+
+// TokenPrefix returns the leading, non-secret part of a token.
+func TokenPrefix(token string) string {
+	if len(token) <= TokenPrefixLen {
+		return token
+	}
+	return token[:TokenPrefixLen]
+}
+
+// Masked renders a token for display from the stored prefix alone. The rest is
+// unrecoverable by design, so this is all any read path can ever show.
+func (t *EnrollmentToken) Masked() string {
+	return t.TokenPrefix + "...***"
+}

--- a/internal/agent/types.go
+++ b/internal/agent/types.go
@@ -32,10 +32,14 @@ type Agent struct {
 	RevokedBy       *string
 }
 
-// EnrollmentToken represents a one-time token for enrolling an agent.
+// EnrollmentToken represents a one-time token for enrolling an agent. The
+// cleartext is deliberately absent: only its SHA-256 is persisted, so a copy of
+// the database file yields nothing replayable. TokenPrefix is the leading,
+// non-secret slice kept so a read path can still name the token it matched.
 type EnrollmentToken struct {
 	TokenID           string
-	Token             string // cleartext (only stored, never returned via API after creation)
+	TokenHash         string
+	TokenPrefix       string
 	CreatedAt         time.Time
 	ExpiresAt         time.Time
 	ConsumedAt        *time.Time

--- a/internal/agentserver/enrollment_hostlimit_test.go
+++ b/internal/agentserver/enrollment_hostlimit_test.go
@@ -72,13 +72,16 @@ func insertActiveAgents(t *testing.T, store *sqlite.AgentStore, n int) {
 	}
 }
 
+// insertToken stores tok the way the creation handler does — hash and display
+// prefix only — and returns the cleartext for the caller to enroll with.
 func insertToken(t *testing.T, store *sqlite.AgentStore, id, tok string) string {
 	t.Helper()
 	require.NoError(t, store.InsertToken(context.Background(), &agent.EnrollmentToken{
-		TokenID:   id,
-		Token:     tok,
-		CreatedAt: time.Now().UTC(),
-		ExpiresAt: time.Now().UTC().Add(time.Hour),
+		TokenID:     id,
+		TokenHash:   agent.HashToken(tok),
+		TokenPrefix: agent.TokenPrefix(tok),
+		CreatedAt:   time.Now().UTC(),
+		ExpiresAt:   time.Now().UTC().Add(time.Hour),
 	}))
 	return tok
 }

--- a/internal/agentserver/integration_test.go
+++ b/internal/agentserver/integration_test.go
@@ -240,19 +240,21 @@ func TestIntegration_Enrollment(t *testing.T) {
 
 	client := agentpb.NewIngestClient(conn)
 
-	// Insert an enrollment token valid for 1 hour.
-	tok := &agent.EnrollmentToken{
-		TokenID:   "inttest001",
-		Token:     "mnt_enr_integrationtest01",
-		CreatedAt: time.Now().UTC(),
-		ExpiresAt: time.Now().UTC().Add(time.Hour),
-	}
-	require.NoError(t, store.InsertToken(ctx, tok))
+	// Insert an enrollment token valid for 1 hour. Only its hash is stored; the
+	// cleartext below is what the client sends.
+	const tokCleartext = "mnt_enr_integrationtest01"
+	require.NoError(t, store.InsertToken(ctx, &agent.EnrollmentToken{
+		TokenID:     "inttest001",
+		TokenHash:   agent.HashToken(tokCleartext),
+		TokenPrefix: agent.TokenPrefix(tokCleartext),
+		CreatedAt:   time.Now().UTC(),
+		ExpiresAt:   time.Now().UTC().Add(time.Hour),
+	}))
 
 	// (a) First call should succeed and insert the agent.
 	req := &agentpb.RegisterRequest{
 		AgentId:         "agt-integration-001",
-		EnrollmentToken: tok.Token,
+		EnrollmentToken: tokCleartext,
 		Hostname:        "testhost",
 		Label:           "Test Agent",
 		OsArch:          "linux/amd64",
@@ -273,14 +275,14 @@ func TestIntegration_Enrollment(t *testing.T) {
 	assert.Equal(t, "active", gotAgent.Status)
 
 	// (b) Verify token is marked consumed.
-	gotTok, err := store.GetByToken(ctx, tok.Token)
+	gotTok, err := store.GetByToken(ctx, tokCleartext)
 	require.NoError(t, err)
 	assert.NotNil(t, gotTok.ConsumedAt, "token should be consumed")
 
 	// (c) Re-call with same token → FailedPrecondition.
 	req2 := &agentpb.RegisterRequest{
 		AgentId:         "agt-integration-002",
-		EnrollmentToken: tok.Token,
+		EnrollmentToken: tokCleartext,
 		Hostname:        "testhost2",
 		OsArch:          "linux/amd64",
 		AgentVersion:    "1.0.0",
@@ -367,17 +369,18 @@ func TestIntegration_PushStream(t *testing.T) {
 	// Use a proper UUID-format agent ID (32 hex chars with dashes after stripping).
 	agentID := "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
 
-	enrollTok := &agent.EnrollmentToken{
-		TokenID:   "push-test-tok",
-		Token:     "mnt_enr_pushtest00000001",
-		CreatedAt: time.Now().UTC(),
-		ExpiresAt: time.Now().UTC().Add(time.Hour),
-	}
-	require.NoError(t, agentStore.InsertToken(ctx, enrollTok))
+	const pushTok = "mnt_enr_pushtest00000001"
+	require.NoError(t, agentStore.InsertToken(ctx, &agent.EnrollmentToken{
+		TokenID:     "push-test-tok",
+		TokenHash:   agent.HashToken(pushTok),
+		TokenPrefix: agent.TokenPrefix(pushTok),
+		CreatedAt:   time.Now().UTC(),
+		ExpiresAt:   time.Now().UTC().Add(time.Hour),
+	}))
 
 	_, err = grpcClient.RegisterAgent(ctx, &agentpb.RegisterRequest{
 		AgentId:         agentID,
-		EnrollmentToken: enrollTok.Token,
+		EnrollmentToken: pushTok,
 		Hostname:        "push-test-host",
 		OsArch:          "linux/amd64",
 		AgentVersion:    "1.0.0",
@@ -514,17 +517,18 @@ func TestIntegration_LogsCommandRoundTrip(t *testing.T) {
 	require.NoError(t, err)
 	const agentID = "c0ffee00-1111-2222-3333-444455556666"
 
-	enrollTok := &agent.EnrollmentToken{
-		TokenID:   "cmd-test-tok",
-		Token:     "mnt_enr_cmdtest000000001",
-		CreatedAt: time.Now().UTC(),
-		ExpiresAt: time.Now().UTC().Add(time.Hour),
-	}
-	require.NoError(t, agentStore.InsertToken(ctx, enrollTok))
+	const cmdTok = "mnt_enr_cmdtest000000001"
+	require.NoError(t, agentStore.InsertToken(ctx, &agent.EnrollmentToken{
+		TokenID:     "cmd-test-tok",
+		TokenHash:   agent.HashToken(cmdTok),
+		TokenPrefix: agent.TokenPrefix(cmdTok),
+		CreatedAt:   time.Now().UTC(),
+		ExpiresAt:   time.Now().UTC().Add(time.Hour),
+	}))
 
 	_, err = grpcClient.RegisterAgent(ctx, &agentpb.RegisterRequest{
 		AgentId:         agentID,
-		EnrollmentToken: enrollTok.Token,
+		EnrollmentToken: cmdTok,
 		Hostname:        "cmd-test-host",
 		OsArch:          "linux/amd64",
 		AgentVersion:    "1.3.7",

--- a/internal/api/v1/agents_handler.go
+++ b/internal/api/v1/agents_handler.go
@@ -12,16 +12,11 @@
 package v1
 
 import (
-	"crypto/rand"
-	"crypto/sha256"
-	"encoding/base32"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"log/slog"
 	"net/http"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/kolapsis/maintenant/internal/agent"
@@ -94,22 +89,21 @@ func (h *AgentHandler) HandleCreateEnrollmentToken(w http.ResponseWriter, r *htt
 		ttl = 168 * time.Hour
 	}
 
-	raw := make([]byte, 32)
-	if _, err := rand.Read(raw); err != nil {
+	// This response is the only place the cleartext ever exists: what gets
+	// persisted is the hash and a display prefix.
+	tokenStr, tokenHash, tokenID, tokenPrefix, err := agent.NewToken()
+	if err != nil {
 		WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to generate token")
 		return
 	}
-	tokenStr := "mnt_enr_" + strings.ToLower(strings.TrimRight(base32.StdEncoding.EncodeToString(raw), "="))
-
-	sum := sha256.Sum256([]byte(tokenStr))
-	tokenID := hex.EncodeToString(sum[:])[:16]
 
 	now := time.Now().UTC()
 	tok := &agent.EnrollmentToken{
-		TokenID:   tokenID,
-		Token:     tokenStr,
-		CreatedAt: now,
-		ExpiresAt: now.Add(ttl),
+		TokenID:     tokenID,
+		TokenHash:   tokenHash,
+		TokenPrefix: tokenPrefix,
+		CreatedAt:   now,
+		ExpiresAt:   now.Add(ttl),
 	}
 	if err := h.store.InsertToken(r.Context(), tok); err != nil {
 		h.logger.Error("insert enrollment token", "err", err)
@@ -125,7 +119,7 @@ func (h *AgentHandler) HandleCreateEnrollmentToken(w http.ResponseWriter, r *htt
 	WriteJSON(w, http.StatusCreated, map[string]any{
 		"token_id":             tokenID,
 		"token":                tokenStr,
-		"token_masked":         maskToken(tokenStr),
+		"token_masked":         tok.Masked(),
 		"created_at":           tok.CreatedAt,
 		"expires_at":           tok.ExpiresAt,
 		"consumed_at":          nil,
@@ -288,7 +282,7 @@ func (h *AgentHandler) HandleListEnrollmentTokens(w http.ResponseWriter, r *http
 	for i, t := range tokens {
 		out[i] = masked{
 			TokenID:           t.TokenID,
-			TokenMasked:       maskToken(t.Token),
+			TokenMasked:       t.Masked(),
 			CreatedAt:         t.CreatedAt,
 			ExpiresAt:         t.ExpiresAt,
 			ConsumedAt:        t.ConsumedAt,
@@ -311,7 +305,7 @@ func (h *AgentHandler) HandleGetEnrollmentToken(w http.ResponseWriter, r *http.R
 	}
 	WriteJSON(w, http.StatusOK, map[string]any{
 		"token_id":             tok.TokenID,
-		"token_masked":         maskToken(tok.Token),
+		"token_masked":         tok.Masked(),
 		"created_at":           tok.CreatedAt,
 		"expires_at":           tok.ExpiresAt,
 		"consumed_at":          tok.ConsumedAt,
@@ -542,13 +536,6 @@ func agentToMap(a *agent.Agent, connectionState string) map[string]any {
 		"revoked_at":       a.RevokedAt,
 		"revoked_by":       a.RevokedBy,
 	}
-}
-
-func maskToken(token string) string {
-	if len(token) <= 14 {
-		return token
-	}
-	return token[:14] + "...***"
 }
 
 func parseBoolQuery(r *http.Request, key string, def bool) bool {

--- a/internal/api/v1/agents_token_handler_test.go
+++ b/internal/api/v1/agents_token_handler_test.go
@@ -1,0 +1,140 @@
+// Copyright 2026 Benjamin Touchard (Kolapsis)
+//
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+// or a commercial license. You may not use this file except in compliance
+// with one of these licenses.
+//
+// AGPL-3.0: https://www.gnu.org/licenses/agpl-3.0.html
+// Commercial: See COMMERCIAL-LICENSE.md
+//
+// Source: https://github.com/kolapsis/maintenant
+
+package v1
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kolapsis/maintenant/internal/agent"
+	"github.com/kolapsis/maintenant/internal/extension"
+	"github.com/kolapsis/maintenant/internal/store/sqlite"
+)
+
+// newTokenTestHandler wires an AgentHandler over a temp database, at an edition
+// that opens multi-host (Community refuses enrollment outright).
+func newTokenTestHandler(t *testing.T) (*AgentHandler, *sqlite.AgentStore) {
+	t.Helper()
+
+	prev := extension.CurrentEdition
+	extension.CurrentEdition = func() extension.Edition { return extension.Pro }
+	t.Cleanup(func() { extension.CurrentEdition = prev })
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	db, err := sqlite.Open(filepath.Join(t.TempDir(), "tok.db"), logger)
+	require.NoError(t, err)
+	require.NoError(t, sqlite.Migrate(db.ReadDB(), logger))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	db.StartWriter(ctx)
+	t.Cleanup(func() {
+		cancel()
+		_ = db.Close()
+	})
+
+	store := sqlite.NewAgentStore(db)
+	return NewAgentHandler(store, nil, nil, logger, "grpcs://example.test:8443", "127.0.0.1:8443", time.Minute), store
+}
+
+func createToken(t *testing.T, h *AgentHandler) map[string]any {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/agents/enrollment-tokens",
+		strings.NewReader(`{"ttl_hours":1}`))
+	h.HandleCreateEnrollmentToken(rec, req)
+	require.Equal(t, http.StatusCreated, rec.Code, rec.Body.String())
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	return out
+}
+
+// The creation response is the one and only place the cleartext appears. It
+// must still carry a usable token and the install commands built from it.
+func TestCreateEnrollmentToken_ReturnsCleartextOnce(t *testing.T) {
+	h, store := newTokenTestHandler(t)
+	out := createToken(t, h)
+
+	cleartext, _ := out["token"].(string)
+	require.True(t, strings.HasPrefix(cleartext, "mnt_enr_"), "got %q", cleartext)
+	assert.Equal(t, agent.TokenPrefix(cleartext)+"...***", out["token_masked"])
+	assert.Equal(t, agent.TokenIDFromHash(agent.HashToken(cleartext)), out["token_id"])
+
+	// The install snippets have to embed the real token or the operator cannot
+	// copy-paste them.
+	templates, ok := out["install_templates"].(map[string]any)
+	require.True(t, ok)
+	require.NotEmpty(t, templates)
+	for name, tmpl := range templates {
+		assert.Contains(t, tmpl, cleartext, "install template %q must carry the token", name)
+	}
+
+	// And the stored row holds the hash, never the token.
+	stored, err := store.GetByToken(context.Background(), cleartext)
+	require.NoError(t, err)
+	assert.Equal(t, agent.HashToken(cleartext), stored.TokenHash)
+	assert.NotContains(t, stored.TokenHash, "mnt_enr_")
+}
+
+// Every read path after creation shows the masked form and nothing more. This
+// is what keeps a leaked API response from being replayable.
+func TestEnrollmentTokenReadPaths_NeverReturnCleartext(t *testing.T) {
+	h, _ := newTokenTestHandler(t)
+	out := createToken(t, h)
+	cleartext := out["token"].(string)
+	tokenID := out["token_id"].(string)
+
+	t.Run("list", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		h.HandleListEnrollmentTokens(rec,
+			httptest.NewRequest(http.MethodGet, "/api/v1/agents/enrollment-tokens", nil))
+		require.Equal(t, http.StatusOK, rec.Code)
+
+		assert.NotContains(t, rec.Body.String(), cleartext)
+		assert.Contains(t, rec.Body.String(), agent.TokenPrefix(cleartext)+"...***")
+	})
+
+	t.Run("get by id", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/agents/enrollment-tokens/"+tokenID, nil)
+		req.SetPathValue("token_id", tokenID)
+		h.HandleGetEnrollmentToken(rec, req)
+		require.Equal(t, http.StatusOK, rec.Code)
+
+		assert.NotContains(t, rec.Body.String(), cleartext)
+		assert.Contains(t, rec.Body.String(), agent.TokenPrefix(cleartext)+"...***")
+	})
+}
+
+// Two tokens minted back to back must not collide on their id or their prefix
+// display, or the list becomes ambiguous once the cleartext is gone.
+func TestCreateEnrollmentToken_TokensAreDistinct(t *testing.T) {
+	h, _ := newTokenTestHandler(t)
+	first := createToken(t, h)
+	second := createToken(t, h)
+
+	assert.NotEqual(t, first["token"], second["token"])
+	assert.NotEqual(t, first["token_id"], second["token_id"])
+	assert.NotEqual(t, first["token_masked"], second["token_masked"],
+		"the stored prefix must still tell two tokens apart in the list")
+}

--- a/internal/api/v1/logs_stream.go
+++ b/internal/api/v1/logs_stream.go
@@ -144,11 +144,12 @@ func (h *LogStreamHandler) HandleLogStream(w http.ResponseWriter, r *http.Reques
 	}
 	defer func() { _ = reader.Close() }()
 
-	// Set SSE headers.
+	// Set SSE headers. CORS is deliberately absent: the cors() middleware
+	// applies the configured policy, and forcing a wildcard here let any site
+	// an operator visited read this container's logs.
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
-	w.Header().Set("Access-Control-Allow-Origin", "*")
 	flusher.Flush()
 
 	scanner := bufio.NewScanner(reader)
@@ -238,10 +239,10 @@ func (h *LogStreamHandler) streamRemote(
 	// Releasing tells the agent to stop tailing as soon as the viewer goes away.
 	defer release()
 
+	// Same as the local path: no wildcard CORS, cors() owns the policy.
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
-	w.Header().Set("Access-Control-Allow-Origin", "*")
 	flusher.Flush()
 
 	ctx := r.Context()

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -25,7 +25,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/kolapsis/maintenant/internal/agent"
 	"github.com/kolapsis/maintenant/internal/agentserver"
 	"github.com/kolapsis/maintenant/internal/alert"
@@ -109,6 +108,7 @@ type App struct {
 	maintScheduler *status.MaintenanceScheduler
 	scorer         *security.Scorer
 	rl             *ratelimit.Limiter
+	apiRL          *ratelimit.Limiter
 	licenseMgr     *license.Manager
 	mcpServer      *gomcp.Server
 
@@ -603,8 +603,13 @@ func New(cfg Config, logger *slog.Logger) (*App, error) {
 		AllowPrivateWebhooks: cfg.AllowPrivateWebhooks,
 	})
 
-	// --- Rate limiter ---
+	// --- Rate limiters ---
+	// Public surfaces (/ping/, /status/, /mcp) take the tight bucket.
 	a.rl = ratelimit.New(10, 20)
+	// /api/ gets its own, far looser one: a dashboard load fans out dozens of
+	// parallel calls, so the tight bucket would 429 ordinary use. This is a
+	// flood ceiling, not a quota — it must never be reachable by the UI.
+	a.apiRL = ratelimit.New(50, 200)
 
 	// --- MCP Server ---
 	mcpSvc := &mcp.Services{
@@ -670,6 +675,12 @@ func (a *App) RunMCPStdio(ctx context.Context) error {
 // Start begins all background services and the HTTP server.
 // It blocks until ctx is canceled, then performs a graceful shutdown.
 func (a *App) Start(ctx context.Context) error {
+	// Checked here rather than in New(): this is the only path that listens, so
+	// --mcp-stdio keeps working without OAuth credentials it has no use for.
+	if err := a.cfg.ValidateHTTP(); err != nil {
+		return err
+	}
+
 	a.db.StartWriter(ctx)
 
 	if a.licenseMgr != nil {
@@ -719,6 +730,7 @@ func (a *App) Start(ctx context.Context) error {
 
 	// Background services (always run, regardless of runtime availability)
 	go a.rl.Start(ctx)
+	go a.apiRL.Start(ctx)
 	go a.resourceSvc.Start(ctx)
 	go a.certSvc.Start(ctx)
 	go a.maintScheduler.Start(ctx)
@@ -855,17 +867,24 @@ func (a *App) startEmbeddedAgent(ctx context.Context) {
 
 	var enrollToken string
 	if !id.Registered {
+		cleartext, hash, tokenID, prefix, err := agent.NewToken()
+		if err != nil {
+			a.logger.Error("embedded agent: failed to generate enrollment token", "err", err)
+			return
+		}
 		t := &agent.EnrollmentToken{
-			TokenID:   uuid.New().String(),
-			Token:     uuid.New().String(),
-			CreatedAt: time.Now(),
-			ExpiresAt: time.Now().Add(5 * time.Minute),
+			TokenID:     tokenID,
+			TokenHash:   hash,
+			TokenPrefix: prefix,
+			CreatedAt:   time.Now(),
+			ExpiresAt:   time.Now().Add(5 * time.Minute),
 		}
 		if err := a.agentStore.InsertToken(ctx, t); err != nil {
 			a.logger.Error("embedded agent: failed to create enrollment token", "err", err)
 			return
 		}
-		enrollToken = t.Token
+		// Held in memory just long enough to hand to the agent goroutine below.
+		enrollToken = cleartext
 	}
 
 	grpcURL := "grpcs://" + a.cfg.MultiHost.GRPCListen

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -12,6 +12,7 @@
 package app
 
 import (
+	"errors"
 	"os"
 	"strconv"
 	"strings"
@@ -122,6 +123,29 @@ type MCPConfig struct {
 	ClientID            string
 	ClientSecret        string
 	AllowedRedirectURIs string
+	// AllowUnauthenticated is the explicit opt-out for serving /mcp with no
+	// OAuth at all; without it, MCP without credentials refuses to listen.
+	AllowUnauthenticated bool
+}
+
+// ErrMCPUnauthenticated refuses to expose an MCP server that answers to anyone.
+// docs/security.md has the reverse proxy let /mcp through unauthenticated, so
+// missing OAuth credentials do not degrade the protection — they remove it.
+var ErrMCPUnauthenticated = errors.New(
+	"MAINTENANT_MCP=true but MAINTENANT_MCP_CLIENT_ID/MAINTENANT_MCP_CLIENT_SECRET are unset: " +
+		"/mcp is documented as bypassing the reverse-proxy auth, so it would serve containers, logs " +
+		"and alerts to anyone reaching it. Set both, or set MAINTENANT_MCP_ALLOW_UNAUTHENTICATED=true " +
+		"to accept that on a trusted network")
+
+// ValidateHTTP rejects a configuration that must not be served over HTTP. It is
+// deliberately not called from New(): --mcp-stdio shares that path and never
+// listens, so refusing there would break a local stdio client for no gain.
+func (c Config) ValidateHTTP() error {
+	if c.MCP.Enabled && !c.MCP.AllowUnauthenticated &&
+		(c.MCP.ClientID == "" || c.MCP.ClientSecret == "") {
+		return ErrMCPUnauthenticated
+	}
+	return nil
 }
 
 // ConfigFromEnv reads configuration from environment variables.
@@ -143,10 +167,11 @@ func ConfigFromEnv() Config {
 		},
 
 		MCP: MCPConfig{
-			Enabled:             os.Getenv("MAINTENANT_MCP") == "true",
-			ClientID:            os.Getenv("MAINTENANT_MCP_CLIENT_ID"),
-			ClientSecret:        os.Getenv("MAINTENANT_MCP_CLIENT_SECRET"),
-			AllowedRedirectURIs: os.Getenv("MAINTENANT_MCP_ALLOWED_REDIRECT_URIS"),
+			Enabled:              os.Getenv("MAINTENANT_MCP") == "true",
+			ClientID:             os.Getenv("MAINTENANT_MCP_CLIENT_ID"),
+			ClientSecret:         os.Getenv("MAINTENANT_MCP_CLIENT_SECRET"),
+			AllowedRedirectURIs:  os.Getenv("MAINTENANT_MCP_ALLOWED_REDIRECT_URIS"),
+			AllowUnauthenticated: parseTruthy(os.Getenv("MAINTENANT_MCP_ALLOW_UNAUTHENTICATED")),
 		},
 
 		CORSOrigins: os.Getenv("MAINTENANT_CORS_ORIGINS"),

--- a/internal/app/config_test.go
+++ b/internal/app/config_test.go
@@ -51,3 +51,57 @@ func TestConfigFromEnv_Retention(t *testing.T) {
 		assert.Equal(t, 1000, cfg.Retention.BatchSize)
 	})
 }
+
+// MCP used to fail open: MAINTENANT_MCP=true with no OAuth credentials mounted
+// /mcp with no auth at all and said so in a single Info line. Since the reverse
+// proxy is documented as letting /mcp through, an incomplete .env published
+// containers, logs and alerts. These lock the refusal in place.
+func TestConfigValidateHTTP_MCP(t *testing.T) {
+	base := func() Config {
+		return Config{MCP: MCPConfig{
+			Enabled:      true,
+			ClientID:     "id",
+			ClientSecret: "secret",
+		}}
+	}
+
+	t.Run("credentials present", func(t *testing.T) {
+		assert.NoError(t, base().ValidateHTTP())
+	})
+
+	t.Run("MCP disabled needs nothing", func(t *testing.T) {
+		assert.NoError(t, Config{}.ValidateHTTP())
+	})
+
+	t.Run("missing client id is refused", func(t *testing.T) {
+		cfg := base()
+		cfg.MCP.ClientID = ""
+		assert.ErrorIs(t, cfg.ValidateHTTP(), ErrMCPUnauthenticated)
+	})
+
+	t.Run("missing client secret is refused", func(t *testing.T) {
+		cfg := base()
+		cfg.MCP.ClientSecret = ""
+		assert.ErrorIs(t, cfg.ValidateHTTP(), ErrMCPUnauthenticated)
+	})
+
+	// The opt-out is what keeps a local, trusted-network setup possible.
+	t.Run("explicit opt-out is honoured", func(t *testing.T) {
+		cfg := base()
+		cfg.MCP.ClientID = ""
+		cfg.MCP.ClientSecret = ""
+		cfg.MCP.AllowUnauthenticated = true
+		assert.NoError(t, cfg.ValidateHTTP())
+	})
+}
+
+func TestConfigFromEnv_MCPAllowUnauthenticated(t *testing.T) {
+	t.Run("absent by default", func(t *testing.T) {
+		assert.False(t, ConfigFromEnv().MCP.AllowUnauthenticated)
+	})
+
+	t.Run("parsed with the shared truthy set", func(t *testing.T) {
+		t.Setenv("MAINTENANT_MCP_ALLOW_UNAUTHENTICATED", "yes")
+		assert.True(t, ConfigFromEnv().MCP.AllowUnauthenticated)
+	})
+}

--- a/internal/app/http.go
+++ b/internal/app/http.go
@@ -12,10 +12,14 @@
 package app
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/base64"
 	"io/fs"
 	"log/slog"
 	"net/http"
+	"regexp"
 	"strings"
 	"time"
 
@@ -94,6 +98,102 @@ func WithRequestTimeout(h http.Handler, timeout time.Duration) http.Handler {
 	})
 }
 
+// inlineScriptRe matches a <script> element and captures its attributes and its
+// body. One carrying a src attribute is fetched from the origin and is already
+// covered by 'self'; only an inline body needs a hash.
+var inlineScriptRe = regexp.MustCompile(`(?is)<script([^>]*)>(.*?)</script>`)
+
+// inlineScriptHashes returns the CSP source expression for every inline script
+// in html. The digest covers the element's text content byte for byte, which is
+// what a browser hashes when matching the policy.
+func inlineScriptHashes(html []byte) []string {
+	var hashes []string
+	for _, m := range inlineScriptRe.FindAllSubmatch(html, -1) {
+		if bytes.Contains(bytes.ToLower(m[1]), []byte("src=")) {
+			continue
+		}
+		if len(bytes.TrimSpace(m[2])) == 0 {
+			continue
+		}
+		sum := sha256.Sum256(m[2])
+		hashes = append(hashes, "sha256-"+base64.StdEncoding.EncodeToString(sum[:]))
+	}
+	return hashes
+}
+
+// contentSecurityPolicy builds the policy served with every response, minus the
+// frame-ancestors directive that SecurityHeaders appends per route.
+//
+// It is computed at startup from the embedded index.html because script-src has
+// to carry the sha256 of its inline bootstrap script (it applies the theme and
+// density before the bundle loads, so the page does not flash). Hashing what is
+// actually embedded keeps the policy correct across frontend rebuilds, where a
+// hardcoded digest would rot silently and blank the app.
+//
+// style-src keeps 'unsafe-inline' because Vue and uPlot both set element styles
+// at runtime. img-src allows data: for the status page logo and hero, which are
+// stored and served as data URLs.
+func contentSecurityPolicy(indexHTML []byte) string {
+	scriptSrc := "'self'"
+	for _, h := range inlineScriptHashes(indexHTML) {
+		scriptSrc += " '" + h + "'"
+	}
+	return strings.Join([]string{
+		"default-src 'self'",
+		"script-src " + scriptSrc,
+		"style-src 'self' 'unsafe-inline'",
+		"img-src 'self' data: blob:",
+		"font-src 'self' data:",
+		"connect-src 'self'",
+		"worker-src 'self'",
+		"manifest-src 'self'",
+		"object-src 'none'",
+		"base-uri 'self'",
+		"form-action 'self'",
+	}, "; ")
+}
+
+// isPublicStatusPath reports whether path belongs to the public status page.
+// The admin side of the status feature lives under /api/v1/status/ and is
+// deliberately not matched here.
+func isPublicStatusPath(path string) bool {
+	return path == "/status" || strings.HasPrefix(path, "/status/")
+}
+
+// SecurityHeaders bounds what a browser will do with a response from this
+// origin. Applied outside the timeout handler so the headers are on the wire
+// even when it writes its own 503, and with Set so a route with a stricter
+// policy of its own — the status page asset route — still wins by overwriting.
+//
+// Framing is refused everywhere except the public status page, which docs and
+// SECURITY.md both describe as embeddable. The dashboard and the admin API are
+// the surfaces a clickjacker would want, and they are the ones locked down.
+//
+// No HSTS here: TLS terminates at the reverse proxy, and deriving "this was
+// HTTPS" from a forwarded header would trust something a client can forge.
+// It belongs in the proxy config, where SECURITY.md puts it.
+func SecurityHeaders(csp string) func(http.Handler) http.Handler {
+	noFraming := csp + "; frame-ancestors 'none'"
+	embeddable := csp + "; frame-ancestors *"
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			h := w.Header()
+			h.Set("X-Content-Type-Options", "nosniff")
+			h.Set("Referrer-Policy", "strict-origin-when-cross-origin")
+
+			if isPublicStatusPath(r.URL.Path) {
+				h.Set("Content-Security-Policy", embeddable)
+			} else {
+				h.Set("X-Frame-Options", "DENY")
+				h.Set("Content-Security-Policy", noFraming)
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
 // buildHTTPServer assembles the top-level HTTP mux and creates the server.
 func (a *App) buildHTTPServer() *http.Server {
 	topMux := http.NewServeMux()
@@ -135,29 +235,38 @@ func (a *App) buildHTTPServer() *http.Server {
 			go mcpoauth.StartCleanup(context.Background(), mcpOAuthStore, a.logger.With("component", "mcp-oauth-cleanup"))
 
 			a.logger.Info("MCP server enabled with OAuth2 auth", "client_id", a.cfg.MCP.ClientID)
-		} else {
-			a.logger.Info("MCP server enabled without auth")
+		} else if a.cfg.MCP.AllowUnauthenticated {
+			// The only way this route ever serves traffic: ValidateHTTP refuses
+			// to listen without the opt-out. Warn, because it is a real exposure.
+			a.logger.Warn("MCP server enabled WITHOUT auth — /mcp answers anyone who reaches it",
+				"opt_out", "MAINTENANT_MCP_ALLOW_UNAUTHENTICATED")
 		}
 		mcpHandler = a.rl.Middleware(mcpHandler)
 		topMux.Handle("/mcp", mcpHandler)
 		topMux.Handle("/mcp/", mcpHandler)
 	}
 
-	// Pass the SPA index.html to the status handler so it can serve it for /status/.
+	// Pass the SPA index.html to the status handler so it can serve it for
+	// /status/. The same bytes seed the CSP — its inline script needs a hash.
+	var indexHTML []byte
 	if distFS, err := fs.Sub(web.FS, "dist"); err == nil {
 		if data, err := fs.ReadFile(distFS, "index.html"); err == nil {
+			indexHTML = data
 			a.statusHandler.SetIndexHTML(data)
 		}
 	}
 
 	a.statusHandler.Register(topMux, a.rl.Middleware)
-	topMux.Handle("/api/", a.router.Handler())
+	topMux.Handle("/api/", a.apiRL.Middleware(a.router.Handler()))
 	topMux.Handle("/ping/", a.rl.Middleware(a.router.Handler()))
 	topMux.Handle("/", SPAHandler(a.router.Handler(), a.logger))
 
+	handler := SecurityHeaders(contentSecurityPolicy(indexHTML))(
+		WithRequestTimeout(topMux, 10*time.Second))
+
 	return &http.Server{
 		Addr:         a.cfg.Addr,
-		Handler:      WithRequestTimeout(topMux, 10*time.Second),
+		Handler:      handler,
 		ReadTimeout:  5 * time.Second,
 		WriteTimeout: 0,
 		IdleTimeout:  120 * time.Second,

--- a/internal/app/http_test.go
+++ b/internal/app/http_test.go
@@ -1,0 +1,175 @@
+// Copyright 2026 Benjamin Touchard (Kolapsis)
+//
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+// or a commercial license. You may not use this file except in compliance
+// with one of these licenses.
+//
+// AGPL-3.0: https://www.gnu.org/licenses/agpl-3.0.html
+// Commercial: See COMMERCIAL-LICENSE.md
+//
+// Source: https://github.com/kolapsis/maintenant
+
+package app
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The digest a browser computes for the body of `<script>alert(1)</script>`,
+// obtained independently (openssl dgst -sha256 -binary | openssl base64). If
+// the hashing ever drifts — trimming the body, including the tags — this is
+// what catches it, because a wrong digest blanks the SPA in production.
+const alert1Digest = "sha256-bhHHL3z2vDgxUt0W3dWQOrprscmda2Y5pLsLg4GF+pI="
+
+func TestInlineScriptHashes_MatchesBrowserDigest(t *testing.T) {
+	hashes := inlineScriptHashes([]byte(`<html><body><script>alert(1)</script></body></html>`))
+	require.Len(t, hashes, 1)
+	assert.Equal(t, alert1Digest, hashes[0])
+}
+
+func TestInlineScriptHashes_SkipsExternalAndEmpty(t *testing.T) {
+	html := []byte(`
+		<script type="module" src="/assets/index-abc123.js"></script>
+		<script SRC="/registerSW.js"></script>
+		<script></script>
+		<script>alert(1)</script>
+	`)
+	hashes := inlineScriptHashes(html)
+	assert.Equal(t, []string{alert1Digest}, hashes,
+		"only the inline, non-empty script needs a hash")
+}
+
+func TestInlineScriptHashes_HashesEveryInlineScript(t *testing.T) {
+	hashes := inlineScriptHashes([]byte(`<script>a()</script><script>b()</script>`))
+	assert.Len(t, hashes, 2)
+	assert.NotEqual(t, hashes[0], hashes[1])
+}
+
+// The real index.html bootstraps the theme inline, so the policy must carry a
+// hash. Without one the script is blocked and the app renders unthemed.
+func TestContentSecurityPolicy_CarriesInlineScriptHash(t *testing.T) {
+	index := []byte(`<!DOCTYPE html><html><body>
+	<script>
+	  (function() { document.documentElement.setAttribute('data-theme', 'dark'); })();
+	</script>
+	<div id="app"></div>
+	<script type="module" src="/assets/index.js"></script>
+	</body></html>`)
+
+	csp := contentSecurityPolicy(index)
+
+	assert.Contains(t, csp, "script-src 'self' 'sha256-")
+	assert.NotContains(t, csp, "script-src 'self';",
+		"the inline bootstrap script must be hashed, not blocked")
+	assert.NotContains(t, csp, "'unsafe-inline'; script-src")
+}
+
+// script-src must never fall back to 'unsafe-inline' — that would defeat the
+// only part of the policy that actually mitigates XSS.
+func TestContentSecurityPolicy_NeverAllowsInlineScript(t *testing.T) {
+	for name, index := range map[string][]byte{
+		"no assets embedded": nil,
+		"with inline script": []byte(`<script>alert(1)</script>`),
+	} {
+		t.Run(name, func(t *testing.T) {
+			csp := contentSecurityPolicy(index)
+			assert.Contains(t, csp, "object-src 'none'")
+			assert.Contains(t, csp, "base-uri 'self'")
+			// 'unsafe-inline' is allowed for styles only.
+			assert.Contains(t, csp, "style-src 'self' 'unsafe-inline'")
+			assert.NotContains(t, csp, "script-src 'self' 'unsafe-inline'")
+			// frame-ancestors is per-route, appended by SecurityHeaders.
+			assert.NotContains(t, csp, "frame-ancestors")
+		})
+	}
+}
+
+// The status page stores its logo and hero as data URLs; blocking data: images
+// would break every personalized status page.
+func TestContentSecurityPolicy_AllowsDataURLImages(t *testing.T) {
+	assert.Contains(t, contentSecurityPolicy(nil), "img-src 'self' data: blob:")
+}
+
+func TestSecurityHeaders_SetOnEveryResponse(t *testing.T) {
+	h := SecurityHeaders("default-src 'self'")(http.HandlerFunc(
+		func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }))
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/containers", nil))
+
+	assert.Equal(t, "nosniff", rec.Header().Get("X-Content-Type-Options"))
+	assert.Equal(t, "DENY", rec.Header().Get("X-Frame-Options"))
+	assert.Equal(t, "strict-origin-when-cross-origin", rec.Header().Get("Referrer-Policy"))
+	assert.Equal(t, "default-src 'self'; frame-ancestors 'none'",
+		rec.Header().Get("Content-Security-Policy"))
+}
+
+// The dashboard and the admin API are the clickjacking targets, so they refuse
+// framing outright. /api/v1/status/ is admin despite the name and must not be
+// mistaken for the public status page.
+func TestSecurityHeaders_RefusesFramingOnAdminSurfaces(t *testing.T) {
+	h := SecurityHeaders("default-src 'self'")(http.HandlerFunc(
+		func(w http.ResponseWriter, _ *http.Request) {}))
+
+	for _, path := range []string{"/", "/dashboard", "/api/v1/containers", "/api/v1/status/components", "/statuses"} {
+		t.Run(path, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+
+			assert.Equal(t, "DENY", rec.Header().Get("X-Frame-Options"))
+			assert.Contains(t, rec.Header().Get("Content-Security-Policy"), "frame-ancestors 'none'")
+		})
+	}
+}
+
+// The public status page is documented as embeddable; locking it to
+// frame-ancestors 'none' would silently break anyone iframing it.
+func TestSecurityHeaders_KeepsStatusPageEmbeddable(t *testing.T) {
+	h := SecurityHeaders("default-src 'self'")(http.HandlerFunc(
+		func(w http.ResponseWriter, _ *http.Request) {}))
+
+	for _, path := range []string{"/status", "/status/", "/status/api", "/status/events"} {
+		t.Run(path, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+
+			assert.Empty(t, rec.Header().Get("X-Frame-Options"))
+			assert.Contains(t, rec.Header().Get("Content-Security-Policy"), "frame-ancestors *")
+		})
+	}
+}
+
+// HSTS is the reverse proxy's job — asserting its absence keeps someone from
+// re-adding it here off a forgeable X-Forwarded-Proto.
+func TestSecurityHeaders_NoHSTS(t *testing.T) {
+	h := SecurityHeaders("default-src 'self'")(http.HandlerFunc(
+		func(w http.ResponseWriter, _ *http.Request) {}))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Forwarded-Proto", "https")
+	h.ServeHTTP(rec, req)
+
+	assert.Empty(t, rec.Header().Get("Strict-Transport-Security"))
+}
+
+// The status page asset route sets a much stricter policy of its own. The
+// middleware runs first, so the handler has to be able to overwrite it.
+func TestSecurityHeaders_HandlerCanTightenPolicy(t *testing.T) {
+	strict := "default-src 'none'; style-src 'unsafe-inline'"
+	h := SecurityHeaders("default-src 'self'")(http.HandlerFunc(
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Security-Policy", strict)
+			w.WriteHeader(http.StatusOK)
+		}))
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/status/assets/logo", nil))
+
+	assert.Equal(t, strict, rec.Header().Get("Content-Security-Policy"))
+}

--- a/internal/store/sqlite/agents.go
+++ b/internal/store/sqlite/agents.go
@@ -210,12 +210,13 @@ func (s *AgentStore) CountByRuntime(ctx context.Context) (docker, swarm, kuberne
 	return docker, swarm, kubernetes, rows.Err()
 }
 
-// InsertToken persists a new enrollment token.
+// InsertToken persists a new enrollment token. Only the hash and the display
+// prefix are written — the caller holds the cleartext and must not pass it here.
 func (s *AgentStore) InsertToken(ctx context.Context, t *agent.EnrollmentToken) error {
 	_, err := s.writer.Exec(ctx,
-		`INSERT INTO enrollment_tokens (id, token, created_at, expires_at)
-		VALUES (?, ?, ?, ?)`,
-		t.TokenID, t.Token, t.CreatedAt.Unix(), t.ExpiresAt.Unix(),
+		`INSERT INTO enrollment_tokens (id, token_hash, token_prefix, created_at, expires_at)
+		VALUES (?, ?, ?, ?, ?)`,
+		t.TokenID, t.TokenHash, t.TokenPrefix, t.CreatedAt.Unix(), t.ExpiresAt.Unix(),
 	)
 	if err != nil {
 		return fmt.Errorf("insert token: %w", err)
@@ -245,11 +246,13 @@ func (s *AgentStore) EnrollAtomic(ctx context.Context, limit int, tokenCleartext
 		}
 
 		now := time.Now().Unix()
+		// The client sends the cleartext; the row is found by its hash.
+		tokenHash := agent.HashToken(tokenCleartext)
 		res, err := tx.ExecContext(ctx,
 			`UPDATE enrollment_tokens
 			SET consumed_at = ?, consumed_by_agent_id = ?
-			WHERE token = ? AND consumed_at IS NULL AND expires_at > ?`,
-			now, a.AgentID, tokenCleartext, now,
+			WHERE token_hash = ? AND consumed_at IS NULL AND expires_at > ?`,
+			now, a.AgentID, tokenHash, now,
 		)
 		if err != nil {
 			return fmt.Errorf("consume token: %w", err)
@@ -259,7 +262,7 @@ func (s *AgentStore) EnrollAtomic(ctx context.Context, limit int, tokenCleartext
 			return fmt.Errorf("consume token rows: %w", err)
 		}
 		if affected != 1 {
-			return classifyTokenFailure(ctx, tx, tokenCleartext, now)
+			return classifyTokenFailure(ctx, tx, tokenHash, now)
 		}
 
 		if _, err := tx.ExecContext(ctx,
@@ -276,11 +279,11 @@ func (s *AgentStore) EnrollAtomic(ctx context.Context, limit int, tokenCleartext
 }
 
 // classifyTokenFailure determines why a token UPDATE matched no rows.
-func classifyTokenFailure(ctx context.Context, tx *sql.Tx, tokenCleartext string, now int64) error {
+func classifyTokenFailure(ctx context.Context, tx *sql.Tx, tokenHash string, now int64) error {
 	var consumed sql.NullInt64
 	var expiresAt int64
 	err := tx.QueryRowContext(ctx,
-		`SELECT consumed_at, expires_at FROM enrollment_tokens WHERE token = ?`, tokenCleartext,
+		`SELECT consumed_at, expires_at FROM enrollment_tokens WHERE token_hash = ?`, tokenHash,
 	).Scan(&consumed, &expiresAt)
 	if errors.Is(err, sql.ErrNoRows) {
 		return agent.ErrTokenNotFound
@@ -297,12 +300,13 @@ func classifyTokenFailure(ctx context.Context, tx *sql.Tx, tokenCleartext string
 	return agent.ErrTokenNotFound
 }
 
-const tokenColumns = `id, token, created_at, expires_at, consumed_at, consumed_by_agent_id` // #nosec G101 -- column names, not a credential.
+const tokenColumns = `id, token_hash, token_prefix, created_at, expires_at, consumed_at, consumed_by_agent_id` // #nosec G101 -- column names, not a credential.
 
-// GetByToken retrieves a token by its cleartext value.
+// GetByToken retrieves a token from its cleartext value, which it hashes to
+// find the row. Nothing it returns can reconstruct the cleartext.
 func (s *AgentStore) GetByToken(ctx context.Context, tokenCleartext string) (*agent.EnrollmentToken, error) {
 	row := s.db.QueryRowContext(ctx,
-		`SELECT `+tokenColumns+` FROM enrollment_tokens WHERE token = ?`, tokenCleartext)
+		`SELECT `+tokenColumns+` FROM enrollment_tokens WHERE token_hash = ?`, agent.HashToken(tokenCleartext))
 	t, err := scanToken(row)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, agent.ErrTokenNotFound
@@ -444,7 +448,7 @@ func scanToken(s scanner) (*agent.EnrollmentToken, error) {
 	var consumedBy sql.NullString
 	var createdAt, expiresAt int64
 	err := s.Scan(
-		&t.TokenID, &t.Token, &createdAt, &expiresAt, &consumedAt, &consumedBy,
+		&t.TokenID, &t.TokenHash, &t.TokenPrefix, &createdAt, &expiresAt, &consumedAt, &consumedBy,
 	)
 	if err != nil {
 		return nil, err

--- a/internal/store/sqlite/agents_test.go
+++ b/internal/store/sqlite/agents_test.go
@@ -41,6 +41,20 @@ func enrollAgentRecord(id string) *agent.Agent {
 	}
 }
 
+// tokenFor builds the stored record for a cleartext token the way the creation
+// handler does. The store never sees the cleartext: only its hash, plus the
+// prefix kept for display.
+func tokenFor(cleartext string, createdAt, expiresAt time.Time) *agent.EnrollmentToken {
+	hash := agent.HashToken(cleartext)
+	return &agent.EnrollmentToken{
+		TokenID:     agent.TokenIDFromHash(hash),
+		TokenHash:   hash,
+		TokenPrefix: agent.TokenPrefix(cleartext),
+		CreatedAt:   createdAt,
+		ExpiresAt:   expiresAt,
+	}
+}
+
 // Many agents racing on the SAME one-time token: exactly one wins (consumes the
 // token and is inserted); the rest get ErrTokenAlreadyConsumed. limit < 0 keeps
 // the cap out of the picture so this isolates the token-consume race.
@@ -49,13 +63,9 @@ func TestEnrollAtomic_ConcurrentSameToken(t *testing.T) {
 	store := NewAgentStore(db)
 	ctx := context.Background()
 
-	tok := &agent.EnrollmentToken{
-		TokenID:   "testtoken01",
-		Token:     "mnt_enr_testtoken",
-		CreatedAt: time.Now().UTC(),
-		ExpiresAt: time.Now().UTC().Add(time.Hour),
-	}
-	require.NoError(t, store.InsertToken(ctx, tok))
+	const cleartext = "mnt_enr_testtoken"
+	require.NoError(t, store.InsertToken(ctx,
+		tokenFor(cleartext, time.Now().UTC(), time.Now().UTC().Add(time.Hour))))
 
 	const goroutines = 10
 	var (
@@ -69,7 +79,7 @@ func TestEnrollAtomic_ConcurrentSameToken(t *testing.T) {
 	for i := range goroutines {
 		go func(i int) {
 			defer wg.Done()
-			err := store.EnrollAtomic(ctx, -1, tok.Token, enrollAgentRecord(fmt.Sprintf("agent-%d", i)))
+			err := store.EnrollAtomic(ctx, -1, cleartext, enrollAgentRecord(fmt.Sprintf("agent-%d", i)))
 			switch {
 			case err == nil:
 				successes.Add(1)
@@ -102,12 +112,9 @@ func TestEnrollAtomic_ConcurrentCap(t *testing.T) {
 	const limit = 10
 	const goroutines = 40
 	for i := range goroutines {
-		require.NoError(t, store.InsertToken(ctx, &agent.EnrollmentToken{
-			TokenID:   fmt.Sprintf("captok-%d", i),
-			Token:     fmt.Sprintf("mnt_enr_captoken%012d", i),
-			CreatedAt: time.Now().UTC(),
-			ExpiresAt: time.Now().UTC().Add(time.Hour),
-		}))
+		require.NoError(t, store.InsertToken(ctx, tokenFor(
+			fmt.Sprintf("mnt_enr_captoken%012d", i),
+			time.Now().UTC(), time.Now().UTC().Add(time.Hour))))
 	}
 
 	var (
@@ -158,15 +165,12 @@ func TestEnrollAtomic_TokenExpired(t *testing.T) {
 	store := NewAgentStore(db)
 	ctx := context.Background()
 
-	tok := &agent.EnrollmentToken{
-		TokenID:   "expiredtoken01",
-		Token:     "mnt_enr_expired",
-		CreatedAt: time.Now().UTC().Add(-2 * time.Hour),
-		ExpiresAt: time.Now().UTC().Add(-1 * time.Hour), // already expired
-	}
-	require.NoError(t, store.InsertToken(ctx, tok))
+	const cleartext = "mnt_enr_expired"
+	require.NoError(t, store.InsertToken(ctx, tokenFor(cleartext,
+		time.Now().UTC().Add(-2*time.Hour),
+		time.Now().UTC().Add(-1*time.Hour)))) // already expired
 
-	err := store.EnrollAtomic(ctx, -1, tok.Token, enrollAgentRecord("agent-y"))
+	err := store.EnrollAtomic(ctx, -1, cleartext, enrollAgentRecord("agent-y"))
 	assert.ErrorIs(t, err, agent.ErrTokenExpired)
 }
 

--- a/internal/store/sqlite/enrollment_token_hash_test.go
+++ b/internal/store/sqlite/enrollment_token_hash_test.go
@@ -1,0 +1,218 @@
+// Copyright 2026 Benjamin Touchard (Kolapsis)
+//
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+// or a commercial license. You may not use this file except in compliance
+// with one of these licenses.
+//
+// AGPL-3.0: https://www.gnu.org/licenses/agpl-3.0.html
+// Commercial: See COMMERCIAL-LICENSE.md
+//
+// Source: https://github.com/kolapsis/maintenant
+
+package sqlite
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kolapsis/maintenant/internal/agent"
+)
+
+// downgradeEnrollmentTokens restores the cleartext-token table, standing in for
+// a database converted before the token was hashed. Two rows: one still usable,
+// one already consumed (kept for audit).
+const downgradeEnrollmentTokens = `
+DROP TABLE enrollment_tokens;
+CREATE TABLE enrollment_tokens (
+    id            TEXT PRIMARY KEY NOT NULL,
+    token         TEXT NOT NULL UNIQUE,
+    created_at    BIGINT NOT NULL DEFAULT 0,
+    expires_at    BIGINT NOT NULL,
+    consumed_at   BIGINT,
+    consumed_by_agent_id TEXT
+);
+CREATE INDEX idx_enrollment_tokens_expires_at ON enrollment_tokens(expires_at);
+INSERT INTO enrollment_tokens (id, token, created_at, expires_at, consumed_at, consumed_by_agent_id)
+VALUES ('pending000000001', 'mnt_enr_pendinglegacytoken', 1700000000, 4000000000, NULL, NULL),
+       ('consumed00000001', 'mnt_enr_consumedlegacytok', 1700000000, 4000000000, 1700000100, 'some-agent');
+`
+
+const legacyPendingToken = "mnt_enr_pendinglegacytoken"
+
+// A token handed out before the upgrade must still enroll afterwards. The
+// rebuild derives the hash from the stored cleartext, so nobody has to reissue
+// tokens — and once it has run, the cleartext is gone for good.
+func TestRebuildEnrollmentTokensForHashing(t *testing.T) {
+	db := openTestDB(t)
+	rw := db.ReadDB()
+	ctx := context.Background()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	_, err := rw.ExecContext(ctx, downgradeEnrollmentTokens)
+	require.NoError(t, err)
+
+	require.NoError(t, rebuildEnrollmentTokensForHashing(ctx, rw, logger))
+
+	ddl := scanString(t, rw, `SELECT sql FROM sqlite_master WHERE type='table' AND name='enrollment_tokens'`)
+	require.Contains(t, ddl, enrollmentTokenHashColumn)
+	require.NotContains(t, ddl, "token         TEXT NOT NULL UNIQUE",
+		"the cleartext column must be gone, not merely unused")
+
+	// Both rows survived, hashed, with their audit fields intact.
+	var count int
+	require.NoError(t, rw.QueryRowContext(ctx, `SELECT COUNT(*) FROM enrollment_tokens`).Scan(&count))
+	require.Equal(t, 2, count)
+
+	assert.Equal(t, agent.HashToken(legacyPendingToken),
+		scanString(t, rw, `SELECT token_hash FROM enrollment_tokens WHERE id='pending000000001'`))
+	assert.Equal(t, agent.TokenPrefix(legacyPendingToken),
+		scanString(t, rw, `SELECT token_prefix FROM enrollment_tokens WHERE id='pending000000001'`))
+	assert.Equal(t, "some-agent",
+		scanString(t, rw, `SELECT consumed_by_agent_id FROM enrollment_tokens WHERE id='consumed00000001'`))
+
+	// The pending token is still redeemable through the normal store path.
+	store := NewAgentStore(db)
+	got, err := store.GetByToken(ctx, legacyPendingToken)
+	require.NoError(t, err, "a token issued before the upgrade must still resolve")
+	assert.Equal(t, "pending000000001", got.TokenID)
+	assert.Nil(t, got.ConsumedAt)
+
+	// The index was recreated after the DROP TABLE.
+	var indexes int
+	require.NoError(t, rw.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND tbl_name='enrollment_tokens' AND name LIKE 'idx_%'`).Scan(&indexes))
+	assert.Equal(t, 1, indexes)
+
+	// Second run is a no-op.
+	require.NoError(t, rebuildEnrollmentTokensForHashing(ctx, rw, logger))
+	assert.Equal(t, ddl, scanString(t, rw, `SELECT sql FROM sqlite_master WHERE type='table' AND name='enrollment_tokens'`))
+}
+
+// The rebuild drops the live enrollment_tokens table. That is only acceptable
+// because the whole sequence is one transaction: if any statement fails, the
+// original table and every row in it must still be there.
+//
+// The failure is injected by squatting the scratch table name, which makes the
+// first statement (CREATE TABLE enrollment_tokens_new) fail before the copy.
+func TestRebuildEnrollmentTokensForHashing_RollsBackOnFailure(t *testing.T) {
+	db := openTestDB(t)
+	rw := db.ReadDB()
+	ctx := context.Background()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	_, err := rw.ExecContext(ctx, downgradeEnrollmentTokens)
+	require.NoError(t, err)
+	_, err = rw.ExecContext(ctx, `CREATE TABLE enrollment_tokens_new (squatted TEXT)`)
+	require.NoError(t, err)
+
+	require.Error(t, rebuildEnrollmentTokensForHashing(ctx, rw, logger),
+		"the rebuild must report the failure rather than swallow it")
+
+	// The original table is untouched: same DDL, same rows, cleartext intact.
+	ddl := scanString(t, rw, `SELECT sql FROM sqlite_master WHERE type='table' AND name='enrollment_tokens'`)
+	assert.Contains(t, ddl, "token         TEXT NOT NULL UNIQUE", "the old table must survive a failed rebuild")
+
+	var count int
+	require.NoError(t, rw.QueryRowContext(ctx, `SELECT COUNT(*) FROM enrollment_tokens`).Scan(&count))
+	assert.Equal(t, 2, count, "no row may be lost when the rebuild aborts")
+	assert.Equal(t, legacyPendingToken,
+		scanString(t, rw, `SELECT token FROM enrollment_tokens WHERE id='pending000000001'`))
+
+	// Clearing the obstruction lets the next boot complete the rebuild.
+	_, err = rw.ExecContext(ctx, `DROP TABLE enrollment_tokens_new`)
+	require.NoError(t, err)
+	require.NoError(t, rebuildEnrollmentTokensForHashing(ctx, rw, logger))
+	assert.Equal(t, agent.HashToken(legacyPendingToken),
+		scanString(t, rw, `SELECT token_hash FROM enrollment_tokens WHERE id='pending000000001'`))
+}
+
+// After the rebuild the live table holds no cleartext. This asserts the stored
+// columns only — it says nothing about pages freed inside the file, which
+// secure_delete addresses but which no test here proves.
+func TestRebuildEnrollmentTokensForHashing_LeavesNoCleartext(t *testing.T) {
+	db := openTestDB(t)
+	rw := db.ReadDB()
+	ctx := context.Background()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	_, err := rw.ExecContext(ctx, downgradeEnrollmentTokens)
+	require.NoError(t, err)
+	require.NoError(t, rebuildEnrollmentTokensForHashing(ctx, rw, logger))
+
+	rows, err := rw.QueryContext(ctx,
+		`SELECT id, token_hash, token_prefix, consumed_by_agent_id FROM enrollment_tokens`)
+	require.NoError(t, err)
+	defer func() { _ = rows.Close() }()
+
+	for rows.Next() {
+		var id, hash, prefix string
+		var consumedBy *string
+		require.NoError(t, rows.Scan(&id, &hash, &prefix, &consumedBy))
+		assert.NotContains(t, hash, "mnt_enr_", "the hash must not carry the token")
+		// The prefix is the deliberate exception: 14 chars of a 256-bit secret,
+		// kept so the UI can still name a token it can no longer read.
+		assert.LessOrEqual(t, len(prefix), agent.TokenPrefixLen)
+	}
+	require.NoError(t, rows.Err())
+}
+
+// A fresh install must come out of uuid_schema.sql already hashed, never
+// through the rebuild.
+func TestFreshSchema_EnrollmentTokensAreHashed(t *testing.T) {
+	db := openTestDB(t)
+	rw := db.ReadDB()
+
+	ddl := scanString(t, rw, `SELECT sql FROM sqlite_master WHERE type='table' AND name='enrollment_tokens'`)
+	assert.Contains(t, ddl, enrollmentTokenHashColumn)
+	assert.Contains(t, ddl, "token_prefix")
+	assert.NotContains(t, ddl, "token         TEXT NOT NULL UNIQUE")
+}
+
+// The rebuild's CREATE TABLE must embed the exact column string the idempotency
+// guard looks for, or fresh installs would be rebuilt on every boot.
+func TestEnrollmentTokenHashColumn_MatchesSchema(t *testing.T) {
+	schema, err := os.ReadFile("uuid_schema.sql")
+	require.NoError(t, err)
+	require.True(t, strings.Contains(string(schema), enrollmentTokenHashColumn),
+		"uuid_schema.sql must contain %q verbatim — the rebuild guard depends on it", enrollmentTokenHashColumn)
+}
+
+// End-to-end through the store: what goes in as cleartext is queryable by
+// cleartext, but only ever stored as a hash.
+func TestAgentStore_TokenRoundTripIsHashed(t *testing.T) {
+	db := openTestDB(t)
+	store := NewAgentStore(db)
+	ctx := context.Background()
+
+	cleartext, hash, id, prefix, err := agent.NewToken()
+	require.NoError(t, err)
+	require.NoError(t, store.InsertToken(ctx, &agent.EnrollmentToken{
+		TokenID:     id,
+		TokenHash:   hash,
+		TokenPrefix: prefix,
+		CreatedAt:   time.Now().UTC(),
+		ExpiresAt:   time.Now().UTC().Add(time.Hour),
+	}))
+
+	got, err := store.GetByToken(ctx, cleartext)
+	require.NoError(t, err)
+	assert.Equal(t, hash, got.TokenHash)
+	assert.Equal(t, prefix, got.TokenPrefix)
+	assert.Equal(t, prefix+"...***", got.Masked())
+
+	// A near-miss must not resolve: the lookup matches the full hash, not the
+	// truncated id, so guessing the id buys nothing.
+	_, err = store.GetByToken(ctx, cleartext+"x")
+	assert.ErrorIs(t, err, agent.ErrTokenNotFound)
+
+	stored := scanString(t, db.ReadDB(), `SELECT token_hash FROM enrollment_tokens`)
+	assert.NotEqual(t, cleartext, stored)
+	assert.Equal(t, id, agent.TokenIDFromHash(stored), "the id stays derivable from the hash")
+}

--- a/internal/store/sqlite/migrations.go
+++ b/internal/store/sqlite/migrations.go
@@ -104,6 +104,12 @@ func Migrate(db *sql.DB, logger *slog.Logger) error {
 		return fmt.Errorf("endpoint degraded rebuild: %w", err)
 	}
 
+	// One-time rebuild replacing the cleartext enrollment token with its hash,
+	// for databases converted before the token stopped being stored in clear.
+	if err := rebuildEnrollmentTokensForHashing(context.Background(), db, logger); err != nil {
+		return fmt.Errorf("enrollment token hash rebuild: %w", err)
+	}
+
 	return nil
 }
 

--- a/internal/store/sqlite/transform_enrollment_token_hash.go
+++ b/internal/store/sqlite/transform_enrollment_token_hash.go
@@ -1,0 +1,179 @@
+// Copyright 2026 Benjamin Touchard (Kolapsis)
+//
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+// or a commercial license. You may not use this file except in compliance
+// with one of these licenses.
+//
+// AGPL-3.0: https://www.gnu.org/licenses/agpl-3.0.html
+// Commercial: See COMMERCIAL-LICENSE.md
+//
+// Source: https://github.com/kolapsis/maintenant
+
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/kolapsis/maintenant/internal/agent"
+	"github.com/mattn/go-sqlite3"
+)
+
+// enrollmentTokenHashColumn is the hashed-token column of enrollment_tokens. It
+// must stay byte-identical to the DDL in uuid_schema.sql — SQLite stores the
+// CREATE TABLE text verbatim and the idempotency guard matches on it.
+const enrollmentTokenHashColumn = "token_hash    TEXT NOT NULL UNIQUE" // #nosec G101 -- a DDL fragment, not a credential.
+
+// rebuildEnrollmentTokensForHashing replaces the cleartext `token` column with
+// its SHA-256 plus a short display prefix, on databases converted to the UUID
+// schema before the token was hashed.
+//
+// The cleartext used to sit in the file: any copy of the database (a backup, the
+// data volume, a `.db` grabbed for debugging) handed over every unconsumed,
+// unexpired token, each one directly replayable to enroll an agent. Hashing
+// costs nothing at the lookups — enrollment already knows the cleartext the
+// client just sent — and leaves nothing replayable at rest.
+//
+// Pending tokens survive: the hash is computed from the stored cleartext during
+// the copy, so an operator who handed out a token yesterday does not have to
+// reissue it. Once this has run the cleartext is gone for good, which is the
+// point; the `down` direction does not exist.
+//
+// Runs after convertToUUID rather than as a numbered migration for the same
+// reason as the other rebuilds: migrations execute against the legacy integer
+// schema, where this table does not exist at all.
+func rebuildEnrollmentTokensForHashing(ctx context.Context, db *sql.DB, logger *slog.Logger) error {
+	var ddl string
+	err := db.QueryRowContext(ctx,
+		`SELECT sql FROM sqlite_master WHERE type='table' AND name='enrollment_tokens'`).Scan(&ddl)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("enrollment token hash rebuild: probe ddl: %w", err)
+	}
+	if strings.Contains(ddl, enrollmentTokenHashColumn) {
+		return nil
+	}
+
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("enrollment token hash rebuild: acquire conn: %w", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	// The copy hashes set-based rather than row-by-row in Go, so the whole
+	// rewrite stays inside the one transaction below.
+	if err := registerHashFunc(ctx, conn); err != nil {
+		return fmt.Errorf("enrollment token hash rebuild: register func: %w", err)
+	}
+
+	if _, err := conn.ExecContext(ctx, "PRAGMA foreign_keys=OFF"); err != nil {
+		return fmt.Errorf("enrollment token hash rebuild: fk off: %w", err)
+	}
+
+	// Dropping the old table marks its pages free without overwriting them, so
+	// the cleartext could stay legible in the file's slack space. secure_delete
+	// is SQLite's documented way to zero freed content instead.
+	//
+	// Precaution, not a guarantee: it cannot reach a copy of the file taken
+	// before the upgrade, nor blocks a copy-on-write filesystem or an SSD's
+	// wear-levelling still holds underneath. Revoking an outstanding token is
+	// the only thing that fully closes it — their 7-day TTL does the rest.
+	if _, err := conn.ExecContext(ctx, "PRAGMA secure_delete=ON"); err != nil {
+		return fmt.Errorf("enrollment token hash rebuild: secure_delete on: %w", err)
+	}
+
+	logger.Info("enrollment token hashing rebuild starting")
+
+	if err := runEnrollmentTokenHashRebuild(ctx, conn); err != nil {
+		return err
+	}
+
+	if err := foreignKeyCheck(ctx, conn); err != nil {
+		return err
+	}
+	// Return the freed pages to the file rather than leaving them on the
+	// freelist. The database is auto_vacuum=incremental, so this is bounded
+	// work rather than a full VACUUM rewrite.
+	if _, err := conn.ExecContext(ctx, "PRAGMA incremental_vacuum"); err != nil {
+		return fmt.Errorf("enrollment token hash rebuild: incremental_vacuum: %w", err)
+	}
+	if _, err := conn.ExecContext(ctx, "PRAGMA secure_delete=OFF"); err != nil {
+		return fmt.Errorf("enrollment token hash rebuild: secure_delete off: %w", err)
+	}
+	if _, err := conn.ExecContext(ctx, "PRAGMA foreign_keys=ON"); err != nil {
+		return fmt.Errorf("enrollment token hash rebuild: fk on: %w", err)
+	}
+
+	logger.Info("enrollment token hashing rebuild complete")
+	return nil
+}
+
+// registerHashFunc exposes the token hash and prefix helpers to SQL so the copy
+// below can be a single INSERT ... SELECT.
+func registerHashFunc(ctx context.Context, conn *sql.Conn) error {
+	return conn.Raw(func(driverConn any) error {
+		c, ok := driverConn.(*sqlite3.SQLiteConn)
+		if !ok {
+			return fmt.Errorf("not a sqlite3 conn: %T", driverConn)
+		}
+		if err := c.RegisterFunc("mnt_token_hash", agent.HashToken, true); err != nil {
+			return err
+		}
+		return c.RegisterFunc("mnt_token_prefix", agent.TokenPrefix, true)
+	})
+}
+
+// runEnrollmentTokenHashRebuild performs the table rebuild in one transaction.
+func runEnrollmentTokenHashRebuild(ctx context.Context, conn *sql.Conn) error {
+	tx, err := conn.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("enrollment token hash rebuild: begin: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	stmts := []stmt{
+		// Keep this CREATE TABLE byte-identical to uuid_schema.sql.
+		{"create table", `CREATE TABLE enrollment_tokens_new (
+    id            TEXT PRIMARY KEY NOT NULL,                -- hex(sha256(token))[:16]
+    ` + enrollmentTokenHashColumn + `,                     -- hex(sha256(token)); the cleartext is never stored
+    token_prefix  TEXT NOT NULL DEFAULT '',                 -- leading non-secret chars, display only
+    created_at    BIGINT NOT NULL DEFAULT 0,
+    expires_at    BIGINT NOT NULL,
+    consumed_at   BIGINT,
+    consumed_by_agent_id TEXT                               -- audit only, no FK (agent may not exist yet)
+)`},
+		// A duplicate hash cannot happen (the source column is UNIQUE and the
+		// hash is injective over it), so the UNIQUE above stays satisfiable.
+		{"copy rows", `INSERT INTO enrollment_tokens_new
+			(id, token_hash, token_prefix, created_at, expires_at, consumed_at, consumed_by_agent_id)
+			SELECT id, mnt_token_hash(token), mnt_token_prefix(token),
+			       created_at, expires_at, consumed_at, consumed_by_agent_id
+			FROM enrollment_tokens`},
+		{"drop old table", `DROP TABLE enrollment_tokens`},
+		{"rename", `ALTER TABLE enrollment_tokens_new RENAME TO enrollment_tokens`},
+		// DROP TABLE removed the old table's index — recreate it.
+		{"index expires_at", `CREATE INDEX idx_enrollment_tokens_expires_at ON enrollment_tokens(expires_at)`},
+	}
+	for _, s := range stmts {
+		if _, err := tx.ExecContext(ctx, s.sql); err != nil {
+			return fmt.Errorf("enrollment token hash rebuild: %s: %w", s.desc, err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("enrollment token hash rebuild: commit: %w", err)
+	}
+	committed = true
+	return nil
+}

--- a/internal/store/sqlite/uuid_schema.sql
+++ b/internal/store/sqlite/uuid_schema.sql
@@ -35,7 +35,8 @@ VALUES ('00000000-0000-0000-0000-000000000000', NULL, 'local', 'local', '', '', 
 
 CREATE TABLE enrollment_tokens (
     id            TEXT PRIMARY KEY NOT NULL,                -- hex(sha256(token))[:16]
-    token         TEXT NOT NULL UNIQUE,
+    token_hash    TEXT NOT NULL UNIQUE,                     -- hex(sha256(token)); the cleartext is never stored
+    token_prefix  TEXT NOT NULL DEFAULT '',                 -- leading non-secret chars, display only
     created_at    BIGINT NOT NULL DEFAULT 0,
     expires_at    BIGINT NOT NULL,
     consumed_at   BIGINT,


### PR DESCRIPTION
Five findings from a security review of the backend, plus the dependency bump currently failing CI on main.

**Enrollment tokens were stored in clear** ? any copy of the SQLite file handed over replayable tokens. The column becomes `token_hash` (sha256) plus a 14-char `token_prefix` kept for display, so the list and detail views are unchanged. Existing installs are rewritten in place on first boot, deriving the hash from the stored cleartext: outstanding tokens stay valid, nothing has to be reissued. Copies of the database made *before* the upgrade obviously still hold the cleartext; the 7-day TTL retires those tokens on its own.

**MCP failed open** ? `MAINTENANT_MCP=true` without OAuth credentials served `/mcp` to anyone behind a single `Info` log, while `docs/security.md` tells the reverse proxy to let that route through. It now refuses to listen and names the missing variables; opt out with `MAINTENANT_MCP_ALLOW_UNAUTHENTICATED`. Checked in `Start()` rather than `New()`, so `--mcp-stdio`, which never listens, is unaffected.

**Two hardcoded `Access-Control-Allow-Origin: *`** on the log streams let any site an operator visited read container logs on an unauthenticated deployment. Removed; `cors()` applies the configured policy again.

**No security headers** ? adds `nosniff`, `Referrer-Policy`, frame refusal and a CSP whose `script-src` carries the sha256 of the inline theme bootstrap, computed at startup from the embedded `index.html` rather than hardcoded, so it survives a frontend rebuild. The public status page keeps `frame-ancestors *` to stay embeddable. HSTS stays at the proxy, where the scheme is not inferred from a forgeable header.

**`/api/` had no rate limit** ? it gets its own bucket (50 rps, burst 200), separate from the tighter public one an ordinary dashboard load would trip.

The lockfile bump clears five npm advisories (undici, js-yaml, brace-expansion, fast-uri, postcss), all in build and test tooling, none of it shipped in the bundle. All fixes are semver-minor. This is what has been failing CI on main since the Actions outage.

`go test`, `go test -tags=integration`, `gosec`, `golangci-lint`, `npm audit`, `eslint`, `vue-tsc` and `vitest` all pass locally. The CSP was checked against a real build in a browser: dashboard and status page load with no console violation.