### PR TITLE
fix(endpoints): stop one-off containers minting duplicate monitors

### DIFF
--- a/docs/features/endpoints.md
+++ b/docs/features/endpoints.md
@@ -16,6 +16,16 @@ Each check records:
 - **Status** — Up or down, based on HTTP status code or TCP connection success
 - **Uptime history** — 90-day uptime with daily breakdowns and sparkline charts
 
+When the container behind a label-discovered endpoint disappears, the endpoint
+is **retired**: checks stop and it leaves the list. Retirement happens on the
+container's `destroy` event, and again at every startup for anything that
+vanished while the instance was down.
+
+Retired endpoints are hidden by default; the **Include retired** filter brings
+them back so you can delete them without waiting for retention to do it. A
+label endpoint whose container is still running cannot be deleted: the next
+discovery pass would recreate it. Remove the label, or the container.
+
 ---
 
 ## Quick Start

--- a/docs/guides/docker-labels.md
+++ b/docs/guides/docker-labels.md
@@ -23,6 +23,17 @@ labels:
   maintenant.alert.channels: "slack,email"     # Route to channels
 ```
 
+!!! note "One-off containers are skipped"
+
+    `docker compose run` copies the service definition onto a throwaway
+    container, labels included, but gives it a generated name. Since a
+    label-discovered monitor is keyed on the container name, such a container
+    would mint a second monitor for a service that already has one, and that
+    monitor would outlive the container it came from.
+
+    maintenant skips any container stamped `com.docker.compose.oneoff=True`,
+    so a one-off run never appears in your fleet and never creates a monitor.
+
 ---
 
 ## Endpoint Monitoring

--- a/frontend/src/components/EndpointCard.vue
+++ b/frontend/src/components/EndpointCard.vue
@@ -12,7 +12,7 @@
 -->
 
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import type { Endpoint } from '@/services/endpointApi'
 import { deleteEndpoint } from '@/services/endpointApi'
 import { fetchEndpointDailyUptime, type UptimeDay } from '@/services/uptimeApi'
@@ -33,6 +33,12 @@ const emit = defineEmits<{
 
 const confirm = useConfirm()
 const deleting = ref(false)
+
+// A retired endpoint came from container labels, but that container is gone.
+// Nothing will bring it back, so it is the operator's to remove, unlike a
+// live label endpoint, which the next discovery pass would recreate.
+const isRetired = computed(() => props.endpoint.source !== 'standalone' && !props.endpoint.active)
+const canDelete = computed(() => props.endpoint.source === 'standalone' || isRetired.value)
 
 async function handleDelete() {
   const ok = await confirm({
@@ -189,11 +195,12 @@ function formatResponseTime(ms: number | undefined): string {
 
     <!-- Actions -->
     <div
-      v-if="endpoint.source === 'standalone'"
+      v-if="canDelete"
       class="mt-3 flex items-center pt-2"
       :style="{ borderTop: '1px solid var(--mnt-border-subtle)' }"
       @click.stop
     >
+      <span v-if="isRetired" class="text-xs text-mnt-muted">Container gone</span>
       <button
         class="ml-auto rounded px-2 py-0.5 text-xs transition hover:opacity-80"
         :style="{ color: 'var(--mnt-status-down)' }"

--- a/frontend/src/components/EndpointDetail.vue
+++ b/frontend/src/components/EndpointDetail.vue
@@ -59,6 +59,9 @@ const endpoint = computed<Endpoint | null>(() => liveEndpoint.value ?? fetched.v
 const isHttp = computed(() => endpoint.value?.endpoint_type === 'http')
 const isOffline = computed(() => Boolean(endpoint.value?.stale || endpoint.value?.agent_offline))
 const isStandalone = computed(() => endpoint.value?.source === 'standalone')
+// Its container is gone and nothing will recreate it, so it is deletable.
+const isRetired = computed(() => !isStandalone.value && endpoint.value?.active === false)
+const canDelete = computed(() => isStandalone.value || isRetired.value)
 
 // Close the panel if the open endpoint disappears (deleted elsewhere via SSE).
 const sawInStore = ref(false)
@@ -405,12 +408,13 @@ watch(() => props.endpointId, () => {
         </div>
       </div>
 
-      <!-- Delete (standalone only) -->
+      <!-- Delete: standalone, or a label endpoint whose container is gone -->
       <div
-        v-if="isStandalone"
+        v-if="canDelete"
         class="flex items-center pt-2"
         :style="{ borderTop: '1px solid var(--mnt-border-subtle)' }"
       >
+        <span v-if="isRetired" class="text-xs text-mnt-muted">Container gone</span>
         <button
           class="ml-auto rounded px-2 py-1 text-xs transition hover:opacity-80"
           :style="{ color: 'var(--mnt-status-down)' }"

--- a/frontend/src/pages/EndpointsPage.vue
+++ b/frontend/src/pages/EndpointsPage.vue
@@ -365,6 +365,16 @@ onUnmounted(() => {
           {{ name }}
         </option>
       </select>
+
+      <select
+        v-model="store.showRetired"
+        class="rounded-lg border px-3 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-mnt-green-500 min-h-[44px]"
+        style="background: var(--mnt-bg-elevated); border-color: var(--mnt-border-default); color: var(--mnt-text-secondary)"
+        @change="store.fetchEndpoints()"
+      >
+        <option :value="false">Live only</option>
+        <option :value="true">Include retired</option>
+      </select>
     </div>
 
     <!-- Loading -->

--- a/frontend/src/stores/endpoints.ts
+++ b/frontend/src/stores/endpoints.ts
@@ -31,6 +31,11 @@ export const useEndpointsStore = defineStore('endpoints', () => {
   const statusFilter = ref<string>('')
   const typeFilter = ref<string>('')
   const containerFilter = ref<string>('')
+  // Retired endpoints are the ones whose container is gone. They are hidden by
+  // default (a fleet with churn would otherwise accumulate dead cards), but
+  // they have to be reachable, because they are the only ones you can delete
+  // by hand.
+  const showRetired = ref(false)
 
   const endpointsCount = computed(() => totalCount.value)
 
@@ -61,6 +66,9 @@ export const useEndpointsStore = defineStore('endpoints', () => {
   const statusCounts = computed(() => {
     const counts = { up: 0, down: 0, degraded: 0, unknown: 0 }
     for (const ep of endpoints.value) {
+      // A retired endpoint has no container behind it any more; its last known
+      // status is history, not a state of the fleet.
+      if (!ep.active) continue
       if (ep.status in counts) {
         counts[ep.status as keyof typeof counts]++
       }
@@ -70,7 +78,10 @@ export const useEndpointsStore = defineStore('endpoints', () => {
 
   async function fetchEndpoints(params?: ListEndpointsParams) {
     const q = useResourcesStore().entityQuery
-    const mergedParams = q ? { ...params, agent_id: q } : params
+    let mergedParams = q ? { ...params, agent_id: q } : params
+    if (showRetired.value) {
+      mergedParams = { ...mergedParams, include_inactive: true }
+    }
     loading.value = true
     error.value = null
     try {
@@ -216,6 +227,7 @@ export const useEndpointsStore = defineStore('endpoints', () => {
     statusFilter,
     typeFilter,
     containerFilter,
+    showRetired,
     filteredEndpoints,
     endpointsByContainer,
     statusCounts,

--- a/internal/api/v1/endpoints.go
+++ b/internal/api/v1/endpoints.go
@@ -457,14 +457,14 @@ func (h *EndpointHandler) HandleDeleteEndpoint(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	if err := h.service.DeleteStandalone(r.Context(), id); err != nil {
+	if err := h.service.Delete(r.Context(), id); err != nil {
 		if errors.Is(err, endpoint.ErrEndpointNotFound) {
 			WriteError(w, http.StatusNotFound, "ENDPOINT_NOT_FOUND", "Endpoint not found")
 			return
 		}
-		if errors.Is(err, endpoint.ErrNotStandalone) {
-			WriteError(w, http.StatusBadRequest, "NOT_STANDALONE",
-				"Only standalone endpoints can be deleted; label-discovered endpoints are managed via container labels")
+		if errors.Is(err, endpoint.ErrEndpointLive) {
+			WriteError(w, http.StatusConflict, "ENDPOINT_LIVE",
+				"This endpoint comes from the labels of a running container; remove the label or the container. It becomes deletable once its container is gone")
 			return
 		}
 		WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to delete endpoint")

--- a/internal/app/lifecycle.go
+++ b/internal/app/lifecycle.go
@@ -113,7 +113,9 @@ func (a *App) reconcile(ctx context.Context) {
 			}
 
 			now := time.Now()
+			seen := make(map[string]struct{}, len(results))
 			for _, r := range results {
+				seen[r.Container.ExternalID] = struct{}{}
 				a.endpointSvc.SyncEndpoints(ctx, r.Container.Name, r.Container.ExternalID, r.Labels,
 					r.Container.OrchestrationGroup, r.Container.OrchestrationUnit)
 				a.certSvc.SyncFromLabels(ctx, r.Container.ExternalID, r.Labels)
@@ -136,6 +138,9 @@ func (a *App) reconcile(ctx context.Context) {
 					}, now)
 					a.securitySvc.UpdateContainer(dbC.ID, dbC.Name, insights)
 				}
+			}
+			if swept := a.endpointSvc.SweepOrphanedLabelEndpoints(ctx, seen); swept > 0 {
+				a.logger.Info("retired endpoints whose container is gone", "count", swept)
 			}
 			a.logger.Info("endpoint discovery complete", "active_checks", a.checkEngine.ActiveCount())
 		} else {
@@ -162,6 +167,13 @@ func (a *App) startEventStream(ctx context.Context) <-chan struct{} {
 						go a.swarmUpdateTracker.CheckService(ctx, evt.ExternalID)
 					}
 				}
+				continue
+			}
+
+			// A `docker compose run` container carries the service's labels under
+			// a generated name; monitoring it would duplicate the service it was
+			// run from. Discovery skips them, and so does the event stream.
+			if docker.IsOneOff(evt.Labels) {
 				continue
 			}
 

--- a/internal/docker/discovery.go
+++ b/internal/docker/discovery.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/docker/docker/api/types/container"
@@ -26,6 +27,7 @@ const (
 	labelComposeProject    = "com.docker.compose.project"
 	labelComposeService    = "com.docker.compose.service"
 	labelComposeWorkingDir = "com.docker.compose.project.working_dir"
+	labelComposeOneOff     = "com.docker.compose.oneoff"
 	labelPBIgnore          = "maintenant.ignore"
 	labelPBGroup           = "maintenant.group"
 	labelPBSeverity        = "maintenant.alert.severity"
@@ -61,6 +63,17 @@ type DiscoveryResult struct {
 	SecurityConfig *SecurityConfig
 }
 
+// IsOneOff reports whether a container was created by `docker compose run`.
+//
+// Compose copies the service definition onto these containers, our labels
+// included, but gives them a generated name. Since a label-discovered monitor
+// is keyed on the container name, a one-off would mint a second monitor for a
+// service that already has one, and that monitor outlives the container it came
+// from. They are not part of the fleet, so discovery skips them entirely.
+func IsOneOff(labels map[string]string) bool {
+	return strings.EqualFold(labels[labelComposeOneOff], "true")
+}
+
 // DiscoverAll performs a full container list + inspect pass, returning all discovered containers.
 func (c *Client) DiscoverAll(ctx context.Context) ([]*cmodel.Container, error) {
 	list, err := c.cli.ContainerList(ctx, container.ListOptions{All: true})
@@ -72,6 +85,9 @@ func (c *Client) DiscoverAll(ctx context.Context) ([]*cmodel.Container, error) {
 	containers := make([]*cmodel.Container, 0, len(list))
 
 	for _, dc := range list {
+		if IsOneOff(dc.Labels) {
+			continue
+		}
 		result, err := c.inspectAndMap(ctx, dc, now)
 		if err != nil {
 			c.logger.Warn("failed to inspect container", "docker_id", dc.ID[:12], "error", err)
@@ -96,6 +112,9 @@ func (c *Client) DiscoverAllWithLabels(ctx context.Context) ([]*DiscoveryResult,
 	results := make([]*DiscoveryResult, 0, len(list))
 
 	for _, dc := range list {
+		if IsOneOff(dc.Labels) {
+			continue
+		}
 		result, err := c.inspectAndMap(ctx, dc, now)
 		if err != nil {
 			c.logger.Warn("failed to inspect container", "docker_id", dc.ID[:12], "error", err)

--- a/internal/docker/discovery_oneoff_test.go
+++ b/internal/docker/discovery_oneoff_test.go
@@ -1,0 +1,50 @@
+package docker
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsOneOff(t *testing.T) {
+	tests := []struct {
+		name   string
+		labels map[string]string
+		want   bool
+	}{
+		{
+			// This is what `docker compose run` actually writes: capital T.
+			name:   "compose run container",
+			labels: map[string]string{"com.docker.compose.oneoff": "True"},
+			want:   true,
+		},
+		{
+			name:   "lowercase spelling",
+			labels: map[string]string{"com.docker.compose.oneoff": "true"},
+			want:   true,
+		},
+		{
+			// `docker compose up` stamps the same key with False, so the value
+			// is what decides, not the presence of the label.
+			name:   "compose up container",
+			labels: map[string]string{"com.docker.compose.oneoff": "False"},
+			want:   false,
+		},
+		{
+			name:   "service container carrying our labels",
+			labels: map[string]string{"maintenant.endpoint.http": "https://example.com/health"},
+			want:   false,
+		},
+		{
+			name:   "no labels at all",
+			labels: nil,
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsOneOff(tt.labels))
+		})
+	}
+}

--- a/internal/endpoint/service.go
+++ b/internal/endpoint/service.go
@@ -25,6 +25,7 @@ import (
 
 var (
 	ErrNotStandalone    = errors.New("endpoint is not standalone")
+	ErrEndpointLive     = errors.New("endpoint is still discovered from container labels")
 	ErrEndpointNotFound = errors.New("endpoint not found")
 	ErrLimitReached     = errors.New("endpoint limit reached")
 	// ErrAgentProbed rejects an on-demand check for an endpoint the server never
@@ -508,6 +509,45 @@ func (s *Service) HandleContainerDestroy(ctx context.Context, externalID string)
 	}
 }
 
+// SweepOrphanedLabelEndpoints deactivates label-discovered endpoints whose
+// container is absent from a full discovery pass, and returns how many it
+// deactivated.
+//
+// The destroy event is what normally retires them, but an event that arrives
+// while the process is down is an event nobody hears, and the instance is
+// meant to be stopped for a storage migration, which is exactly when one-off
+// containers come and go. Without this sweep such an endpoint stays active
+// forever, reporting a container that no longer exists.
+func (s *Service) SweepOrphanedLabelEndpoints(ctx context.Context, seen map[string]struct{}) int {
+	endpoints, err := s.store.ListEndpoints(ctx, ListEndpointsOpts{Source: string(SourceLabel)})
+	if err != nil {
+		s.logger.Error("list label endpoints for orphan sweep", "error", err)
+		return 0
+	}
+
+	swept := 0
+	for _, ep := range endpoints {
+		if _, ok := seen[ep.ExternalID]; ok {
+			continue
+		}
+		s.engine.RemoveEndpoint(ep.ID)
+		if err := s.store.DeactivateEndpoint(ctx, ep.ID); err != nil {
+			s.logger.Error("deactivate orphaned endpoint", "endpoint_id", ep.ID, "error", err)
+			continue
+		}
+		if s.onEndpointRemoved != nil {
+			s.onEndpointRemoved(ctx, ep.ID)
+		}
+		s.emitEvent(event.EndpointRemoved, map[string]interface{}{
+			"endpoint_id":    ep.ID,
+			"container_name": ep.ContainerName,
+			"reason":         "container_gone",
+		})
+		swept++
+	}
+	return swept
+}
+
 // ListEndpoints returns endpoints matching the given options.
 func (s *Service) ListEndpoints(ctx context.Context, opts ListEndpointsOpts) ([]*Endpoint, error) {
 	return s.store.ListEndpoints(ctx, opts)
@@ -624,8 +664,16 @@ func (s *Service) UpdateStandalone(ctx context.Context, id string, name, target 
 	return full, nil
 }
 
-// DeleteStandalone removes a standalone endpoint and stops monitoring it.
-func (s *Service) DeleteStandalone(ctx context.Context, id string) error {
+// Delete removes an endpoint and stops monitoring it.
+//
+// A standalone endpoint is the operator's to delete at any time. A
+// label-discovered one is the container's, and is refused while that container
+// is still around: the next discovery pass would recreate it, so the deletion
+// would be theatre. Once the container is gone the endpoint is deactivated and
+// nothing will bring it back, and then it is deletable. Otherwise an endpoint
+// orphaned by a container that vanished while the instance was down could only
+// be removed with SQL.
+func (s *Service) Delete(ctx context.Context, id string) error {
 	existing, err := s.store.GetEndpointByID(ctx, id)
 	if err != nil {
 		return fmt.Errorf("get endpoint: %w", err)
@@ -633,8 +681,8 @@ func (s *Service) DeleteStandalone(ctx context.Context, id string) error {
 	if existing == nil {
 		return ErrEndpointNotFound
 	}
-	if existing.Source != SourceStandalone {
-		return ErrNotStandalone
+	if existing.Source != SourceStandalone && existing.Active {
+		return ErrEndpointLive
 	}
 
 	s.engine.RemoveEndpoint(id)
@@ -643,7 +691,7 @@ func (s *Service) DeleteStandalone(ctx context.Context, id string) error {
 		s.onEndpointRemoved(ctx, id)
 	}
 
-	if err := s.store.DeleteStandaloneEndpoint(ctx, id); err != nil {
+	if err := s.store.DeleteEndpoint(ctx, id); err != nil {
 		return err
 	}
 

--- a/internal/endpoint/service_test.go
+++ b/internal/endpoint/service_test.go
@@ -110,11 +110,17 @@ func (m *memStore) GetEndpointByID(_ context.Context, id string) (*Endpoint, err
 	return c, nil
 }
 
-func (m *memStore) ListEndpoints(_ context.Context, _ ListEndpointsOpts) ([]*Endpoint, error) {
+func (m *memStore) ListEndpoints(_ context.Context, opts ListEndpointsOpts) ([]*Endpoint, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	out := make([]*Endpoint, 0, len(m.endpoints))
 	for _, ep := range m.endpoints {
+		if opts.Source != "" && string(ep.Source) != opts.Source {
+			continue
+		}
+		if !opts.IncludeInactive && !ep.Active {
+			continue
+		}
 		c := m.cloneEp(ep)
 		out = append(out, c)
 	}
@@ -249,6 +255,16 @@ func (m *memStore) UpdateStandaloneEndpoint(_ context.Context, id string, name, 
 	ep.Name = name
 	ep.Target = target
 	ep.EndpointType = epType
+	return nil
+}
+
+func (m *memStore) DeleteEndpoint(_ context.Context, id string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, ok := m.endpoints[id]; !ok {
+		return fmt.Errorf("endpoint %s not found", id)
+	}
+	delete(m.endpoints, id)
 	return nil
 }
 
@@ -815,4 +831,123 @@ func TestService_CheckNow_RefusesAConcurrentCheck(t *testing.T) {
 
 	_, err := svc.CheckNow(context.Background(), id)
 	assert.ErrorIs(t, err, ErrCheckInProgress)
+}
+
+// ---------------------------------------------------------------------------
+// SweepOrphanedLabelEndpoints: the destroy event nobody heard
+// ---------------------------------------------------------------------------
+
+func TestService_SweepOrphanedLabelEndpoints_RetiresGoneContainer(t *testing.T) {
+	store := newMemStore()
+	svc := newService(store)
+	ctx := context.Background()
+
+	id := seedEndpoint(t, store, &Endpoint{
+		ContainerName: "web", LabelKey: "maintenant.endpoint.http", ExternalID: "gone",
+		EndpointType: TypeHTTP, Target: "http://web/health", Source: SourceLabel,
+	})
+
+	swept := svc.SweepOrphanedLabelEndpoints(ctx, map[string]struct{}{"still-here": {}})
+
+	require.Equal(t, 1, swept)
+	ep, err := store.GetEndpointByID(ctx, id)
+	require.NoError(t, err)
+	require.False(t, ep.Active, "an endpoint whose container is gone must not stay active")
+}
+
+func TestService_SweepOrphanedLabelEndpoints_KeepsDiscoveredContainer(t *testing.T) {
+	store := newMemStore()
+	svc := newService(store)
+	ctx := context.Background()
+
+	id := seedEndpoint(t, store, &Endpoint{
+		ContainerName: "web", LabelKey: "maintenant.endpoint.http", ExternalID: "here",
+		EndpointType: TypeHTTP, Target: "http://web/health", Source: SourceLabel,
+	})
+
+	swept := svc.SweepOrphanedLabelEndpoints(ctx, map[string]struct{}{"here": {}})
+
+	require.Equal(t, 0, swept)
+	ep, err := store.GetEndpointByID(ctx, id)
+	require.NoError(t, err)
+	require.True(t, ep.Active)
+}
+
+func TestService_SweepOrphanedLabelEndpoints_LeavesStandaloneAlone(t *testing.T) {
+	store := newMemStore()
+	svc := newService(store)
+	ctx := context.Background()
+
+	// A standalone endpoint has no container, so an empty discovery pass must
+	// not read as "its container disappeared".
+	id := seedEndpoint(t, store, &Endpoint{
+		LabelKey: "manual", ExternalID: "", Name: "public API",
+		EndpointType: TypeHTTP, Target: "https://example.com", Source: SourceStandalone,
+	})
+
+	swept := svc.SweepOrphanedLabelEndpoints(ctx, map[string]struct{}{})
+
+	require.Equal(t, 0, swept)
+	ep, err := store.GetEndpointByID(ctx, id)
+	require.NoError(t, err)
+	require.True(t, ep.Active)
+}
+
+// ---------------------------------------------------------------------------
+// Delete: who owns the endpoint
+// ---------------------------------------------------------------------------
+
+func TestService_Delete_RefusesEndpointOfLivingContainer(t *testing.T) {
+	store := newMemStore()
+	svc := newService(store)
+	ctx := context.Background()
+
+	id := seedEndpoint(t, store, &Endpoint{
+		ContainerName: "web", LabelKey: "maintenant.endpoint.http", ExternalID: "here",
+		EndpointType: TypeHTTP, Target: "http://web/health", Source: SourceLabel,
+	})
+
+	// Deleting it would only last until the next discovery pass recreated it.
+	err := svc.Delete(ctx, id)
+
+	require.ErrorIs(t, err, ErrEndpointLive)
+	ep, err := store.GetEndpointByID(ctx, id)
+	require.NoError(t, err)
+	require.NotNil(t, ep)
+}
+
+func TestService_Delete_AllowsOrphanedLabelEndpoint(t *testing.T) {
+	store := newMemStore()
+	svc := newService(store)
+	ctx := context.Background()
+
+	id := seedEndpoint(t, store, &Endpoint{
+		ContainerName: "maintenant-maintenant-run-ba08fd7ce2f0",
+		LabelKey:      "maintenant.endpoint.http", ExternalID: "gone",
+		EndpointType: TypeHTTP, Target: "https://example.com/health", Source: SourceLabel,
+	})
+	require.NoError(t, store.DeactivateEndpoint(ctx, id))
+
+	require.NoError(t, svc.Delete(ctx, id))
+
+	ep, err := store.GetEndpointByID(ctx, id)
+	require.NoError(t, err)
+	require.Nil(t, ep, "an orphaned endpoint must be removable without SQL")
+}
+
+func TestService_Delete_AllowsStandalone(t *testing.T) {
+	store := newMemStore()
+	svc := newService(store)
+	ctx := context.Background()
+
+	id := seedEndpoint(t, store, &Endpoint{
+		LabelKey: "manual", Name: "public API",
+		EndpointType: TypeHTTP, Target: "https://example.com", Source: SourceStandalone,
+	})
+
+	require.NoError(t, svc.Delete(ctx, id))
+
+	ep, err := store.GetEndpointByID(ctx, id)
+	require.NoError(t, err)
+	require.Nil(t, ep)
 }

--- a/internal/endpoint/store.go
+++ b/internal/endpoint/store.go
@@ -27,6 +27,7 @@ type EndpointStore interface {
 	ListEndpointsByExternalID(ctx context.Context, externalID string) ([]*Endpoint, error)
 	CountActiveEndpoints(ctx context.Context) (int, error)
 	DeactivateEndpoint(ctx context.Context, id string) error
+	DeleteEndpoint(ctx context.Context, id string) error
 
 	// Standalone endpoint CRUD
 	InsertStandaloneEndpoint(ctx context.Context, e *Endpoint) (string, error)

--- a/internal/store/endpoints.go
+++ b/internal/store/endpoints.go
@@ -364,6 +364,24 @@ func (s *EndpointStore) UpdateStandaloneEndpoint(ctx context.Context, id string,
 	return nil
 }
 
+// DeleteEndpoint permanently removes an endpoint and its check results,
+// whatever its source. The caller decides what may be deleted; see
+// endpoint.Service.Delete.
+func (s *EndpointStore) DeleteEndpoint(ctx context.Context, id string) error {
+	if _, err := s.writer.Exec(ctx, `DELETE FROM check_results WHERE endpoint_id=?`, id); err != nil {
+		return fmt.Errorf("delete check results for endpoint %s: %w", id, err)
+	}
+
+	res, err := s.writer.Exec(ctx, `DELETE FROM endpoints WHERE id=?`, id)
+	if err != nil {
+		return fmt.Errorf("delete endpoint %s: %w", id, err)
+	}
+	if res.RowsAffected == 0 {
+		return fmt.Errorf("endpoint %s not found", id)
+	}
+	return nil
+}
+
 // DeleteStandaloneEndpoint permanently removes a standalone endpoint and its check results.
 func (s *EndpointStore) DeleteStandaloneEndpoint(ctx context.Context, id string) error {
 	// Delete check results first


### PR DESCRIPTION
`docker compose run` copies the service definition onto a throwaway container,
our labels included, but gives it a generated name. A label-discovered monitor
is keyed on the container name, so the one-off minted a **second** monitor for
a service that already had one, aimed at the same target, and that monitor
outlived the container that carried it.

Reported from a real install: a migration run left an endpoint stuck Down on
the same URL a live endpoint reported Up.

- Discovery and the event stream skip anything stamped
  `com.docker.compose.oneoff=True`. Compose writes that label itself, `True`
  for `run` and `False` for `up`; a one-off is not part of the fleet.
- Startup reconciliation retires label endpoints whose container is absent.
  The destroy event retires them normally, but an event arriving while the
  process is down is an event nobody hears, and the instance is meant to be
  stopped for a storage migration, which is exactly when one-offs come and go.
- A retired endpoint can now be deleted. A live one still cannot (409
  `ENDPOINT_LIVE`), since the next discovery pass would recreate it. The list
  hides retired entries behind an "Include retired" filter and leaves them out
  of the status counters.

Full suite green, `golangci-lint` clean, `vue-tsc` clean. The label values are
covered by a test taken from what Compose actually writes.