### PR TITLE
feat(alerts): let triggers opt out of recovery notifications

### DIFF
--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -161,6 +161,8 @@ Triggers route alerts to channels based on filters (severity, source, scope, tag
 
 Filters `filter_scopes` and `filter_tags` require Personal or above; `filter_severities` and `filter_sources` are available on every edition.
 
+`notify_on_resolve` (boolean, default `true`) controls whether the trigger also relays `alert.resolved` events; set it to `false` for a channel that should only receive failures.
+
 ---
 
 ## Escalation Policies :material-crown:{ title="Pro" }

--- a/docs/features/alerts.md
+++ b/docs/features/alerts.md
@@ -95,11 +95,14 @@ POST /api/v1/alert-triggers
   "filter_scopes": "",
   "filter_tags": "",
   "enabled": true,
+  "notify_on_resolve": true,
   "channel_ids": [3, 7]
 }
 ```
 
 Filters are CSV strings, combined in AND between fields and OR within a field. An empty filter matches everything. Multiple triggers can share the same channel without duplicating deliveries (the engine de-dupes per alert).
+
+A trigger relays both the initial alert and its recovery. Set `notify_on_resolve` to `false` (default `true`) for a channel that should only receive failures.
 
 **CE vs Pro filters** :
 

--- a/frontend/src/components/TriggerEditor.vue
+++ b/frontend/src/components/TriggerEditor.vue
@@ -44,6 +44,7 @@ const SOURCE_OPTIONS = ['container', 'endpoint', 'heartbeat', 'certificate', 'mo
 
 const name = ref(props.trigger?.name ?? '')
 const enabled = ref(props.trigger?.enabled ?? true)
+const notifyOnResolve = ref(props.trigger?.notify_on_resolve ?? true)
 const severities = ref<string[]>(toCsvArray(props.trigger?.filter_severities ?? ''))
 const sources = ref<string[]>(toCsvArray(props.trigger?.filter_sources ?? ''))
 const scopesCsv = ref(props.trigger?.filter_scopes ?? '')
@@ -58,6 +59,7 @@ watch(
   (t) => {
     name.value = t?.name ?? ''
     enabled.value = t?.enabled ?? true
+    notifyOnResolve.value = t?.notify_on_resolve ?? true
     severities.value = toCsvArray(t?.filter_severities ?? '')
     sources.value = toCsvArray(t?.filter_sources ?? '')
     scopesCsv.value = t?.filter_scopes ?? ''
@@ -119,6 +121,7 @@ async function handleSave() {
       filter_scopes: scopesCsv.value.trim(),
       filter_tags: tagsCsv.value.trim(),
       enabled: enabled.value,
+      notify_on_resolve: notifyOnResolve.value,
       channel_ids: selectedChannelIds.value,
     }
     if (props.trigger) {
@@ -205,6 +208,26 @@ async function handleSave() {
           <span
             class="pointer-events-none inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform"
             :class="enabled ? 'translate-x-4' : 'translate-x-0'"
+          />
+        </button>
+      </div>
+
+      <!-- Notify on recovery toggle -->
+      <div class="flex items-center justify-between">
+        <div>
+          <p class="text-sm font-medium text-mnt-secondary">Notify on recovery</p>
+          <p class="text-[10px] text-mnt-muted mt-0.5">
+            Also send a notification when the alert resolves.
+          </p>
+        </div>
+        <button
+          class="relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors focus:outline-none"
+          :class="notifyOnResolve ? 'bg-mnt-green-600' : 'bg-mnt-elevated'"
+          @click="notifyOnResolve = !notifyOnResolve"
+        >
+          <span
+            class="pointer-events-none inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform"
+            :class="notifyOnResolve ? 'translate-x-4' : 'translate-x-0'"
           />
         </button>
       </div>

--- a/frontend/src/components/TriggerList.vue
+++ b/frontend/src/components/TriggerList.vue
@@ -62,6 +62,11 @@ function summarizeFilter(t: AlertTrigger): string {
             v-if="!t.enabled"
             class="rounded px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wider bg-mnt-elevated text-mnt-muted"
           >disabled</span>
+          <span
+            v-if="!t.notify_on_resolve"
+            class="rounded px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wider bg-mnt-elevated text-mnt-muted"
+            title="This trigger only relays fires, not recoveries"
+          >fires only</span>
         </div>
         <p class="mt-1 text-[11px] text-mnt-muted">{{ summarizeFilter(t) }}</p>
         <p class="mt-1 text-[11px] text-mnt-muted">

--- a/frontend/src/components/TriggerManager.vue
+++ b/frontend/src/components/TriggerManager.vue
@@ -67,6 +67,7 @@ async function handleToggleEnabled(t: AlertTrigger) {
     filter_scopes: t.filter_scopes,
     filter_tags: t.filter_tags,
     enabled: !t.enabled,
+    notify_on_resolve: t.notify_on_resolve,
     channel_ids: t.channel_ids,
   })
 }

--- a/frontend/src/types/triggers.ts
+++ b/frontend/src/types/triggers.ts
@@ -17,6 +17,7 @@ export interface AlertTrigger {
   filter_scopes: string
   filter_tags: string
   enabled: boolean
+  notify_on_resolve: boolean
   channel_ids: string[]
   created_at: string
   updated_at: string
@@ -29,5 +30,6 @@ export interface TriggerRequest {
   filter_scopes: string
   filter_tags: string
   enabled: boolean
+  notify_on_resolve: boolean
   channel_ids: string[]
 }

--- a/internal/alert/engine.go
+++ b/internal/alert/engine.go
@@ -645,6 +645,9 @@ func (e *Engine) enqueueDelivery(ctx context.Context, ch *NotificationChannel, a
 // FilterTags is treated as no-op for now: Alert does not yet expose tags.
 // The match is enforced via filter_severities, filter_sources and filter_scopes.
 func matchesTrigger(t *AlertTrigger, a *Alert) bool {
+	if a.Status == StatusResolved && !t.NotifyOnResolve {
+		return false
+	}
 	if t.FilterSeverities != "" && !containsCSV(t.FilterSeverities, a.Severity) {
 		return false
 	}

--- a/internal/alert/engine_triggers_test.go
+++ b/internal/alert/engine_triggers_test.go
@@ -127,6 +127,35 @@ func fireEvent(eng *alert.Engine, severity, source, entityType string, entityID 
 	time.Sleep(150 * time.Millisecond)
 }
 
+func recoverEvent(eng *alert.Engine, severity, source, entityType string, entityID string) {
+	eng.EventChannel() <- alert.Event{
+		Source:     source,
+		AlertType:  "test",
+		Severity:   severity,
+		IsRecover:  true,
+		EntityType: entityType,
+		EntityID:   entityID,
+		EntityName: "test-entity",
+		Timestamp:  time.Now(),
+	}
+	time.Sleep(150 * time.Millisecond)
+}
+
+func seedTriggerNotifyOnResolve(t *testing.T, ts alert.TriggerStore, name string, notifyOnResolve bool, severities, sources string, channelIDs []string) string {
+	t.Helper()
+	trig := &alert.AlertTrigger{
+		Name:             name,
+		FilterSeverities: severities,
+		FilterSources:    sources,
+		Enabled:          true,
+		NotifyOnResolve:  notifyOnResolve,
+		ChannelIDs:       channelIDs,
+	}
+	id, err := ts.InsertTrigger(context.Background(), trig)
+	require.NoError(t, err)
+	return id
+}
+
 // T077 — E2E test 1: trigger matches → delivery created for each channel.
 func TestEngineDispatch_TriggerMatch_DeliveriesCreated(t *testing.T) {
 	ctx, cancel, db, alertStore, channelStore, triggerStore, _, eng := engineTestSetup(t)
@@ -272,4 +301,48 @@ func TestEngineDispatch_ReservedEscalationChannel_NoInitialDelivery(t *testing.T
 	triggersForCTO, err := triggerStore.ListTriggersForChannel(ctx, emailCTO)
 	require.NoError(t, err)
 	assert.Empty(t, triggersForCTO, "email-cto must have zero triggers (reserved-escalation pattern)")
+}
+
+// NotifyOnResolve=false: fire delivers, recovery does not.
+func TestEngineDispatch_NotifyOnResolveFalse_NoRecoveryDelivery(t *testing.T) {
+	ctx, cancel, db, alertStore, channelStore, triggerStore, _, eng := engineTestSetup(t)
+	_ = db
+	defer cancel()
+
+	chID := seedWebhookChannel(t, channelStore, "fires-only-ch", true)
+	seedTriggerNotifyOnResolve(t, triggerStore, "FiresOnly", false, "critical", "container", []string{chID})
+
+	fireEvent(eng, "critical", "container", "container", "80")
+
+	alerts, err := alertStore.ListActiveAlerts(ctx)
+	require.NoError(t, err)
+	require.Len(t, alerts, 1)
+	alertID := alerts[0].ID
+	assert.Equal(t, 1, countDeliveriesForChannel(t, channelStore, alertID, chID), "trigger must deliver the fire")
+
+	recoverEvent(eng, "critical", "container", "container", "80")
+
+	assert.Equal(t, 1, countDeliveriesForChannel(t, channelStore, alertID, chID), "trigger with notify_on_resolve=false must not deliver the recovery")
+}
+
+// NotifyOnResolve=true (default): both fire and recovery deliver.
+func TestEngineDispatch_NotifyOnResolveTrue_RecoveryDelivered(t *testing.T) {
+	ctx, cancel, db, alertStore, channelStore, triggerStore, _, eng := engineTestSetup(t)
+	_ = db
+	defer cancel()
+
+	chID := seedWebhookChannel(t, channelStore, "fires-and-recovers-ch", true)
+	seedTriggerNotifyOnResolve(t, triggerStore, "FiresAndRecovers", true, "critical", "container", []string{chID})
+
+	fireEvent(eng, "critical", "container", "container", "90")
+
+	alerts, err := alertStore.ListActiveAlerts(ctx)
+	require.NoError(t, err)
+	require.Len(t, alerts, 1)
+	alertID := alerts[0].ID
+	assert.Equal(t, 1, countDeliveriesForChannel(t, channelStore, alertID, chID), "trigger must deliver the fire")
+
+	recoverEvent(eng, "critical", "container", "container", "90")
+
+	assert.Equal(t, 2, countDeliveriesForChannel(t, channelStore, alertID, chID), "trigger with notify_on_resolve=true must also deliver the recovery")
 }

--- a/internal/alert/engine_triggers_test.go
+++ b/internal/alert/engine_triggers_test.go
@@ -98,6 +98,7 @@ func seedTriggerForChannel(t *testing.T, ts alert.TriggerStore, name string, ena
 		FilterSeverities: severities,
 		FilterSources:    sources,
 		Enabled:          enabled,
+		NotifyOnResolve:  true,
 		ChannelIDs:       channelIDs,
 	}
 	id, err := ts.InsertTrigger(context.Background(), trig)

--- a/internal/alert/model.go
+++ b/internal/alert/model.go
@@ -116,6 +116,7 @@ type AlertTrigger struct {
 	FilterScopes     string    `json:"filter_scopes"`
 	FilterTags       string    `json:"filter_tags"`
 	Enabled          bool      `json:"enabled"`
+	NotifyOnResolve  bool      `json:"notify_on_resolve"`
 	ChannelIDs       []string  `json:"channel_ids"`
 	CreatedAt        time.Time `json:"created_at"`
 	UpdatedAt        time.Time `json:"updated_at"`

--- a/internal/api/v1/alert_triggers.go
+++ b/internal/api/v1/alert_triggers.go
@@ -46,6 +46,7 @@ type triggerInput struct {
 	FilterScopes     string   `json:"filter_scopes"`
 	FilterTags       string   `json:"filter_tags"`
 	Enabled          *bool    `json:"enabled"`
+	NotifyOnResolve  *bool    `json:"notify_on_resolve"`
 	ChannelIDs       []string `json:"channel_ids"`
 }
 
@@ -107,6 +108,10 @@ func (h *AlertTriggerHandler) HandleCreateTrigger(w http.ResponseWriter, r *http
 	if input.Enabled != nil {
 		enabled = *input.Enabled
 	}
+	notifyOnResolve := true
+	if input.NotifyOnResolve != nil {
+		notifyOnResolve = *input.NotifyOnResolve
+	}
 
 	t := &alert.AlertTrigger{
 		Name:             input.Name,
@@ -115,6 +120,7 @@ func (h *AlertTriggerHandler) HandleCreateTrigger(w http.ResponseWriter, r *http
 		FilterScopes:     input.FilterScopes,
 		FilterTags:       input.FilterTags,
 		Enabled:          enabled,
+		NotifyOnResolve:  notifyOnResolve,
 		ChannelIDs:       input.ChannelIDs,
 	}
 
@@ -181,6 +187,10 @@ func (h *AlertTriggerHandler) HandleUpdateTrigger(w http.ResponseWriter, r *http
 	if input.Enabled != nil {
 		enabled = *input.Enabled
 	}
+	notifyOnResolve := existing.NotifyOnResolve
+	if input.NotifyOnResolve != nil {
+		notifyOnResolve = *input.NotifyOnResolve
+	}
 
 	existing.Name = input.Name
 	existing.FilterSeverities = input.FilterSeverities
@@ -188,6 +198,7 @@ func (h *AlertTriggerHandler) HandleUpdateTrigger(w http.ResponseWriter, r *http
 	existing.FilterScopes = input.FilterScopes
 	existing.FilterTags = input.FilterTags
 	existing.Enabled = enabled
+	existing.NotifyOnResolve = notifyOnResolve
 	existing.ChannelIDs = input.ChannelIDs
 
 	if err := h.triggerStore.UpdateTrigger(r.Context(), existing); err != nil {

--- a/internal/api/v1/alert_triggers_test.go
+++ b/internal/api/v1/alert_triggers_test.go
@@ -217,6 +217,32 @@ func TestHandleCreateTrigger_NameConflict(t *testing.T) {
 	assert.Contains(t, rec.Body.String(), "name_conflict")
 }
 
+func TestHandleCreateTrigger_NotifyOnResolve_DefaultsTrue(t *testing.T) {
+	h, ts := newTriggerHandler(true)
+	body := `{"name":"NoField","channel_ids":["1"]}`
+	req := httptest.NewRequest("POST", "/api/v1/alert-triggers", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	h.HandleCreateTrigger(rec, req)
+	assert.Equal(t, http.StatusCreated, rec.Code)
+	got := ts.triggers["1"]
+	require.NotNil(t, got)
+	assert.True(t, got.NotifyOnResolve)
+}
+
+func TestHandleCreateTrigger_NotifyOnResolve_False(t *testing.T) {
+	h, ts := newTriggerHandler(true)
+	body := `{"name":"FiresOnly","notify_on_resolve":false,"channel_ids":["1"]}`
+	req := httptest.NewRequest("POST", "/api/v1/alert-triggers", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	h.HandleCreateTrigger(rec, req)
+	assert.Equal(t, http.StatusCreated, rec.Code)
+	got := ts.triggers["1"]
+	require.NotNil(t, got)
+	assert.False(t, got.NotifyOnResolve)
+}
+
 func TestHandleCreateTrigger_ProFilterScopes_CommunityBlocked(t *testing.T) {
 	original := extension.CurrentEdition
 	extension.CurrentEdition = func() extension.Edition { return extension.Community }
@@ -276,6 +302,38 @@ func TestHandleUpdateTrigger_Happy(t *testing.T) {
 	h.HandleUpdateTrigger(rec, req)
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Contains(t, rec.Body.String(), "Updated")
+}
+
+func TestHandleUpdateTrigger_NotifyOnResolve_False(t *testing.T) {
+	h, ts := newTriggerHandler(true)
+	id := seedTrigger(t, ts, "Original")
+	body := `{"name":"Updated","notify_on_resolve":false,"channel_ids":["1"]}`
+	req := httptest.NewRequest("PUT", "/api/v1/alert-triggers/1", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.SetPathValue("id", id)
+	rec := httptest.NewRecorder()
+	h.HandleUpdateTrigger(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	got := ts.triggers[id]
+	require.NotNil(t, got)
+	assert.False(t, got.NotifyOnResolve)
+}
+
+func TestHandleUpdateTrigger_NotifyOnResolve_OmittedKeepsExisting(t *testing.T) {
+	h, ts := newTriggerHandler(true)
+	id := seedTrigger(t, ts, "Original")
+	ts.triggers[id].NotifyOnResolve = false
+
+	body := `{"name":"Updated","channel_ids":["1"]}`
+	req := httptest.NewRequest("PUT", "/api/v1/alert-triggers/1", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.SetPathValue("id", id)
+	rec := httptest.NewRecorder()
+	h.HandleUpdateTrigger(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	got := ts.triggers[id]
+	require.NotNil(t, got)
+	assert.False(t, got.NotifyOnResolve, "omitted field must keep the existing value")
 }
 
 func TestHandleUpdateTrigger_NotFound(t *testing.T) {

--- a/internal/mcp/tools_triggers.go
+++ b/internal/mcp/tools_triggers.go
@@ -44,7 +44,7 @@ func registerTriggerTools(server *gomcp.Server, svc *Services) {
 
 	gomcp.AddTool(server, &gomcp.Tool{
 		Name:        "create_trigger",
-		Description: "Create a new alert trigger. Scope and tag filters" + requires(extension.CapAlertAdvancedFilters),
+		Description: "Create a new alert trigger, notifying recoveries by default. Scope and tag filters" + requires(extension.CapAlertAdvancedFilters),
 	}, createTriggerHandler(svc))
 
 	gomcp.AddTool(server, &gomcp.Tool{
@@ -73,6 +73,7 @@ type triggerInput struct {
 	FilterScopes     string   `json:"filter_scopes" jsonschema:"CSV scope filter (e.g. 'container:42,endpoint:7'). Needs the advanced filters capability. Empty matches everything."`
 	FilterTags       string   `json:"filter_tags" jsonschema:"CSV tag filter. Needs the advanced filters capability. Empty matches everything."`
 	Enabled          bool     `json:"enabled" jsonschema:"Whether the trigger is active"`
+	NotifyOnResolve  *bool    `json:"notify_on_resolve,omitempty" jsonschema:"Relay recovery (resolved) notifications, default true"`
 	ChannelIDs       []string `json:"channel_ids" jsonschema:"Notification channel IDs (at least one required)"`
 }
 
@@ -165,6 +166,11 @@ func createTriggerHandler(svc *Services) gomcp.ToolHandlerFor[triggerInput, any]
 			}
 		}
 
+		notifyOnResolve := true
+		if input.NotifyOnResolve != nil {
+			notifyOnResolve = *input.NotifyOnResolve
+		}
+
 		t := &alert.AlertTrigger{
 			Name:             input.Name,
 			FilterSeverities: input.FilterSeverities,
@@ -172,6 +178,7 @@ func createTriggerHandler(svc *Services) gomcp.ToolHandlerFor[triggerInput, any]
 			FilterScopes:     input.FilterScopes,
 			FilterTags:       input.FilterTags,
 			Enabled:          input.Enabled,
+			NotifyOnResolve:  notifyOnResolve,
 			ChannelIDs:       input.ChannelIDs,
 		}
 		if _, err := svc.Triggers.InsertTrigger(ctx, t); err != nil {
@@ -219,6 +226,9 @@ func updateTriggerHandler(svc *Services) gomcp.ToolHandlerFor[updateTriggerInput
 		existing.FilterScopes = input.FilterScopes
 		existing.FilterTags = input.FilterTags
 		existing.Enabled = input.Enabled
+		if input.NotifyOnResolve != nil {
+			existing.NotifyOnResolve = *input.NotifyOnResolve
+		}
 		existing.ChannelIDs = input.ChannelIDs
 
 		if err := svc.Triggers.UpdateTrigger(ctx, existing); err != nil {

--- a/internal/mcp/tools_triggers_test.go
+++ b/internal/mcp/tools_triggers_test.go
@@ -246,6 +246,40 @@ func TestCreateTriggerHandler_ChannelNotFound(t *testing.T) {
 	assert.Contains(t, textFromContent(t, result.Content), "999")
 }
 
+func TestCreateTriggerHandler_NotifyOnResolve_DefaultsTrue(t *testing.T) {
+	svc, ts := buildTriggerServices()
+	handler := createTriggerHandler(svc)
+
+	result, _, err := handler(context.Background(), nil, triggerInput{
+		Name:       "NoField",
+		ChannelIDs: []string{"1"},
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	got := ts.triggers["1"]
+	require.NotNil(t, got)
+	assert.True(t, got.NotifyOnResolve)
+}
+
+func TestCreateTriggerHandler_NotifyOnResolve_False(t *testing.T) {
+	svc, ts := buildTriggerServices()
+	handler := createTriggerHandler(svc)
+
+	notifyOnResolve := false
+	result, _, err := handler(context.Background(), nil, triggerInput{
+		Name:            "FiresOnly",
+		NotifyOnResolve: &notifyOnResolve,
+		ChannelIDs:      []string{"1"},
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	got := ts.triggers["1"]
+	require.NotNil(t, got)
+	assert.False(t, got.NotifyOnResolve)
+}
+
 func TestCreateTriggerHandler_FilterScopes_CommunityBlocked(t *testing.T) {
 	original := extension.CurrentEdition
 	extension.CurrentEdition = func() extension.Edition { return extension.Community }
@@ -322,6 +356,56 @@ func TestUpdateTriggerHandler_Happy(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, result.IsError)
 	assert.Contains(t, textFromContent(t, result.Content), "AfterUpdate")
+}
+
+func TestUpdateTriggerHandler_NotifyOnResolve_False(t *testing.T) {
+	svc, ts := buildTriggerServices()
+	id, err := ts.InsertTrigger(context.Background(), &alert.AlertTrigger{
+		Name: "BeforeUpdate", Enabled: true, NotifyOnResolve: true, ChannelIDs: []string{"1"},
+	})
+	require.NoError(t, err)
+
+	notifyOnResolve := false
+	handler := updateTriggerHandler(svc)
+	result, _, err := handler(context.Background(), nil, updateTriggerInputWithID{
+		ID: id,
+		triggerInput: triggerInput{
+			Name:            "AfterUpdate",
+			Enabled:         true,
+			NotifyOnResolve: &notifyOnResolve,
+			ChannelIDs:      []string{"1"},
+		},
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	got := ts.triggers[id]
+	require.NotNil(t, got)
+	assert.False(t, got.NotifyOnResolve)
+}
+
+func TestUpdateTriggerHandler_NotifyOnResolve_OmittedKeepsExisting(t *testing.T) {
+	svc, ts := buildTriggerServices()
+	id, err := ts.InsertTrigger(context.Background(), &alert.AlertTrigger{
+		Name: "BeforeUpdate", Enabled: true, NotifyOnResolve: false, ChannelIDs: []string{"1"},
+	})
+	require.NoError(t, err)
+
+	handler := updateTriggerHandler(svc)
+	result, _, err := handler(context.Background(), nil, updateTriggerInputWithID{
+		ID: id,
+		triggerInput: triggerInput{
+			Name:       "AfterUpdate",
+			Enabled:    true,
+			ChannelIDs: []string{"1"},
+		},
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	got := ts.triggers[id]
+	require.NotNil(t, got)
+	assert.False(t, got.NotifyOnResolve, "omitted field must keep the existing value")
 }
 
 func TestUpdateTriggerHandler_NotFound(t *testing.T) {

--- a/internal/store/sqlite/migrations/28_alert_triggers_notify_on_resolve.down.sql
+++ b/internal/store/sqlite/migrations/28_alert_triggers_notify_on_resolve.down.sql
@@ -1,0 +1,2 @@
+-- Migration rollback is intentionally a no-op per the project convention
+-- (see 20_cert_ocsp.down.sql, 25_cert_sni.down.sql).

--- a/internal/store/sqlite/migrations/28_alert_triggers_notify_on_resolve.up.sql
+++ b/internal/store/sqlite/migrations/28_alert_triggers_notify_on_resolve.up.sql
@@ -1,0 +1,2 @@
+-- Lets a trigger opt out of recovery (alert.resolved) notifications, so a channel can receive failures only.
+ALTER TABLE alert_triggers ADD COLUMN notify_on_resolve INTEGER NOT NULL DEFAULT 1;

--- a/internal/store/sqlite/transform.go
+++ b/internal/store/sqlite/transform.go
@@ -423,9 +423,9 @@ func copyStatements() []stmt {
 
 		// -------- alert triggers (minted) + channels join -----------------------
 		{"alert_triggers", `INSERT INTO alert_triggers
-			(id, name, filter_severities, filter_sources, filter_scopes, filter_tags, enabled, created_at, updated_at)
+			(id, name, filter_severities, filter_sources, filter_scopes, filter_tags, enabled, notify_on_resolve, created_at, updated_at)
 			SELECT mt.new_id, t.name, t.filter_severities, t.filter_sources, t.filter_scopes, t.filter_tags,
-			 t.enabled, ` + epoch("t.created_at") + `, ` + epoch("t.updated_at") + `
+			 t.enabled, t.notify_on_resolve, ` + epoch("t.created_at") + `, ` + epoch("t.updated_at") + `
 			FROM _old_alert_triggers t JOIN _map_trigger mt ON t.id = mt.old_id`},
 
 		{"alert_trigger_channels", `INSERT INTO alert_trigger_channels (trigger_id, channel_id)

--- a/internal/store/sqlite/triggers.go
+++ b/internal/store/sqlite/triggers.go
@@ -42,9 +42,9 @@ func (s *TriggerStoreImpl) InsertTrigger(ctx context.Context, t *alert.AlertTrig
 	now := time.Now().Unix()
 	_, err := s.writer.Exec(ctx,
 		`INSERT INTO alert_triggers
-			(id, name, filter_severities, filter_sources, filter_scopes, filter_tags, enabled, created_at, updated_at)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		t.ID, t.Name, t.FilterSeverities, t.FilterSources, t.FilterScopes, t.FilterTags, boolToInt(t.Enabled), now, now,
+			(id, name, filter_severities, filter_sources, filter_scopes, filter_tags, enabled, notify_on_resolve, created_at, updated_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		t.ID, t.Name, t.FilterSeverities, t.FilterSources, t.FilterScopes, t.FilterTags, boolToInt(t.Enabled), boolToInt(t.NotifyOnResolve), now, now,
 	)
 	if err != nil {
 		return "", fmt.Errorf("insert trigger: %w", err)
@@ -58,7 +58,7 @@ func (s *TriggerStoreImpl) InsertTrigger(ctx context.Context, t *alert.AlertTrig
 func (s *TriggerStoreImpl) GetTrigger(ctx context.Context, id string) (*alert.AlertTrigger, error) {
 	row := s.db.QueryRowContext(ctx,
 		`SELECT id, name, filter_severities, filter_sources, filter_scopes, filter_tags,
-			enabled, created_at, updated_at
+			enabled, notify_on_resolve, created_at, updated_at
 			FROM alert_triggers WHERE id = ?`, id)
 
 	t, err := scanTrigger(row)
@@ -89,7 +89,7 @@ func (s *TriggerStoreImpl) ListEnabledTriggers(ctx context.Context) ([]*alert.Al
 func (s *TriggerStoreImpl) listTriggersWhere(ctx context.Context, where string) ([]*alert.AlertTrigger, error) {
 	// #nosec G202 -- `where` is a package-internal constant, never caller input.
 	query := `SELECT id, name, filter_severities, filter_sources, filter_scopes, filter_tags,
-		enabled, created_at, updated_at
+		enabled, notify_on_resolve, created_at, updated_at
 		FROM alert_triggers ` + where + ` ORDER BY created_at ASC`
 
 	rows, err := s.db.QueryContext(ctx, query)
@@ -126,10 +126,10 @@ func (s *TriggerStoreImpl) UpdateTrigger(ctx context.Context, t *alert.AlertTrig
 	_, err := s.writer.Exec(ctx,
 		`UPDATE alert_triggers
 			SET name=?, filter_severities=?, filter_sources=?, filter_scopes=?, filter_tags=?,
-				enabled=?, updated_at=?
+				enabled=?, notify_on_resolve=?, updated_at=?
 			WHERE id=?`,
 		t.Name, t.FilterSeverities, t.FilterSources, t.FilterScopes, t.FilterTags,
-		boolToInt(t.Enabled), time.Now().Unix(), t.ID,
+		boolToInt(t.Enabled), boolToInt(t.NotifyOnResolve), time.Now().Unix(), t.ID,
 	)
 	if err != nil {
 		return fmt.Errorf("update trigger: %w", err)
@@ -202,7 +202,7 @@ func (s *TriggerStoreImpl) ListChannelsForTrigger(ctx context.Context, triggerID
 func (s *TriggerStoreImpl) ListTriggersForChannel(ctx context.Context, channelID string) ([]*alert.AlertTrigger, error) {
 	rows, err := s.db.QueryContext(ctx,
 		`SELECT t.id, t.name, t.filter_severities, t.filter_sources, t.filter_scopes, t.filter_tags,
-			t.enabled, t.created_at, t.updated_at
+			t.enabled, t.notify_on_resolve, t.created_at, t.updated_at
 			FROM alert_triggers t
 			JOIN alert_trigger_channels atc ON atc.trigger_id = t.id
 			WHERE atc.channel_id = ?
@@ -240,14 +240,15 @@ func (s *TriggerStoreImpl) ListTriggersForChannel(ctx context.Context, channelID
 
 func scanTrigger(row *sql.Row) (*alert.AlertTrigger, error) {
 	t := &alert.AlertTrigger{}
-	var enabled int
+	var enabled, notifyOnResolve int
 	var createdAt, updatedAt int64
 	err := row.Scan(&t.ID, &t.Name, &t.FilterSeverities, &t.FilterSources,
-		&t.FilterScopes, &t.FilterTags, &enabled, &createdAt, &updatedAt)
+		&t.FilterScopes, &t.FilterTags, &enabled, &notifyOnResolve, &createdAt, &updatedAt)
 	if err != nil {
 		return nil, err
 	}
 	t.Enabled = enabled == 1
+	t.NotifyOnResolve = notifyOnResolve == 1
 	t.CreatedAt = time.Unix(createdAt, 0)
 	t.UpdatedAt = time.Unix(updatedAt, 0)
 	return t, nil
@@ -255,14 +256,15 @@ func scanTrigger(row *sql.Row) (*alert.AlertTrigger, error) {
 
 func scanTriggerRow(rows *sql.Rows) (*alert.AlertTrigger, error) {
 	t := &alert.AlertTrigger{}
-	var enabled int
+	var enabled, notifyOnResolve int
 	var createdAt, updatedAt int64
 	err := rows.Scan(&t.ID, &t.Name, &t.FilterSeverities, &t.FilterSources,
-		&t.FilterScopes, &t.FilterTags, &enabled, &createdAt, &updatedAt)
+		&t.FilterScopes, &t.FilterTags, &enabled, &notifyOnResolve, &createdAt, &updatedAt)
 	if err != nil {
 		return nil, err
 	}
 	t.Enabled = enabled == 1
+	t.NotifyOnResolve = notifyOnResolve == 1
 	t.CreatedAt = time.Unix(createdAt, 0)
 	t.UpdatedAt = time.Unix(updatedAt, 0)
 	return t, nil

--- a/internal/store/sqlite/triggers_test.go
+++ b/internal/store/sqlite/triggers_test.go
@@ -53,6 +53,7 @@ func setupTriggerTestDB(t *testing.T) (*TriggerStoreImpl, *sql.DB) {
 			filter_scopes     TEXT    NOT NULL DEFAULT '',
 			filter_tags       TEXT    NOT NULL DEFAULT '',
 			enabled           INTEGER NOT NULL DEFAULT 1 CHECK (enabled IN (0,1)),
+			notify_on_resolve INTEGER NOT NULL DEFAULT 1 CHECK (notify_on_resolve IN (0,1)),
 			created_at        BIGINT  NOT NULL DEFAULT 0,
 			updated_at        BIGINT  NOT NULL DEFAULT 0
 		);
@@ -97,6 +98,7 @@ func TestTriggerStore_InsertAndGet(t *testing.T) {
 		FilterSeverities: "critical",
 		FilterSources:    "container",
 		Enabled:          true,
+		NotifyOnResolve:  true,
 		ChannelIDs:       []string{chID},
 	}
 	id, err := store.InsertTrigger(ctx, trig)
@@ -110,7 +112,32 @@ func TestTriggerStore_InsertAndGet(t *testing.T) {
 	assert.Equal(t, "critical", got.FilterSeverities)
 	assert.Equal(t, "container", got.FilterSources)
 	assert.True(t, got.Enabled)
+	assert.True(t, got.NotifyOnResolve)
 	assert.Equal(t, []string{chID}, got.ChannelIDs)
+}
+
+func TestTriggerStore_NotifyOnResolve_RoundTrip(t *testing.T) {
+	store, rawDB := setupTriggerTestDB(t)
+	ctx := context.Background()
+
+	chID := seedChannelForTrigger(t, rawDB, "notify-ch")
+
+	trig := &alert.AlertTrigger{Name: "FiresOnly", Enabled: true, NotifyOnResolve: false, ChannelIDs: []string{chID}}
+	id, err := store.InsertTrigger(ctx, trig)
+	require.NoError(t, err)
+
+	got, err := store.GetTrigger(ctx, id)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.False(t, got.NotifyOnResolve)
+
+	got.NotifyOnResolve = true
+	require.NoError(t, store.UpdateTrigger(ctx, got))
+
+	got, err = store.GetTrigger(ctx, id)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.True(t, got.NotifyOnResolve)
 }
 
 func TestTriggerStore_GetNotFound(t *testing.T) {

--- a/internal/store/sqlite/uuid_schema.sql
+++ b/internal/store/sqlite/uuid_schema.sql
@@ -393,6 +393,7 @@ CREATE TABLE alert_triggers (
     filter_scopes     TEXT NOT NULL DEFAULT '',
     filter_tags       TEXT NOT NULL DEFAULT '',
     enabled       INTEGER NOT NULL DEFAULT 1 CHECK(enabled IN (0,1)),
+    notify_on_resolve INTEGER NOT NULL DEFAULT 1 CHECK(notify_on_resolve IN (0,1)),
     created_at    BIGINT NOT NULL DEFAULT 0,
     updated_at    BIGINT NOT NULL DEFAULT 0
 );


### PR DESCRIPTION
Triggers are evaluated twice per alert, at fire and at recovery, with no
way to say "failures only". This adds `notify_on_resolve` (boolean,
default true) to alert triggers, as suggested in #67.

- Migration 28 adds the column; uuid_schema.sql and the UUID transform
  carry it.
- The engine skips `alert.resolved` for triggers that opted out
  (matchesTrigger); fires are unaffected.
- REST and MCP accept `notify_on_resolve`: omitted means true on create
  and unchanged on update.
- The trigger editor gets a "Notify on recovery" toggle and the list
  shows a "fires only" badge.
- Docs updated (alerts feature page, API reference).

Replaces #69, which was merged into fix/heartbeat-recovery-alerts by
mistake instead of main. Verified: go test ./..., vue-tsc and
golangci-lint clean.

Refs #67.
