### PR TITLE
fix(agentserver): stop the stale-watcher test from racing the lifecycle hook

### DIFF
--- a/internal/agentserver/sessions_test.go
+++ b/internal/agentserver/sessions_test.go
@@ -221,6 +221,10 @@ func TestSessions_StaleWatcher_ReapsDeadStreamDuringGrace(t *testing.T) {
 
 	require.Eventually(t, func() bool { return !sessions.IsConnected("agent-A") }, time.Second, 5*time.Millisecond,
 		"a stale live stream must be reaped whatever the grace period")
+	// IsConnected flips before the lifecycle hook runs, so wait for the hook
+	// itself instead of asserting right after the connection check.
+	require.Eventually(t, func() bool { return len(rec.snapshot()) == 2 }, time.Second, 5*time.Millisecond,
+		"the reap must announce the outage through the lifecycle hook")
 	assert.Equal(t, []string{"agent-A//true", "agent-A/stale/false"}, rec.snapshot())
 	assert.True(t, broadcaster.hasEvent("agent.disconnected"))
 }


### PR DESCRIPTION
TestSessions_StaleWatcher_ReapsDeadStreamDuringGrace asserted the hook
snapshot right after IsConnected flipped to false, but the watcher
deletes the session before calling the lifecycle hook. Under -race
the widened window let the assertion run ahead of the hook, failing
intermittently in CI (run 31941494145).

Fix: wait for the hook snapshot itself via require.Eventually, same
pattern already used by the neighboring reconnect test.

Verified with go test -race -count=20 on the affected tests.