### PR TITLE
docs(postgresql): show the guide in Docker Compose, not docker run

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -84,11 +84,11 @@ Open **http://localhost:8080**. maintenant auto-discovers all your containers im
     every host by hand. If you already operate a PostgreSQL, point the server at
     it and the instance becomes replaceable — see
     [PostgreSQL storage](../guides/postgresql.md). An existing install moves
-    over with one command:
+    over with a one-shot service you add next to the instance:
 
     ```bash
-    maintenant --db /data/maintenant.db \
-      --copy-store-to "postgres://maintenant:secret@db.internal:5432/maintenant?sslmode=require"
+    docker compose stop maintenant
+    docker compose run --rm copy-store
     ```
 
 ---

--- a/docs/guides/postgresql.md
+++ b/docs/guides/postgresql.md
@@ -33,14 +33,45 @@ refuses a connection string outright.
 
 ## New install
 
-```bash
-docker run -d --name maintenant \
-  -e MAINTENANT_DATABASE_URL="postgres://maintenant:secret@db.internal:5432/maintenant?sslmode=require" \
-  -e MAINTENANT_LICENSE_KEY="…" \
-  -v maintenant-data:/data \
-  -p 127.0.0.1:8080:8080 \
-  ghcr.io/kolapsis/maintenant:latest
+Point the instance at the database with `MAINTENANT_DATABASE_URL`. The
+connection string is written once, as a YAML anchor, so the instance and the
+copy command further down can never drift onto two different databases:
+
+```yaml
+# compose.yml
+x-database-url: &database-url
+  "postgres://maintenant:secret@db.internal:5432/maintenant?sslmode=require"
+
+services:
+  maintenant:
+    image: ghcr.io/kolapsis/maintenant:latest
+    restart: unless-stopped
+    read_only: true
+    security_opt:
+      - no-new-privileges:true
+    tmpfs:
+      - /tmp:noexec,nosuid,size=64m
+    ports:
+      - "127.0.0.1:8080:8080"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /proc:/host/proc:ro
+      - maintenant-data:/data
+    environment:
+      MAINTENANT_ADDR: "0.0.0.0:8080"
+      MAINTENANT_DATABASE_URL: *database-url
+      MAINTENANT_LICENSE_KEY: "…"
+
+volumes:
+  maintenant-data:
 ```
+
+```bash
+docker compose up -d
+```
+
+The database is yours and stays out of this file: the guide assumes a server
+you already operate, not one the stack brings up.
 
 The schema is created on first start, with no manual step. Check it:
 
@@ -50,6 +81,19 @@ curl -s localhost:8080/api/v1/health | jq .storage
 ```
 
 Without `MAINTENANT_DATABASE_URL`, nothing changes: SQLite, exactly as before.
+
+!!! tip "Keep the password out of the file you commit"
+
+    The connection string carries a password, and `compose.yml` usually ends up
+    in a repository. Put it in a `.env` file next to it and reference it from
+    the anchor instead:
+
+    ```yaml
+    x-database-url: &database-url "${MAINTENANT_DATABASE_URL:?}"
+    ```
+
+    A Compose secret works too. The product itself never writes the string
+    anywhere, so the file is the only place it can leak from.
 
 ### Transport encryption
 
@@ -87,24 +131,59 @@ An install already running on the local file can move to PostgreSQL without
 touching a single monitored machine. One command carries what the fleet cannot
 rebuild; everything else is re-reported or recomputed.
 
-```bash
-# 1. Stop the instance: the source must not move during the copy.
-docker stop maintenant
+Add the connection string and a one-shot `copy-store` service next to the
+instance you already run:
 
-# 2. Carry what does not rebuild itself.
-docker run --rm -v maintenant-data:/data ghcr.io/kolapsis/maintenant:latest \
-  --db /data/maintenant.db \
-  --copy-store-to "postgres://maintenant:secret@db.internal:5432/maintenant?sslmode=require"
+```yaml
+# compose.yml
+x-database-url: &database-url
+  "postgres://maintenant:secret@db.internal:5432/maintenant?sslmode=require"
 
-# 3. Restart with the connection string.
-docker run -d --name maintenant \
-  -e MAINTENANT_DATABASE_URL="postgres://maintenant:secret@db.internal:5432/maintenant?sslmode=require" \
-  -v maintenant-data:/data -p 127.0.0.1:8080:8080 \
-  ghcr.io/kolapsis/maintenant:latest
+services:
+  maintenant:
+    # … your existing service, unchanged, plus:
+    environment:
+      MAINTENANT_DATABASE_URL: *database-url
+
+  copy-store:
+    # The profile keeps it out of `up`; `run` enables it by itself.
+    profiles: ["migrate"]
+    image: ghcr.io/kolapsis/maintenant:latest
+    read_only: true
+    security_opt:
+      - no-new-privileges:true
+    tmpfs:
+      - /tmp:noexec,nosuid,size=64m
+    volumes:
+      # The volume the instance writes to. The copy opens it read-only.
+      - maintenant-data:/data
+    # No MAINTENANT_DATABASE_URL here on purpose: the source is the local file,
+    # the target is the argument. Giving it both would blur which is which.
+    command:
+      - "--db"
+      - "/data/maintenant.db"
+      - "--copy-store-to"
+      - *database-url
 ```
 
-The agents reconnect on their own, with the identity they already had. Add
-`--yes` to skip the confirmation prompt in a script.
+Then, in order:
+
+```bash
+# 1. Stop the instance: the source must not move during the copy.
+docker compose stop maintenant
+
+# 2. Carry what does not rebuild itself.
+docker compose run --rm copy-store
+
+# 3. Restart on the database, which the service now points at.
+docker compose up -d maintenant
+```
+
+The agents reconnect on their own, with the identity they already had.
+
+`docker compose run` keeps a terminal attached, so the command says what it is
+about to do and waits for you. For an unattended run, add `--yes` to the
+`command:` list.
 
 ### What travels
 
@@ -223,11 +302,13 @@ something already listens there.
 **The migration, end to end.** `make e2e-migrate` takes a running SQLite stack,
 stops it, copies it into the PostgreSQL one the way an operator would, restarts
 on the database and re-runs the checks — so the path from an existing install
-to an external database is exercised, not just described.
+to an external database is exercised, not just described. It runs the very
+`copy-store` service shown above, on the released image and entrypoint, so what
+CI proves is the command you type.
 
 ## Going back
 
-Remove `MAINTENANT_DATABASE_URL` and restart: the instance finds its SQLite
-database in the state it left it. Whatever was written to PostgreSQL in the
+Remove `MAINTENANT_DATABASE_URL` from the service and `docker compose up -d
+maintenant`: the instance finds its SQLite database in the state it left it. Whatever was written to PostgreSQL in the
 meantime is not there, and the migration command does not run in that
 direction.


### PR DESCRIPTION
The PostgreSQL guide was the only page under `docs/guides` carrying no Compose
example, while `installation.md` presents Compose as the recommended path. An
operator running Compose had to translate the `docker run` snippets themselves,
at the exact moment they touch their data.

- New install, migration and rollback are Compose blocks now, with the same
  hardening keys as `installation.md`.
- The copy is a one-shot `copy-store` service under `profiles: ["migrate"]`,
  ported from `compose.test.postgres.yml`. That is the service `make
  e2e-migrate` runs, so the documented command is the tested one.
- The connection string sits in a single YAML anchor, so the instance and the
  copy cannot drift onto two different databases. A tip covers keeping the
  password out of the file you commit.
- Two precisions the `docker run` form did not need: `run` enables the profile
  by itself, and it keeps a terminal attached, so `--yes` is only for an
  unattended run.
- The `Watching a fleet?` note in `installation.md` takes the same form.

`mkdocs build --strict` passes, the three YAML blocks parse, no `docker run`
is left in either page, and the `#migrating-an-existing-install` anchor that
`compose.test.postgres.yml` links to is unchanged.