### PR TITLE
ci: skip the jobs a change cannot affect

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -49,8 +49,48 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  # What this run has to consider. Every heavy job below is gated on it, so a
+  # change that cannot alter a verdict does not pay for one. The classification
+  # lives in scripts/ci-changed-paths.sh and fails open: an unknown path, a
+  # missing range or a diff that errors turns the whole pipeline back on.
+  changes:
+    name: Changed paths
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      backend: ${{ steps.classify.outputs.backend }}
+      frontend: ${{ steps.classify.outputs.frontend }}
+    steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      # Full history: the classification diffs against the base commit, which a
+      # shallow clone does not carry.
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Classify the changed paths
+        id: classify
+        env:
+          # Both are empty on any other event, and an empty range is what makes
+          # a manual dispatch, a schedule or a release run everything.
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
+        run: scripts/ci-changed-paths.sh
+
   build:
     name: Build (${{ matrix.platform }})
+    needs: [changes]
+    # Nothing that reaches the image changed, so the image would come out
+    # identical. On a release the range is empty, so this is always true.
+    if: needs.changes.outputs.backend == 'true' || needs.changes.outputs.frontend == 'true'
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 45
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,11 @@
 # Deep static analysis lives in codeql.yml; the image build and its Trivy scan
 # in build-docker.yml; the signed release chain in release.yml.
 #
+# Ahead of all of it, `changes` classifies the paths this run touches, and the
+# jobs that cannot be affected by them are skipped. It fails open: an unknown
+# path runs everything. A pipeline that runs too much wastes minutes, one that
+# skips a check by mistake ships a bug.
+#
 # Hardening baseline: every action is pinned to a full commit SHA, the default
 # token has no permissions, each job grants only what it needs, checkout never
 # persists credentials, and jobs are time-boxed.
@@ -32,6 +37,42 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # What this run has to consider. Every heavy job below is gated on it, so a
+  # change that cannot alter a verdict does not pay for one. The classification
+  # lives in scripts/ci-changed-paths.sh and fails open: an unknown path, a
+  # missing range or a diff that errors turns the whole pipeline back on.
+  changes:
+    name: Changed paths
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      backend: ${{ steps.classify.outputs.backend }}
+      frontend: ${{ steps.classify.outputs.frontend }}
+    steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      # Full history: the classification diffs against the base commit, which a
+      # shallow clone does not carry.
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Classify the changed paths
+        id: classify
+        env:
+          # Both are empty on any other event, and an empty range is what makes
+          # a manual dispatch, a schedule or a release run everything.
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
+        run: scripts/ci-changed-paths.sh
+
   # Fast security gate — every heavier job depends on the three scanners below.
   zizmor:
     name: Zizmor (workflow static analysis)
@@ -141,6 +182,12 @@ jobs:
       - name: Poutine
         run: poutine analyze_local .
 
+  # This chain carries no condition of its own: a job whose need was skipped is
+  # skipped too, so the `if:` on sast and audit switches off lint, test, the
+  # PostgreSQL matrix and e2e with it. The one consequence worth knowing is that
+  # a frontend-only change no longer reaches e2e. What e2e drives is the HTTP
+  # surface, and a SPA that stops building fails build-docker, which does run on
+  # a frontend change. workflow_dispatch forces the whole thing when in doubt.
   lint:
     name: Lint (golangci-lint)
     needs: [sast, audit]
@@ -339,7 +386,8 @@ jobs:
 
   sast:
     name: SAST (gosec)
-    needs: [zizmor, actionlint, poutine]
+    needs: [changes, zizmor, actionlint, poutine]
+    if: needs.changes.outputs.backend == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     permissions:
@@ -381,7 +429,9 @@ jobs:
 
   audit:
     name: Dependency audit (govulncheck + Trivy)
-    needs: [zizmor, actionlint, poutine]
+    needs: [changes, zizmor, actionlint, poutine]
+    # Trivy scans both lockfiles, govulncheck only the Go one.
+    if: needs.changes.outputs.backend == 'true' || needs.changes.outputs.frontend == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     permissions:
@@ -437,7 +487,8 @@ jobs:
 
   frontend:
     name: Frontend (eslint + vitest)
-    needs: [zizmor, actionlint, poutine]
+    needs: [changes, zizmor, actionlint, poutine]
+    if: needs.changes.outputs.frontend == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     permissions:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,8 +25,50 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # What this run has to consider. Every heavy job below is gated on it, so a
+  # change that cannot alter a verdict does not pay for one. The classification
+  # lives in scripts/ci-changed-paths.sh and fails open: an unknown path, a
+  # missing range or a diff that errors turns the whole pipeline back on.
+  changes:
+    name: Changed paths
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      backend: ${{ steps.classify.outputs.backend }}
+      frontend: ${{ steps.classify.outputs.frontend }}
+    steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      # Full history: the classification diffs against the base commit, which a
+      # shallow clone does not carry.
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Classify the changed paths
+        id: classify
+        env:
+          # Both are empty on any other event, and an empty range is what makes
+          # a manual dispatch, a schedule or a release run everything.
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
+        run: scripts/ci-changed-paths.sh
+
+  # The matrix stays static on purpose. Computing it from the outputs above
+  # would save a couple of minutes on a backend-only change, at the price of a
+  # silent failure mode: one slip and a language stops being analysed without
+  # anything going red. This job carries the Scorecard SAST control.
   analyze:
     name: CodeQL (${{ matrix.language }})
+    needs: [changes]
+    if: needs.changes.outputs.backend == 'true' || needs.changes.outputs.frontend == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     permissions:

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -10,6 +10,7 @@ on:
     paths:
       - "docs/**"
       - "mkdocs.yml"
+      - ".github/workflows/deploy-docs.yml"
   workflow_dispatch:
 
 # No default rights: every job declares the strict minimum it needs.

--- a/scripts/ci-changed-paths.sh
+++ b/scripts/ci-changed-paths.sh
@@ -1,0 +1,95 @@
+#!/bin/sh
+# Classifies the paths a run touches, so CI can skip the jobs whose verdict
+# cannot have changed. Writes `backend` and `frontend` to $GITHUB_OUTPUT.
+#
+# Fail-open by design: no diff range, a git diff that fails, an empty diff, or
+# a path matching no known category turns everything on. A pipeline that runs
+# too much is an inconvenience; a check skipped by mistake is a bug.
+#
+# The range comes from the environment, never interpolated into a workflow
+# run: block — see the hardening note at the top of build-docker.yml.
+#   BASE_SHA  pull_request: the base commit. push: the commit before.
+#             Empty on every other event, which is what makes a release,
+#             a schedule or a manual dispatch run the whole pipeline.
+#   HEAD_SHA  the commit under test, HEAD if unset.
+set -eu
+
+backend=false
+frontend=false
+reason=""
+
+everything() {
+	backend=true
+	frontend=true
+}
+
+base="${BASE_SHA:-}"
+head="${HEAD_SHA:-HEAD}"
+zero="0000000000000000000000000000000000000000"
+
+files=""
+if [ -z "$base" ] || [ "$base" = "$zero" ]; then
+	reason="no diff range for this event"
+	everything
+elif ! files=$(git diff --name-only "$base" "$head" 2>/dev/null); then
+	reason="git diff ${base}..${head} failed"
+	everything
+elif [ -z "$files" ]; then
+	reason="empty diff for ${base}..${head}"
+	everything
+fi
+
+if [ -z "$reason" ]; then
+	list=$(mktemp)
+	printf '%s\n' "$files" >"$list"
+
+	# A path can only fall in one bucket, so order matters: the inert list
+	# wins over everything, then the frontend, then the backend. What no
+	# pattern claims is unknown, and unknown means run it all.
+	while read -r f; do
+		[ -n "$f" ] || continue
+		case "$f" in
+		# Nothing in CI reads these. The docs have their own workflow.
+		docs/* | mkdocs.yml | deploy/* | *.md | LICENSE | .env.example | .gitignore) ;;
+		frontend/*)
+			frontend=true
+			;;
+		# Grouped because they decide the same verdicts: the Makefile, the
+		# test compose files and the e2e script drive `make e2e-both`, which
+		# sits at the end of the sast → lint → test → e2e chain.
+		*.go | go.mod | go.sum | cmd/* | internal/* | proto/* | scripts/* | \
+			Makefile | Dockerfile | docker-entrypoint.sh | .dockerignore | \
+			.trivyignore | .golangci.yml | codeql-config.yml | compose*.yml)
+			backend=true
+			;;
+		*)
+			reason="unclassified path: ${f}"
+			everything
+			break
+			;;
+		esac
+	done <"$list"
+
+	rm -f "$list"
+fi
+
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+	{
+		echo "backend=${backend}"
+		echo "frontend=${frontend}"
+	} >>"$GITHUB_OUTPUT"
+fi
+
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+	{
+		echo "| Category | Runs |"
+		echo "|---|---|"
+		echo "| backend | \`${backend}\` |"
+		echo "| frontend | \`${frontend}\` |"
+		[ -z "$reason" ] || echo ""
+		[ -z "$reason" ] || echo "Everything runs: ${reason}."
+	} >>"$GITHUB_STEP_SUMMARY"
+fi
+
+echo "backend=${backend} frontend=${frontend}"
+[ -z "$reason" ] || echo "everything runs: ${reason}"


### PR DESCRIPTION
Every pull request ran the whole pipeline: gosec, golangci-lint, the race
suite, the store on PostgreSQL 16 and 17, eslint, vitest, npm audit, CodeQL on
both languages and a two-architecture image build. A commit touching only docs
paid about 34 runner-minutes to reprove what was already true, and waited a
quarter of an hour for it.

- A `changes` job classifies the paths of the run and exposes `backend` and
  `frontend`. Gating `sast`, `audit` and `frontend` is enough: the existing
  `needs` chain carries the skip down to `lint`, `test`, the PostgreSQL matrix
  and `e2e`. CodeQL and the image build take the same gate.
- The classification lives in `scripts/ci-changed-paths.sh` and **fails open**:
  an unknown path, a missing range or a diff that errors runs everything. That
  is also why the matrices stay static and why the three workflow scanners keep
  running unconditionally, so the `needs` chain keeps its meaning.
- No new third-party action. `dorny/paths-filter` and `tj-actions/changed-files`
  would widen the trust boundary of the pipeline that guards the repository.
- One consequence worth stating: a frontend-only change no longer reaches
  `e2e`, which sits behind `test`. `e2e-check.sh` drives the HTTP surface, and
  a SPA that stops building still fails `build-docker`.

actionlint, zizmor and poutine are clean, shellcheck passes on the script, and
the classification was replayed against the last 60 commits of the repository.
This PR touches `.github/`, so it runs the full pipeline on itself.