### PR TITLE
fix(alerts): heartbeat recoveries read as recoveries, no orphaned alerts

### DIFF
--- a/docs/features/alerts.md
+++ b/docs/features/alerts.md
@@ -20,6 +20,8 @@ maintenant generates alerts from every monitoring subsystem:
 
 An agent alert fires when a remote agent stops reporting, whether its stream dropped or it never came back after a restart, and resolves on reconnection. Revoking or deleting an agent clears it instead of raising one.
 
+Deleting a monitored entity (container, agent, heartbeat, endpoint, certificate) resolves its active alerts. On every startup, maintenant also resolves any active alert whose entity no longer exists, so alerts left behind by an earlier version cannot linger.
+
 ---
 
 ## Notification Channels

--- a/docs/features/alerts.md
+++ b/docs/features/alerts.md
@@ -12,7 +12,7 @@ maintenant generates alerts from every monitoring subsystem:
 |--------|--------|------------------|
 | **Container** | `restart_loop`, `health_unhealthy` | Warning |
 | **Endpoint** | `consecutive_failure` | Critical |
-| **Heartbeat** | `deadline_missed` | Critical |
+| **Heartbeat** | `deadline_missed`, `exit_code_failure` | Critical |
 | **Certificate** | `expiring`, `expired`, `chain_invalid` | Critical |
 | **Resource** | `cpu_threshold`, `memory_threshold` | Warning |
 | **Update** | `available` | Info |

--- a/docs/features/heartbeats.md
+++ b/docs/features/heartbeats.md
@@ -103,7 +103,7 @@ For each heartbeat monitor, maintenant records:
 
 ## Deadline Missed Alerts
 
-When a heartbeat monitor does not receive a ping within its configured deadline, maintenant fires a `deadline_missed` alert with **Critical** severity.
+When a heartbeat monitor does not receive a ping within its configured deadline, maintenant fires a `deadline_missed` alert with **Critical** severity. A ping reporting a non-zero exit code fires an `exit_code_failure` alert instead, also Critical. Both resolve automatically, with a recovery notification, on the next successful ping; deleting or pausing a heartbeat clears its active alerts too.
 
 This means your cron job either:
 

--- a/docs/features/mcp.md
+++ b/docs/features/mcp.md
@@ -151,7 +151,7 @@ read-only except the ones listed under [Actions](#actions-write).
 | `get_endpoint_history` | Check history for a specific endpoint | Community |
 | `list_heartbeats` | All heartbeat monitors with status, last ping, periods | Community |
 | `list_certificates` | TLS certificates with expiration, issuer, chain validity | Community |
-| `list_alerts` | Active alerts (or full history with `active_only: false`) | Community |
+| `list_alerts` | Active alerts (or recent resolved/silenced ones with `active_only: false`) | Community |
 | `get_resources` | Host resource summary: CPU, memory, network, disk | Community |
 | `get_top_consumers` | Containers ranked by CPU or memory usage | Community |
 | `get_updates` | Available image updates for monitored containers | Community |

--- a/internal/alert/engine.go
+++ b/internal/alert/engine.go
@@ -342,7 +342,7 @@ func (e *Engine) processEvent(ctx context.Context, evt Event) {
 
 	// Dispatch notifications (only if not silenced)
 	if !silenced && e.notifier != nil {
-		e.dispatchNotifications(ctx, a)
+		e.dispatchNotifications(ctx, a, a)
 	}
 }
 
@@ -397,7 +397,7 @@ func (e *Engine) escalateAlert(ctx context.Context, existing *Alert, evt Event) 
 	}
 
 	if e.notifier != nil {
-		e.dispatchNotifications(ctx, existing)
+		e.dispatchNotifications(ctx, existing, existing)
 	}
 }
 
@@ -487,9 +487,12 @@ func (e *Engine) processRecovery(ctx context.Context, evt Event) {
 	// SSE broadcast
 	e.broadcastResolved(activeAlert)
 
-	// Dispatch recovery notifications
+	// Route by the original alert, but notify a payload that reads as a recovery.
 	if e.notifier != nil {
-		e.dispatchNotifications(ctx, activeAlert)
+		payload := *activeAlert
+		payload.Message = evt.Message
+		payload.Severity = evt.Severity
+		e.dispatchNotifications(ctx, activeAlert, &payload)
 	}
 }
 
@@ -555,7 +558,9 @@ func matchesSilenceRule(rule *SilenceRule, evt Event) bool {
 	return true
 }
 
-func (e *Engine) dispatchNotifications(ctx context.Context, a *Alert) {
+// dispatchNotifications matches triggers and the entity router against routeBy,
+// then delivers payload (they differ only for recoveries).
+func (e *Engine) dispatchNotifications(ctx context.Context, routeBy *Alert, payload *Alert) {
 	if e.channelStore == nil || e.notifier == nil {
 		return
 	}
@@ -569,7 +574,7 @@ func (e *Engine) dispatchNotifications(ctx context.Context, a *Alert) {
 			e.logger.Error("alert engine: list triggers", "error", err)
 		}
 		for _, t := range triggers {
-			if !matchesTrigger(t, a) {
+			if !matchesTrigger(t, routeBy) {
 				continue
 			}
 			for _, chID := range t.ChannelIDs {
@@ -585,14 +590,14 @@ func (e *Engine) dispatchNotifications(ctx context.Context, a *Alert) {
 					continue
 				}
 				dispatched[chID] = true
-				e.enqueueDelivery(ctx, ch, a)
+				e.enqueueDelivery(ctx, ch, payload)
 			}
 		}
 	}
 
 	// Consult entity router extension for additional channels (Pro: per-entity routing).
 	// Continues to operate independently from triggers.
-	extraIDs, err := e.entityRouter.Route(ctx, a.EntityType, a.EntityID, a.Severity)
+	extraIDs, err := e.entityRouter.Route(ctx, routeBy.EntityType, routeBy.EntityID, routeBy.Severity)
 	if err != nil {
 		e.logger.Error("alert engine: entity router error", "error", err)
 	}
@@ -609,7 +614,7 @@ func (e *Engine) dispatchNotifications(ctx context.Context, a *Alert) {
 			continue
 		}
 		dispatched[chID] = true
-		e.enqueueDelivery(ctx, ch, a)
+		e.enqueueDelivery(ctx, ch, payload)
 	}
 }
 

--- a/internal/alert/engine_triggers_test.go
+++ b/internal/alert/engine_triggers_test.go
@@ -13,9 +13,13 @@ package alert_test
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -125,6 +129,102 @@ func fireEvent(eng *alert.Engine, severity, source, entityType string, entityID 
 		Timestamp:  time.Now(),
 	}
 	time.Sleep(150 * time.Millisecond)
+}
+
+// capturingWebhookServer records every JSON payload POSTed to it.
+func capturingWebhookServer(t *testing.T) (*httptest.Server, func() []map[string]any) {
+	t.Helper()
+	var mu sync.Mutex
+	var bodies []map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&payload)
+		mu.Lock()
+		bodies = append(bodies, payload)
+		mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, func() []map[string]any {
+		mu.Lock()
+		defer mu.Unlock()
+		out := make([]map[string]any, len(bodies))
+		copy(out, bodies)
+		return out
+	}
+}
+
+// TestEngineRecovery_NotificationReadsAsRecovery pins FIX 1: a recovery must
+// route by the original alert (so a trigger filtered on the original severity
+// still matches) but the notified payload must read as the recovery, not repeat
+// the original failure's message/severity.
+func TestEngineRecovery_NotificationReadsAsRecovery(t *testing.T) {
+	ctx, cancel, db, alertStore, channelStore, triggerStore, _, eng := engineTestSetup(t)
+	defer cancel()
+	_ = db
+
+	srv, capturedBodies := capturingWebhookServer(t)
+	chID, err := channelStore.InsertChannel(ctx, &alert.NotificationChannel{
+		Name: "hb-channel", Type: "webhook", URL: srv.URL, Enabled: true,
+	})
+	require.NoError(t, err)
+	seedTriggerForChannel(t, triggerStore, "CriticalHeartbeats", true, "critical", "heartbeat", []string{chID})
+
+	eng.EventChannel() <- alert.Event{
+		Source:     "heartbeat",
+		AlertType:  "deadline_missed",
+		Severity:   "critical",
+		EntityType: "heartbeat",
+		EntityID:   "hb-1",
+		EntityName: "backup",
+		Message:    "Heartbeat 'backup' missed deadline",
+		Timestamp:  time.Now(),
+	}
+	time.Sleep(150 * time.Millisecond)
+
+	alerts, err := alertStore.ListActiveAlerts(ctx)
+	require.NoError(t, err)
+	require.Len(t, alerts, 1)
+	originalID := alerts[0].ID
+	assert.Equal(t, 1, countDeliveriesForChannel(t, channelStore, originalID, chID), "initial critical alert must be delivered")
+
+	eng.EventChannel() <- alert.Event{
+		Source:     "heartbeat",
+		AlertType:  "deadline_missed",
+		Severity:   "info",
+		IsRecover:  true,
+		EntityType: "heartbeat",
+		EntityID:   "hb-1",
+		EntityName: "backup",
+		Message:    "Heartbeat 'backup' recovered",
+		Timestamp:  time.Now(),
+	}
+	time.Sleep(150 * time.Millisecond)
+
+	active, err := alertStore.ListActiveAlerts(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, active, "original alert must be resolved")
+
+	resolved, err := alertStore.GetAlert(ctx, originalID)
+	require.NoError(t, err)
+	require.NotNil(t, resolved)
+	assert.Equal(t, alert.StatusResolved, resolved.Status)
+	require.NotNil(t, resolved.ResolvedAt)
+	require.NotNil(t, resolved.ResolvedByID, "resolved_by_id must point at the recovery record")
+
+	// The trigger matches on the ORIGINAL severity (critical), so the recovery
+	// must still be delivered to the same channel — but with the recovery payload.
+	assert.Equal(t, 2, countDeliveriesForChannel(t, channelStore, originalID, chID), "recovery must still be delivered, trigger matched on the original severity")
+
+	bodies := capturedBodies()
+	require.Len(t, bodies, 2, "webhook must have received both the failure and the recovery")
+	recoveryPayload, ok := bodies[1]["alert"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, originalID, recoveryPayload["id"], "recovery payload must carry the original alert's ID")
+	assert.Equal(t, alert.StatusResolved, recoveryPayload["status"])
+	assert.Equal(t, "Heartbeat 'backup' recovered", recoveryPayload["message"], "must read as a recovery, not repeat the failure message")
+	assert.Equal(t, alert.SeverityInfo, recoveryPayload["severity"], "must carry the recovery severity, not the original critical severity")
+	assert.NotEmpty(t, recoveryPayload["resolved_at"])
 }
 
 // T077 — E2E test 1: trigger matches → delivery created for each channel.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -736,6 +736,8 @@ func (a *App) Start(ctx context.Context) error {
 	}
 
 	a.alertEngine.Start(ctx)
+	// Runs here too so DB-backed monitors are swept even without a container runtime.
+	a.pruneOrphanAlerts(ctx)
 
 	if extension.Allows(extension.CapAlertEscalation) {
 		go a.escalationSvc.RunRetentionLoop(ctx)

--- a/internal/app/lifecycle.go
+++ b/internal/app/lifecycle.go
@@ -34,27 +34,36 @@ import (
 const localTopologyReconcileInterval = 30 * time.Second
 
 // pruneOrphanAlerts resolves active alerts whose underlying entity no longer
-// exists: a container that was removed, or an agent that was deleted while
-// already offline (its lifecycle hook never fired a recover at delete time, so
-// the disconnect alert lingered). Idempotent — safe to run on every startup.
+// exists: a container that was removed, an agent deleted while already offline,
+// or a heartbeat/endpoint/certificate monitor deleted before its alert was
+// resolved. Idempotent, safe to run on every startup.
 func (a *App) pruneOrphanAlerts(ctx context.Context) {
 	activeAlerts, err := a.alertStore.ListActiveAlerts(ctx)
 	if err != nil {
 		return
 	}
 	for _, al := range activeAlerts {
+		var orphan bool
 		switch al.EntityType {
 		case "container":
 			c, err := a.containerSvc.GetContainer(ctx, al.EntityID)
-			if err != nil || c == nil {
-				a.alertEngine.ResolveByEntity(ctx, "container", al.EntityID)
-				a.logger.Info("pruned orphan container alert", "alert_id", al.ID, "entity_id", al.EntityID)
-			}
+			orphan = err != nil || c == nil
 		case "agent":
-			if _, err := a.agentStore.Get(ctx, al.EntityID); errors.Is(err, agent.ErrAgentNotFound) {
-				a.alertEngine.ResolveByEntity(ctx, "agent", al.EntityID)
-				a.logger.Info("pruned orphan agent alert", "alert_id", al.ID, "entity_id", al.EntityID)
-			}
+			_, err := a.agentStore.Get(ctx, al.EntityID)
+			orphan = errors.Is(err, agent.ErrAgentNotFound)
+		case "heartbeat":
+			h, err := a.hbStore.GetHeartbeatByID(ctx, al.EntityID)
+			orphan = err == nil && h == nil
+		case "endpoint":
+			ep, err := a.epStore.GetEndpointByID(ctx, al.EntityID)
+			orphan = err == nil && ep == nil
+		case "certificate":
+			m, err := a.certStore.GetMonitorByID(ctx, al.EntityID)
+			orphan = err == nil && m == nil
+		}
+		if orphan {
+			a.alertEngine.ResolveByEntity(ctx, al.EntityType, al.EntityID)
+			a.logger.Info("pruned orphan alert", "alert_id", al.ID, "entity_type", al.EntityType, "entity_id", al.EntityID)
 		}
 	}
 }

--- a/internal/app/prune_orphan_alerts_test.go
+++ b/internal/app/prune_orphan_alerts_test.go
@@ -24,6 +24,9 @@ import (
 
 	"github.com/kolapsis/maintenant/internal/agent"
 	"github.com/kolapsis/maintenant/internal/alert"
+	"github.com/kolapsis/maintenant/internal/certificate"
+	"github.com/kolapsis/maintenant/internal/endpoint"
+	"github.com/kolapsis/maintenant/internal/heartbeat"
 	"github.com/kolapsis/maintenant/internal/store/sqlite"
 )
 
@@ -88,4 +91,83 @@ func TestPruneOrphanAlerts_ResolvesDeletedAgent(t *testing.T) {
 	require.Len(t, active, 1, "the orphan agent alert must be resolved")
 	assert.Equal(t, "live-agent", active[0].EntityID, "the alert of the still-enrolled agent must remain active")
 	assert.Equal(t, 1, engine.AlertCount(), "engine in-memory map must drop the resolved alert")
+}
+
+// TestPruneOrphanAlerts_ResolvesDeletedMonitors covers the DB-backed monitors:
+// an alert whose heartbeat, endpoint or certificate monitor no longer exists is
+// resolved, while alerts of monitors that still exist are left untouched.
+func TestPruneOrphanAlerts_ResolvesDeletedMonitors(t *testing.T) {
+	ctx := context.Background()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	db, err := sqlite.Open(filepath.Join(t.TempDir(), "test.db"), logger)
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+	require.NoError(t, sqlite.Migrate(db.ReadDB(), logger))
+	db.StartWriter(ctx)
+
+	alertStore := sqlite.NewAlertStore(db)
+	hbStore := sqlite.NewHeartbeatStore(db)
+	epStore := sqlite.NewEndpointStore(db)
+	certStore := sqlite.NewCertificateStore(db)
+	engine := alert.NewEngine(alert.EngineDeps{
+		AlertStore:   alertStore,
+		ChannelStore: sqlite.NewChannelStore(db),
+		TriggerStore: sqlite.NewTriggerStore(db),
+		SilenceStore: sqlite.NewSilenceStore(db),
+		Logger:       logger,
+	})
+
+	hbID, err := hbStore.CreateHeartbeat(ctx, &heartbeat.Heartbeat{Name: "backup", IntervalSeconds: 60, GraceSeconds: 30})
+	require.NoError(t, err)
+	epID, err := epStore.UpsertEndpoint(ctx, &endpoint.Endpoint{
+		ContainerName: "web", LabelKey: "http", EndpointType: endpoint.TypeHTTP, Target: "http://web/health",
+	})
+	require.NoError(t, err)
+	certID, err := certStore.CreateMonitor(ctx, &certificate.CertMonitor{
+		Hostname: "example.com", Port: 443, Source: certificate.SourceStandalone,
+		Status: certificate.StatusValid, CheckIntervalSeconds: 3600, WarningThresholds: []int{30, 7},
+	})
+	require.NoError(t, err)
+
+	now := time.Now().Unix()
+	insertAlert := func(id, source, alertType, entityType, entityID string) {
+		_, err := db.Writer().Exec(ctx,
+			`INSERT INTO alerts (id, source, alert_type, severity, status, message,
+			 entity_type, entity_id, entity_name, fired_at, created_at)
+			 VALUES (?,?,?,'critical','active','down',?,?,'name',?,?)`,
+			id, source, alertType, entityType, entityID, now, now,
+		)
+		require.NoError(t, err)
+	}
+	insertAlert("hb-live", "heartbeat", "deadline_missed", "heartbeat", hbID)
+	insertAlert("hb-orphan", "heartbeat", "deadline_missed", "heartbeat", "deleted-heartbeat")
+	insertAlert("ep-live", "endpoint", "consecutive_failure", "endpoint", epID)
+	insertAlert("ep-orphan", "endpoint", "consecutive_failure", "endpoint", "deleted-endpoint")
+	insertAlert("cert-live", "certificate", "expiring", "certificate", certID)
+	insertAlert("cert-orphan", "certificate", "expiring", "certificate", "deleted-certificate")
+
+	engineCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	engine.Start(engineCtx)
+	require.Equal(t, 6, engine.AlertCount())
+
+	a := &App{
+		alertStore:  alertStore,
+		hbStore:     hbStore,
+		epStore:     epStore,
+		certStore:   certStore,
+		alertEngine: engine,
+		logger:      logger,
+	}
+	a.pruneOrphanAlerts(ctx)
+
+	active, err := alertStore.ListActiveAlerts(ctx)
+	require.NoError(t, err)
+	var remaining []string
+	for _, al := range active {
+		remaining = append(remaining, al.ID)
+	}
+	assert.ElementsMatch(t, []string{"hb-live", "ep-live", "cert-live"}, remaining)
+	assert.Equal(t, 3, engine.AlertCount())
 }

--- a/internal/app/wiring.go
+++ b/internal/app/wiring.go
@@ -265,8 +265,9 @@ func (a *App) wireAlertCallbacks(alertDetector *alert.EndpointAlertDetector) {
 		}
 	})
 
-	// Endpoint removal → certificate monitor cleanup + status component dangling ref cleanup.
+	// Endpoint removal → alert, certificate monitor and status component cleanup.
 	a.endpointSvc.SetEndpointRemovedCallback(func(callCtx context.Context, endpointID string) {
+		a.alertEngine.ResolveByEntity(callCtx, "endpoint", endpointID)
 		a.certSvc.DeleteByEndpointID(callCtx, endpointID)
 		if err := a.statusCompStore.RemoveDanglingMonitorRefs(callCtx, "endpoint", endpointID); err != nil {
 			a.logger.Error("failed to remove dangling endpoint refs from status components", "endpoint_id", endpointID, "error", err)
@@ -318,6 +319,7 @@ func (a *App) wireAlertCallbacks(alertDetector *alert.EndpointAlertDetector) {
 
 		if eventType == event.CertificateDeleted {
 			certID := toString(m["monitor_id"])
+			a.alertEngine.ResolveByEntity(ctx, "certificate", certID)
 			if err := a.statusCompStore.RemoveDanglingMonitorRefs(ctx, "certificate", certID); err != nil {
 				a.logger.Error("failed to remove dangling certificate refs from status components", "certificate_id", certID, "error", err)
 			}

--- a/internal/app/wiring.go
+++ b/internal/app/wiring.go
@@ -26,6 +26,42 @@ import (
 	"github.com/kolapsis/maintenant/internal/security"
 )
 
+// heartbeatAlertEvents builds the alert events for a heartbeat callback. A recovery
+// clears both failure keys (the engine ignores the one not active). Caller sets Timestamp.
+func heartbeatAlertEvents(h *heartbeat.Heartbeat, alertType string, details map[string]any) []alert.Event {
+	build := func(t string, isRecover bool, severity, message string) alert.Event {
+		return alert.Event{
+			Source:     alert.SourceHeartbeat,
+			AlertType:  t,
+			Severity:   severity,
+			IsRecover:  isRecover,
+			Message:    message,
+			EntityType: "heartbeat",
+			EntityID:   h.ID,
+			EntityName: h.Name,
+			Details:    details,
+		}
+	}
+
+	if alertType == "recovery" {
+		msg := fmt.Sprintf("Heartbeat '%s' recovered", h.Name)
+		return []alert.Event{
+			build(heartbeat.AlertTypeDeadlineMissed, true, alert.SeverityInfo, msg),
+			build(heartbeat.AlertTypeExitCodeFailure, true, alert.SeverityInfo, msg),
+		}
+	}
+
+	hbAlertType := heartbeat.AlertTypeDeadlineMissed
+	if t, ok := details["alert_type"].(string); ok {
+		hbAlertType = t
+	}
+	msg := fmt.Sprintf("Heartbeat '%s' missed deadline", h.Name)
+	if hbAlertType == heartbeat.AlertTypeExitCodeFailure {
+		msg = fmt.Sprintf("Heartbeat '%s' failed with exit code %v", h.Name, details["exit_code"])
+	}
+	return []alert.Event{build(hbAlertType, false, alert.SeverityCritical, msg)}
+}
+
 // wireAlertCallbacks wires all service event callbacks for SSE broadcasting,
 // alert event forwarding, and status page integration.
 func (a *App) wireAlertCallbacks(alertDetector *alert.EndpointAlertDetector) {
@@ -240,41 +276,30 @@ func (a *App) wireAlertCallbacks(alertDetector *alert.EndpointAlertDetector) {
 	// Heartbeat alerts
 	a.heartbeatSvc.SetAlertCallback(func(h *heartbeat.Heartbeat, alertType string, details map[string]any) {
 		a.statusSvc.NotifyMonitorChanged(ctx, "heartbeat", h.ID)
-
-		isRecover := alertType == "recovery"
-		severity := alert.SeverityCritical
-		msg := fmt.Sprintf("Heartbeat '%s' missed deadline", h.Name)
-		if isRecover {
-			severity = alert.SeverityInfo
-			msg = fmt.Sprintf("Heartbeat '%s' recovered", h.Name)
+		for _, evt := range heartbeatAlertEvents(h, alertType, details) {
+			evt.Timestamp = time.Now()
+			sendAlert(evt)
 		}
-		hbAlertType := "deadline_missed"
-		if t, ok := details["alert_type"].(string); ok {
-			hbAlertType = t
-		}
-		sendAlert(alert.Event{
-			Source:     alert.SourceHeartbeat,
-			AlertType:  hbAlertType,
-			Severity:   severity,
-			IsRecover:  isRecover,
-			Message:    msg,
-			EntityType: "heartbeat",
-			EntityID:   h.ID,
-			EntityName: h.Name,
-			Details:    details,
-			Timestamp:  time.Now(),
-		})
 	})
 
 	// Heartbeat events
 	a.heartbeatSvc.SetEventCallback(func(eventType string, data any) {
 		a.broker.Broadcast(v1.SSEEvent{Type: eventType, Data: data})
-		if eventType == event.HeartbeatDeleted {
-			if m, ok := data.(map[string]any); ok {
-				hid := toString(m["heartbeat_id"])
-				if err := a.statusCompStore.RemoveDanglingMonitorRefs(ctx, "heartbeat", hid); err != nil {
-					a.logger.Error("failed to remove dangling heartbeat refs from status components", "heartbeat_id", hid, "error", err)
-				}
+		m, ok := data.(map[string]any)
+		if !ok {
+			return
+		}
+		switch eventType {
+		case event.HeartbeatDeleted:
+			hid := toString(m["heartbeat_id"])
+			a.alertEngine.ResolveByEntity(ctx, "heartbeat", hid)
+			if err := a.statusCompStore.RemoveDanglingMonitorRefs(ctx, "heartbeat", hid); err != nil {
+				a.logger.Error("failed to remove dangling heartbeat refs from status components", "heartbeat_id", hid, "error", err)
+			}
+		case event.HeartbeatStatusChanged:
+			// Pausing takes the heartbeat out of monitoring: clear its active alerts.
+			if newStatus, _ := m["new_status"].(string); newStatus == string(heartbeat.StatusPaused) {
+				a.alertEngine.ResolveByEntity(ctx, "heartbeat", toString(m["heartbeat_id"]))
 			}
 		}
 	})

--- a/internal/app/wiring_heartbeat_test.go
+++ b/internal/app/wiring_heartbeat_test.go
@@ -1,0 +1,79 @@
+// Copyright 2026 Benjamin Touchard (Kolapsis)
+//
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+// or a commercial license. You may not use this file except in compliance
+// with one of these licenses.
+//
+// AGPL-3.0: https://www.gnu.org/licenses/agpl-3.0.html
+// Commercial: See COMMERCIAL-LICENSE.md
+//
+// Source: https://github.com/kolapsis/maintenant
+
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kolapsis/maintenant/internal/alert"
+	"github.com/kolapsis/maintenant/internal/heartbeat"
+)
+
+// TestHeartbeatAlertEvents_Recovery_ClearsBothAlertTypes pins FIX 3c/3d: a single
+// recovery must clear both dedup keys a failing ping can have used (deadline_missed
+// and exit_code_failure), since the engine resolves by exact key.
+func TestHeartbeatAlertEvents_Recovery_ClearsBothAlertTypes(t *testing.T) {
+	h := &heartbeat.Heartbeat{ID: "hb-1", Name: "backup"}
+
+	events := heartbeatAlertEvents(h, "recovery", map[string]any{"heartbeat_id": "hb-1"})
+
+	require.Len(t, events, 2)
+	types := map[string]bool{}
+	for _, evt := range events {
+		types[evt.AlertType] = true
+		assert.True(t, evt.IsRecover)
+		assert.Equal(t, alert.SeverityInfo, evt.Severity)
+		assert.Equal(t, "Heartbeat 'backup' recovered", evt.Message)
+		assert.Equal(t, alert.SourceHeartbeat, evt.Source)
+		assert.Equal(t, "heartbeat", evt.EntityType)
+		assert.Equal(t, "hb-1", evt.EntityID)
+	}
+	assert.True(t, types[heartbeat.AlertTypeDeadlineMissed])
+	assert.True(t, types[heartbeat.AlertTypeExitCodeFailure])
+}
+
+// TestHeartbeatAlertEvents_DeadlineMissed pins the default failure path: no
+// alert_type in details means a missed deadline.
+func TestHeartbeatAlertEvents_DeadlineMissed(t *testing.T) {
+	h := &heartbeat.Heartbeat{ID: "hb-2", Name: "nightly-backup"}
+
+	events := heartbeatAlertEvents(h, "alert", map[string]any{"heartbeat_id": "hb-2"})
+
+	require.Len(t, events, 1)
+	evt := events[0]
+	assert.False(t, evt.IsRecover)
+	assert.Equal(t, alert.SeverityCritical, evt.Severity)
+	assert.Equal(t, heartbeat.AlertTypeDeadlineMissed, evt.AlertType)
+	assert.Equal(t, "Heartbeat 'nightly-backup' missed deadline", evt.Message)
+}
+
+// TestHeartbeatAlertEvents_ExitCodeFailure pins the exit-code failure path: a
+// distinct alert_type and a message naming the exit code.
+func TestHeartbeatAlertEvents_ExitCodeFailure(t *testing.T) {
+	h := &heartbeat.Heartbeat{ID: "hb-3", Name: "etl-job"}
+
+	events := heartbeatAlertEvents(h, "alert", map[string]any{
+		"heartbeat_id": "hb-3",
+		"alert_type":   heartbeat.AlertTypeExitCodeFailure,
+		"exit_code":    2,
+	})
+
+	require.Len(t, events, 1)
+	evt := events[0]
+	assert.False(t, evt.IsRecover)
+	assert.Equal(t, alert.SeverityCritical, evt.Severity)
+	assert.Equal(t, heartbeat.AlertTypeExitCodeFailure, evt.AlertType)
+	assert.Equal(t, "Heartbeat 'etl-job' failed with exit code 2", evt.Message)
+}

--- a/internal/heartbeat/model.go
+++ b/internal/heartbeat/model.go
@@ -41,6 +41,12 @@ const (
 	PingExitCode PingType = "exit_code"
 )
 
+// Heartbeat alert types (Source is always SourceHeartbeat in internal/alert).
+const (
+	AlertTypeDeadlineMissed  = "deadline_missed"
+	AlertTypeExitCodeFailure = "exit_code_failure"
+)
+
 // ExecutionOutcome represents the result of a job execution.
 type ExecutionOutcome string
 

--- a/internal/heartbeat/service.go
+++ b/internal/heartbeat/service.go
@@ -301,10 +301,11 @@ func (s *Service) ProcessPing(ctx context.Context, token string, sourceIP, httpM
 		}
 	}
 
-	// Update state
+	// Update state. Recover from a missed deadline or from an alerting state left
+	// by a start/finish pair (down -> start -> finish never crosses StatusDown here).
 	alertState := h.AlertState
-	wasDown := previousStatus == StatusDown
-	if wasDown {
+	recovering := previousStatus == StatusDown || h.AlertState == AlertAlerting
+	if recovering {
 		alertState = AlertNormal
 	}
 
@@ -333,7 +334,7 @@ func (s *Service) ProcessPing(ctx context.Context, token string, sourceIP, httpM
 	}
 
 	// Recovery alert
-	if wasDown {
+	if recovering {
 		s.emitEvent(event.HeartbeatRecovery, map[string]interface{}{
 			"heartbeat_id": h.ID,
 			"name":         h.Name,
@@ -544,7 +545,7 @@ func (s *Service) ProcessExitCodePing(ctx context.Context, token string, exitCod
 		s.emitEvent(event.HeartbeatAlert, map[string]interface{}{
 			"heartbeat_id": h.ID,
 			"name":         h.Name,
-			"alert_type":   "exit_code_failure",
+			"alert_type":   AlertTypeExitCodeFailure,
 			"details":      fmt.Sprintf("exit code %d", exitCode),
 		})
 		if s.alertCallback != nil {
@@ -552,6 +553,8 @@ func (s *Service) ProcessExitCodePing(ctx context.Context, token string, exitCod
 				"heartbeat_id": h.ID,
 				"name":         h.Name,
 				"exit_code":    exitCode,
+				"alert_type":   AlertTypeExitCodeFailure,
+				"message":      fmt.Sprintf("exit code %d", exitCode),
 			})
 		}
 	} else if previousStatus == StatusDown || h.AlertState == AlertAlerting {
@@ -640,7 +643,7 @@ func (s *Service) checkDeadlines(ctx context.Context) {
 		s.emitEvent(event.HeartbeatAlert, map[string]interface{}{
 			"heartbeat_id": h.ID,
 			"name":         h.Name,
-			"alert_type":   "deadline_missed",
+			"alert_type":   AlertTypeDeadlineMissed,
 			"details":      alertMsg,
 		})
 
@@ -648,7 +651,7 @@ func (s *Service) checkDeadlines(ctx context.Context) {
 			s.alertCallback(h, "alert", map[string]interface{}{
 				"heartbeat_id": h.ID,
 				"name":         h.Name,
-				"alert_type":   "deadline_missed",
+				"alert_type":   AlertTypeDeadlineMissed,
 				"message":      alertMsg,
 			})
 		}

--- a/internal/heartbeat/service_test.go
+++ b/internal/heartbeat/service_test.go
@@ -602,6 +602,52 @@ func TestService_ProcessPing_StartedToUpCompletionCalculatesDuration(t *testing.
 	assert.NotNil(t, execs[0].CompletedAt)
 }
 
+func TestService_ProcessPing_DownStartFinish_RecoversOnCompletion(t *testing.T) {
+	store := newMockStore()
+
+	var alertCalls []string
+	svc := newService(store, &mockLicense{canCreate: true})
+	svc.SetAlertCallback(func(_ *Heartbeat, alertType string, _ map[string]interface{}) {
+		alertCalls = append(alertCalls, alertType)
+	})
+
+	seedHeartbeat(store, "uuid-startfinish-1", StatusDown, AlertAlerting)
+
+	_, err := svc.ProcessStartPing(context.Background(), "uuid-startfinish-1", "127.0.0.1", "GET")
+	require.NoError(t, err)
+	assert.Empty(t, alertCalls, "the start ping alone must not emit a recovery")
+
+	result, err := svc.ProcessPing(context.Background(), "uuid-startfinish-1", "127.0.0.1", "GET", nil, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, StatusUp, result.Status)
+	assert.Equal(t, AlertNormal, result.AlertState)
+	require.Len(t, alertCalls, 1, "the completion ping after down->start must emit exactly one recovery")
+	assert.Equal(t, "recovery", alertCalls[0])
+}
+
+func TestService_ProcessPing_UpButAlerting_EmitsRecoveryAndResetsAlertState(t *testing.T) {
+	store := newMockStore()
+
+	var alertCalls []string
+	svc := newService(store, &mockLicense{canCreate: true})
+	svc.SetAlertCallback(func(_ *Heartbeat, alertType string, _ map[string]interface{}) {
+		alertCalls = append(alertCalls, alertType)
+	})
+
+	// Status is already "up" (e.g. after the fix to ProcessExitCodePing/ProcessPing
+	// itself), but AlertState is stuck "alerting" from an earlier failure mode.
+	seedHeartbeat(store, "uuid-stale-alerting-1", StatusUp, AlertAlerting)
+
+	result, err := svc.ProcessPing(context.Background(), "uuid-stale-alerting-1", "127.0.0.1", "GET", nil, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, StatusUp, result.Status)
+	assert.Equal(t, AlertNormal, result.AlertState)
+	require.Len(t, alertCalls, 1, "a stale alerting state must be cleared by the next successful ping")
+	assert.Equal(t, "recovery", alertCalls[0])
+}
+
 func TestService_ProcessPing_UnknownUUID(t *testing.T) {
 	store := newMockStore()
 	svc := newService(store, &mockLicense{canCreate: true})
@@ -718,6 +764,26 @@ func TestService_ProcessExitCodePing_NonZeroExitCodeFiresAlert(t *testing.T) {
 
 	require.Len(t, alertCalls, 1)
 	assert.Equal(t, "alert", alertCalls[0])
+}
+
+func TestService_ProcessExitCodePing_AlertTypeIsExitCodeFailure(t *testing.T) {
+	store := newMockStore()
+
+	var gotDetails map[string]interface{}
+	svc := newService(store, &mockLicense{canCreate: true})
+	svc.SetAlertCallback(func(_ *Heartbeat, alertType string, details map[string]interface{}) {
+		if alertType == "alert" {
+			gotDetails = details
+		}
+	})
+
+	seedHeartbeat(store, "uuid-exit-alerttype-1", StatusUp, AlertNormal)
+
+	_, err := svc.ProcessExitCodePing(context.Background(), "uuid-exit-alerttype-1", 7, "127.0.0.1", "GET", nil)
+	require.NoError(t, err)
+
+	require.NotNil(t, gotDetails)
+	assert.Equal(t, AlertTypeExitCodeFailure, gotDetails["alert_type"])
 }
 
 func TestService_ProcessExitCodePing_ConsecutiveFailuresIncrement(t *testing.T) {

--- a/internal/mcp/tools_read.go
+++ b/internal/mcp/tools_read.go
@@ -50,7 +50,7 @@ func registerReadTools(server *gomcp.Server, svc *Services) {
 
 	gomcp.AddTool(server, &gomcp.Tool{
 		Name:        "list_alerts",
-		Description: "List alerts. By default returns only active (unresolved) alerts. Set active_only to false to include recent resolved alerts.",
+		Description: "List alerts. By default returns only active (unresolved) alerts. Set active_only to false to also return recent resolved and silenced alerts (last 100).",
 		Annotations: &gomcp.ToolAnnotations{ReadOnlyHint: true},
 	}, listAlertsHandler(svc))
 
@@ -123,7 +123,7 @@ type getContainerLogsInput struct {
 	Timestamps  bool   `json:"timestamps,omitempty" jsonschema:"Include timestamps in log output"`
 }
 type listAlertsInput struct {
-	ActiveOnly bool `json:"active_only,omitempty" jsonschema:"Only return active alerts, default true"`
+	ActiveOnly *bool `json:"active_only,omitempty" jsonschema:"Only return active alerts, default true"`
 }
 type getResourcesInput struct{}
 type getTopConsumersInput struct {
@@ -236,8 +236,8 @@ func getContainerLogsHandler(svc *Services) gomcp.ToolHandlerFor[getContainerLog
 
 func listAlertsHandler(svc *Services) gomcp.ToolHandlerFor[listAlertsInput, any] {
 	return func(ctx context.Context, _ *gomcp.CallToolRequest, input listAlertsInput) (*gomcp.CallToolResult, any, error) {
-		// Default to active only
-		if input.ActiveOnly || input == (listAlertsInput{}) {
+		// Default (nil) and explicit true both mean active only.
+		if input.ActiveOnly == nil || *input.ActiveOnly {
 			alerts, err := svc.Alerts.ListActiveAlerts(ctx)
 			if err != nil {
 				return nil, nil, fmt.Errorf("failed to list active alerts: %w", err)

--- a/internal/mcp/tools_read_test.go
+++ b/internal/mcp/tools_read_test.go
@@ -12,9 +12,12 @@
 package mcp
 
 import (
+	"context"
 	"encoding/json"
+	"log/slog"
 	"testing"
 
+	"github.com/kolapsis/maintenant/internal/alert"
 	"github.com/kolapsis/maintenant/internal/uid"
 	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/assert"
@@ -139,18 +142,61 @@ func TestErrResult_InvalidInput(t *testing.T) {
 	assert.Equal(t, "invalid input: container_id must be a valid integer", textFromContent(t, result.Content))
 }
 
-func TestListAlertsInput_DefaultsToActiveOnly(t *testing.T) {
-	// When the input is zero-valued (no fields set), the handler defaults to active-only.
-	// The handler checks: input.ActiveOnly || input == (listAlertsInput{})
-	// So a zero-valued struct triggers the active-only path.
-	input := listAlertsInput{}
-	zeroValue := listAlertsInput{}
-	assert.Equal(t, zeroValue, input, "zero-valued input should be equal to default")
+// mcpListAlertsSpy wraps mcpAlertStore to record which listing method the
+// handler called, so the active_only tri-state (nil/true/false) can be pinned.
+type mcpListAlertsSpy struct {
+	*mcpAlertStore
+	activeOnlyCalled bool
+	listAlertsCalled bool
+	listAlertsOpts   alert.ListAlertsOpts
 }
 
-func TestListAlertsInput_ExplicitActiveOnly(t *testing.T) {
-	input := listAlertsInput{ActiveOnly: true}
-	assert.True(t, input.ActiveOnly)
+func newMCPListAlertsSpy() *mcpListAlertsSpy {
+	return &mcpListAlertsSpy{mcpAlertStore: newMCPAlertStore()}
+}
+
+func (m *mcpListAlertsSpy) ListActiveAlerts(ctx context.Context) ([]*alert.Alert, error) {
+	m.activeOnlyCalled = true
+	return m.mcpAlertStore.ListActiveAlerts(ctx)
+}
+
+func (m *mcpListAlertsSpy) ListAlerts(ctx context.Context, opts alert.ListAlertsOpts) ([]*alert.Alert, error) {
+	m.listAlertsCalled = true
+	m.listAlertsOpts = opts
+	return m.mcpAlertStore.ListAlerts(ctx, opts)
+}
+
+func TestListAlertsHandler_DefaultActiveOnly(t *testing.T) {
+	spy := newMCPListAlertsSpy()
+	svc := &Services{Alerts: spy, Logger: slog.Default(), Version: "test"}
+
+	_, _, err := listAlertsHandler(svc)(context.Background(), nil, listAlertsInput{})
+	require.NoError(t, err)
+	assert.True(t, spy.activeOnlyCalled, "nil active_only must default to ListActiveAlerts")
+	assert.False(t, spy.listAlertsCalled)
+}
+
+func TestListAlertsHandler_ExplicitActiveOnlyTrue(t *testing.T) {
+	spy := newMCPListAlertsSpy()
+	svc := &Services{Alerts: spy, Logger: slog.Default(), Version: "test"}
+	activeOnly := true
+
+	_, _, err := listAlertsHandler(svc)(context.Background(), nil, listAlertsInput{ActiveOnly: &activeOnly})
+	require.NoError(t, err)
+	assert.True(t, spy.activeOnlyCalled)
+	assert.False(t, spy.listAlertsCalled)
+}
+
+func TestListAlertsHandler_ActiveOnlyFalse_ReturnsAllStatuses(t *testing.T) {
+	spy := newMCPListAlertsSpy()
+	svc := &Services{Alerts: spy, Logger: slog.Default(), Version: "test"}
+	activeOnly := false
+
+	_, _, err := listAlertsHandler(svc)(context.Background(), nil, listAlertsInput{ActiveOnly: &activeOnly})
+	require.NoError(t, err)
+	assert.False(t, spy.activeOnlyCalled, "active_only:false must not call ListActiveAlerts")
+	assert.True(t, spy.listAlertsCalled)
+	assert.Equal(t, 100, spy.listAlertsOpts.Limit)
 }
 
 func TestGetContainerLogsInput_Defaults(t *testing.T) {

--- a/internal/store/sqlite/heartbeats.go
+++ b/internal/store/sqlite/heartbeats.go
@@ -203,8 +203,9 @@ func (s *HeartbeatStore) UpdateHeartbeatState(ctx context.Context, id string,
 
 func (s *HeartbeatStore) PauseHeartbeat(ctx context.Context, id string) error {
 	now := time.Now().Unix()
+	// Pausing stops monitoring, so alert_state must not stay stuck on alerting.
 	_, err := s.writer.Exec(ctx,
-		`UPDATE heartbeats SET status='paused', next_deadline_at=NULL, updated_at=? WHERE id=?`,
+		`UPDATE heartbeats SET status='paused', alert_state='normal', next_deadline_at=NULL, updated_at=? WHERE id=?`,
 		now, id)
 	if err != nil {
 		return fmt.Errorf("pause heartbeat %s: %w", id, err)

--- a/internal/store/sqlite/heartbeats_test.go
+++ b/internal/store/sqlite/heartbeats_test.go
@@ -1,0 +1,51 @@
+// Copyright 2026 Benjamin Touchard (Kolapsis)
+//
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+// or a commercial license. You may not use this file except in compliance
+// with one of these licenses.
+//
+// AGPL-3.0: https://www.gnu.org/licenses/agpl-3.0.html
+// Commercial: See COMMERCIAL-LICENSE.md
+//
+// Source: https://github.com/kolapsis/maintenant
+
+package sqlite
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kolapsis/maintenant/internal/heartbeat"
+)
+
+// PauseHeartbeat must clear alert_state so a heartbeat paused while alerting
+// does not stay "alerting" forever: the operator deliberately stopped monitoring.
+func TestPauseHeartbeat_ResetsAlertStateToNormal(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	store := NewHeartbeatStore(db)
+
+	h := &heartbeat.Heartbeat{
+		ID:              "hb-pause-1",
+		Name:            "job",
+		IntervalSeconds: 300,
+		GraceSeconds:    60,
+	}
+	_, err := store.CreateHeartbeat(ctx, h)
+	require.NoError(t, err)
+
+	// Simulate the heartbeat going down and alerting before it gets paused.
+	require.NoError(t, store.UpdateHeartbeatState(ctx, h.ID, heartbeat.StatusDown, heartbeat.AlertAlerting,
+		nil, nil, nil, nil, nil, 3, 0))
+
+	require.NoError(t, store.PauseHeartbeat(ctx, h.ID))
+
+	got, err := store.GetHeartbeatByID(ctx, h.ID)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, heartbeat.StatusPaused, got.Status)
+	assert.Equal(t, heartbeat.AlertNormal, got.AlertState, "pausing must reset alert_state to normal")
+}


### PR DESCRIPTION
When a heartbeat recovered, channels received the original alert record:
failure message, critical severity, red colour, with only
`event: alert.resolved` telling it apart. Some heartbeat alerts also stayed
active forever, and the MCP `list_alerts` tool could not return resolved ones.

- Recovery notifications are still routed by the original alert (a trigger
  on `critical` keeps receiving them) but carry the recovery message and
  `info` severity; id, resolved_at and resolved_by_id are unchanged.
- MCP `list_alerts`: `active_only: false` was indistinguishable from the
  zero value and always returned active alerts; the field is now a *bool.
- Heartbeats emit the recovery after a down -> start -> finish sequence
  (alert_state stayed `alerting` before), exit code failures are typed
  `exit_code_failure` with a matching message, delete and pause clear the
  active alerts.
- The startup sweep of orphan alerts now covers heartbeats, endpoints and
  certificate monitors and runs without a container runtime, so alerts left
  behind by 1.3.8 are resolved on the first restart. Endpoint and
  certificate deletion resolve their alerts immediately.

Verified: go test ./... green (new tests in alert, heartbeat, mcp, app,
store), golangci-lint clean.

Fixes #67. The per-trigger `notify_on_resolve` option suggested in the
issue comes in a separate PR.
