### PR TITLE
style(compose): write environment and build args as mappings, not lists

### DIFF
--- a/compose.authproxy.yml
+++ b/compose.authproxy.yml
@@ -22,10 +22,10 @@ services:
     build:
       context: .
       args:
-        - VERSION=dev
-        - COMMIT=xxxxx
-        - BUILD_DATE=2026-03-01
-        - LICENSE_PUBLIC_KEY=XRnZAk+VcCWdtsNrIsJZ4GBKKzbP6RyH/EO0F4qYdyI=
+        VERSION: "dev"
+        COMMIT: "xxxxx"
+        BUILD_DATE: "2026-03-01"
+        LICENSE_PUBLIC_KEY: "XRnZAk+VcCWdtsNrIsJZ4GBKKzbP6RyH/EO0F4qYdyI="
     container_name: authlab-maintenant
     restart: unless-stopped
     read_only: true

--- a/docs/security.md
+++ b/docs/security.md
@@ -332,12 +332,12 @@ services:
     image: tecnativa/docker-socket-proxy:latest
     environment:
       # The only endpoint groups maintenant needs — all read-only:
-      - CONTAINERS=1        # discovery, inspect, stats, logs
-      - INFO=1              # runtime + Swarm detection
-      - NETWORKS=1          # network metadata
+      CONTAINERS: "1"       # discovery, inspect, stats, logs
+      INFO: "1"             # runtime + Swarm detection
+      NETWORKS: "1"         # network metadata
       # EVENTS, PING and VERSION are already enabled by default.
       # POST defaults to 0 -> every write returns 403.
-      # On a Swarm manager, also enable: SWARM=1, NODES=1, SERVICES=1, TASKS=1
+      # On a Swarm manager, also enable: SWARM, NODES, SERVICES and TASKS.
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
     networks: [dockerapi]


### PR DESCRIPTION
Compose accepts two forms for `environment` and `build.args`, and this repo
used both. Only the mapping form can carry a YAML anchor: in `- KEY=*alias`
the star sits inside a scalar and Compose stores the literal string. That is
what surfaced when the test stack needed its connection string written once
and reused.

The mapping form was already the one used everywhere else and in every doc
example, so this aligns the two outliers on it.

- `compose.authproxy.yml`: build args.
- `docs/security.md`: the socket-proxy snippet, and the Swarm comment that
  spelled the variables in the old notation.
- Values are quoted: in mapping form YAML types what it reads, so
  `BUILD_DATE: 2026-03-01` would become a date and `CONTAINERS: 1` an int.

The resolved output of `docker compose config` is byte-identical before and
after, on every compose file in the repository.