### PR TITLE
test(e2e): run the migration through a compose service, not a Makefile string

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,13 +76,11 @@ e2e-down:
 	docker compose $(E2E_BASE) down -v --remove-orphans 2>/dev/null || true
 
 ## Migrate a running SQLite test stack onto the PostgreSQL one, the way an
-## operator would: stop, copy, restart on the database.
+## operator would: stop, copy, restart on the database. The copy is the
+## copy-store service of the overlay, which is where the connection string
+## lives; run starts the database and waits for it to be healthy.
 e2e-migrate:
 	docker compose $(E2E_BASE) stop maintenant
-	docker compose $(E2E_PG) up -d db
-	docker compose $(E2E_PG) run --rm --entrypoint /app/maintenant maintenant \
-		--db /data/maintenant.db \
-		--copy-store-to "postgres://maintenant:e2e-throwaway-password@db:5432/maintenant?sslmode=disable" \
-		--yes
+	docker compose $(E2E_PG) run --rm copy-store
 	docker compose $(E2E_PG) up -d maintenant
 	scripts/e2e-check.sh postgres

--- a/compose.test.postgres.yml
+++ b/compose.test.postgres.yml
@@ -9,6 +9,11 @@
 # PostgreSQL 14 on purpose: it is the oldest release the product supports, so
 # it is the one worth testing. A newer server would hide a 14 incompatibility.
 
+# The connection string, written once. Everything that needs it takes it from
+# here, so the stack and the copy can never drift onto two different databases.
+x-database-url: &database-url
+  "postgres://maintenant:e2e-throwaway-password@db:5432/maintenant?sslmode=disable"
+
 services:
   db:
     image: postgres:14-alpine
@@ -34,7 +39,49 @@ services:
       # sslmode=disable because the test server speaks plaintext on a private
       # network. Towards a real database, leave sslmode out and the product
       # adds require by itself.
-      MAINTENANT_DATABASE_URL: "postgres://maintenant:e2e-throwaway-password@db:5432/maintenant?sslmode=disable"
+      MAINTENANT_DATABASE_URL: *database-url
+    depends_on:
+      db:
+        condition: service_healthy
+
+  # The migration from the docs, as a one-shot service:
+  # https://docs.maintenant.dev/guides/postgresql/#migrating-an-existing-install
+  #
+  #   docker compose -f compose.test.yml -f compose.test.postgres.yml \
+  #     run --rm copy-store
+  #
+  # Stop the instance first: the source must not move during the copy. The
+  # profile keeps it out of `up`, and `run` enables the profile by itself.
+  #
+  # It runs the released image, the released entrypoint and the same unprivileged
+  # user as the instance, so what is exercised is the command an operator types,
+  # not a convenient approximation of it.
+  copy-store:
+    profiles: ["migrate"]
+    image: ghcr.io/kolapsis/maintenant:test
+    build:
+      context: .
+      args:
+        VERSION: "e2e"
+        COMMIT: "e2e"
+        BUILD_DATE: "2026-01-01"
+    read_only: true
+    security_opt:
+      - no-new-privileges:true
+    tmpfs:
+      - /tmp:noexec,nosuid,size=64m
+    volumes:
+      # The same volume the instance writes to: the copy reads the real file
+      # the stack has been filling, and opens it read-only.
+      - maintenant_test_data:/data
+    # No MAINTENANT_DATABASE_URL here on purpose: the source is the local file,
+    # and the target is the argument. Giving it both would blur which is which.
+    command:
+      - "--db"
+      - "/data/maintenant.db"
+      - "--copy-store-to"
+      - *database-url
+      - "--yes"
     depends_on:
       db:
         condition: service_healthy

--- a/compose.test.yml
+++ b/compose.test.yml
@@ -23,9 +23,9 @@ services:
     build:
       context: .
       args:
-        - VERSION=e2e
-        - COMMIT=e2e
-        - BUILD_DATE=2026-01-01
+        VERSION: "e2e"
+        COMMIT: "e2e"
+        BUILD_DATE: "2026-01-01"
     container_name: maintenant-test
     restart: unless-stopped
     read_only: true


### PR DESCRIPTION
`make e2e-migrate` carried the copy command inline, with its own copy of the
connection string, right next to an overlay whose header says it is the only
place that string exists. Two sources for one value, and nothing to catch a
drift between them.

The copy becomes a `copy-store` service in the PostgreSQL overlay:

- A `migrate` profile keeps it out of `up`; `docker compose run` enables the
  profile itself, and `depends_on` starts the database and waits for it.
- A YAML anchor holds the connection string once, shared by the instance and
  by the copy. Only a mapping can carry an anchor, so the build args move to
  that form too.
- It runs the released image, the released entrypoint and the same
  unprivileged user as the instance, so what runs is the command an operator
  types rather than an approximation of it.

Verified end to end: SQLite stack up, `make e2e-migrate`, copy done with row
counts checked table by table, then 16 checks on PostgreSQL, none failed.

Replaces #74, which was opened from the already-merged 029 branch.