### PR TITLE
feat(ui): link to the feedback form

### DIFF
--- a/README.md
+++ b/README.md
@@ -785,27 +785,33 @@ MAINTENANT_LICENSE_KEY=your-license-key
 
 ## Support the project
 
-maintenant is built independently in Bordeaux, France. No VC, no tracking, no telemetry, no data collection, no acquisition exit. The only way this keeps going is if users who benefit from it give back. **Here's how, ranked by impact:**
+maintenant is built independently in Bordeaux, France. No VC, no tracking, no acquisition exit, and no data collection beyond [anonymous opt-out telemetry](#telemetry). The only way this keeps going is if users who benefit from it give back. **Here's how, ranked by impact:**
 
 <table>
   <tr>
-    <td width="33%" valign="top" align="center">
+    <td width="25%" valign="top" align="center">
       <h3>1. Buy a licence</h3>
       <p><strong>Personal €149</strong> once · <strong>Pro €29/mo</strong></p>
       <p><sub>The single most impactful way to support the project. Unlocks advanced features AND funds development. Personal if the infrastructure is yours, Pro if you run it for others.</sub></p>
       <p><a href="https://maintenant.dev/pricing/"><strong>See editions →</strong></a></p>
     </td>
-    <td width="33%" valign="top" align="center">
+    <td width="25%" valign="top" align="center">
       <h3>2. Sponsor</h3>
       <p><strong>Any amount</strong> · one-off or monthly</p>
       <p><sub>Don't need a paid edition? Sponsor on GitHub. Every sponsor gets credited in the <a href="#backers">Backers</a> wall below.</sub></p>
       <p><a href="https://github.com/sponsors/kolapsis"><strong>Sponsor →</strong></a></p>
     </td>
-    <td width="33%" valign="top" align="center">
+    <td width="25%" valign="top" align="center">
       <h3>3. Spread the word</h3>
       <p><strong>Free · 10 seconds</strong></p>
       <p><sub>Star the repo, share on HN / Lobsters / Reddit / LinkedIn. Discoverability is oxygen for indie projects.</sub></p>
       <p><a href="https://github.com/kolapsis/maintenant"><strong>Star repo →</strong></a></p>
+    </td>
+    <td width="25%" valign="top" align="center">
+      <h3>4. Tell me how you use it</h3>
+      <p><strong>Two minutes</strong></p>
+      <p><sub>Read by the developer, quoted only if you allow it.</sub></p>
+      <p><a href="https://maintenant.dev/feedback/"><strong>Give feedback →</strong></a></p>
     </td>
   </tr>
 </table>

--- a/frontend/src/components/AppHeader.vue
+++ b/frontend/src/components/AppHeader.vue
@@ -20,11 +20,12 @@ import { useResourcesStore } from '@/stores/resources'
 import { useContainersStore } from '@/stores/containers'
 import { useStorageStore } from '@/stores/storage'
 import { useAgentsStore } from '@/stores/agents'
-import { Search, Bell, AlertTriangle, Box, Globe, Heart, ShieldCheck, Cpu, Sun, Moon, Monitor } from 'lucide-vue-next'
+import { Search, Bell, AlertTriangle, Box, Globe, Heart, ShieldCheck, Cpu, Sun, Moon, Monitor, MessageSquare } from 'lucide-vue-next'
 import RuntimeBadge from '@/components/RuntimeBadge.vue'
 import HostFilterDropdown from '@/components/HostFilterDropdown.vue'
 import AlertBanner from '@/components/ui/AlertBanner.vue'
 import { useTheme } from '@/composables/useTheme'
+import { useFeedbackUrl } from '@/composables/useFeedbackUrl'
 
 const router = useRouter()
 const dashboard = useDashboardStore()
@@ -166,6 +167,8 @@ const themeTooltip = computed(() => {
   if (theme.value === 'dark') return 'Dark mode'
   return 'Follow system theme'
 })
+
+const { feedbackUrl } = useFeedbackUrl()
 </script>
 
 <template>
@@ -254,7 +257,7 @@ const themeTooltip = computed(() => {
       </div>
     </div>
 
-    <!-- Right: runtime badge + theme toggle + bell -->
+    <!-- Right: runtime badge + theme toggle + feedback + bell -->
     <div class="flex items-center gap-4">
       <!-- Runtime badge with popover -->
       <RuntimeBadge />
@@ -270,6 +273,18 @@ const themeTooltip = computed(() => {
         <Moon v-else-if="theme === 'dark'" :size="18" />
         <Monitor v-else :size="18" />
       </button>
+
+      <!-- Feedback form on maintenant.dev, opened by the browser in a new tab -->
+      <a
+        :href="feedbackUrl"
+        target="_blank"
+        rel="noopener noreferrer"
+        title="Give feedback"
+        aria-label="Give feedback"
+        class="p-2 text-mnt-muted hover:text-mnt-primary hover:bg-mnt-elevated rounded-lg transition-all"
+      >
+        <MessageSquare :size="18" />
+      </a>
 
       <div
         class="relative"

--- a/frontend/src/composables/__tests__/useFeedbackUrl.spec.ts
+++ b/frontend/src/composables/__tests__/useFeedbackUrl.spec.ts
@@ -1,0 +1,64 @@
+// Copyright 2026 Benjamin Touchard (Kolapsis)
+//
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+// or a commercial license. See COMMERCIAL-LICENSE.md.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { ref } from 'vue'
+
+// Mock the two composables the URL reads from, so the test drives edition and
+// version directly without an edition fetch or a /api/v1/health call.
+const state = vi.hoisted(() => ({
+  edition: { value: 'community' },
+  version: { value: '...' },
+}))
+
+vi.mock('@/composables/useEdition', () => ({ useEdition: () => ({ editionName: state.edition }) }))
+vi.mock('@/composables/useAppVersion', () => ({ useAppVersion: () => ({ version: state.version }) }))
+
+import { buildFeedbackUrl, useFeedbackUrl, FEEDBACK_URL } from '../useFeedbackUrl'
+
+beforeEach(() => {
+  state.edition = ref('community')
+  state.version = ref('...')
+})
+
+describe('buildFeedbackUrl', () => {
+  it('tags the form with source, edition and version', () => {
+    const url = new URL(buildFeedbackUrl('pro', '1.4.0'))
+    expect(url.origin + url.pathname).toBe(FEEDBACK_URL)
+    expect(url.searchParams.get('source')).toBe('app')
+    expect(url.searchParams.get('edition')).toBe('pro')
+    expect(url.searchParams.get('version')).toBe('1.4.0')
+  })
+
+  it('leaves version out while it is still the loading placeholder', () => {
+    const url = new URL(buildFeedbackUrl('community', '...'))
+    expect(url.searchParams.get('edition')).toBe('community')
+    expect(url.searchParams.has('version')).toBe(false)
+  })
+
+  it('leaves version out when it is empty', () => {
+    expect(new URL(buildFeedbackUrl('personal', '')).searchParams.has('version')).toBe(false)
+  })
+
+  it('encodes the parameters', () => {
+    const url = buildFeedbackUrl('a b&c', '1.0.0+dev')
+    expect(url).toBe(`${FEEDBACK_URL}?source=app&edition=a+b%26c&version=1.0.0%2Bdev`)
+  })
+})
+
+describe('useFeedbackUrl', () => {
+  it('follows the running edition and adds the version once it is known', () => {
+    state.edition = ref('personal')
+    const { feedbackUrl } = useFeedbackUrl()
+
+    expect(feedbackUrl.value).toBe(`${FEEDBACK_URL}?source=app&edition=personal`)
+
+    state.version.value = '1.4.0'
+    expect(feedbackUrl.value).toBe(`${FEEDBACK_URL}?source=app&edition=personal&version=1.4.0`)
+
+    state.edition.value = 'pro'
+    expect(feedbackUrl.value).toBe(`${FEEDBACK_URL}?source=app&edition=pro&version=1.4.0`)
+  })
+})

--- a/frontend/src/composables/useFeedbackUrl.ts
+++ b/frontend/src/composables/useFeedbackUrl.ts
@@ -1,0 +1,34 @@
+// Copyright 2026 Benjamin Touchard (Kolapsis)
+//
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+// or a commercial license. See COMMERCIAL-LICENSE.md.
+
+import { computed } from 'vue'
+import { useEdition } from '@/composables/useEdition'
+import { useAppVersion } from '@/composables/useAppVersion'
+
+export const FEEDBACK_URL = 'https://maintenant.dev/feedback/'
+
+/**
+ * The version placeholder useAppVersion shows until /api/v1/health answers.
+ * Passing it along would tag the feedback with a meaningless value.
+ */
+const VERSION_PENDING = '...'
+
+/**
+ * The feedback form, tagged with the running edition and version so the
+ * answer can be read in context. It is a plain link the browser opens in a
+ * new tab: the instance itself never contacts maintenant.dev.
+ */
+export function buildFeedbackUrl(edition: string, version: string): string {
+  const params = new URLSearchParams({ source: 'app', edition })
+  if (version && version !== VERSION_PENDING) params.set('version', version)
+  return `${FEEDBACK_URL}?${params.toString()}`
+}
+
+export function useFeedbackUrl() {
+  const { editionName } = useEdition()
+  const { version } = useAppVersion()
+  const feedbackUrl = computed(() => buildFeedbackUrl(editionName.value, version.value))
+  return { feedbackUrl }
+}

--- a/frontend/src/pages/EditionsPage.vue
+++ b/frontend/src/pages/EditionsPage.vue
@@ -15,6 +15,7 @@
 import { computed, onMounted } from 'vue'
 import { Check, Minus, ExternalLink } from 'lucide-vue-next'
 import { useEdition } from '@/composables/useEdition'
+import { useFeedbackUrl } from '@/composables/useFeedbackUrl'
 import type { Edition, QuotaResource } from '@/services/editionApi'
 import EditionBadge from '@/components/EditionBadge.vue'
 import InlineAlert from '@/components/ui/InlineAlert.vue'
@@ -31,6 +32,8 @@ const {
 } = useEdition()
 
 onMounted(loadLicenseStatus)
+
+const { feedbackUrl } = useFeedbackUrl()
 
 const TIERS = ['community', 'personal', 'pro'] as const
 type Tier = (typeof TIERS)[number]
@@ -277,6 +280,23 @@ function isUpgrade(tier: Tier): boolean {
       to use Maintenant on behalf of others, support, and the features a team needs to be
       paged and to address third parties.
     </p>
+
+    <!-- Feedback: a plain link the browser opens, the instance sends nothing. -->
+    <section class="mt-8 rounded-xl border border-mnt-default bg-mnt-surface p-5">
+      <h2 class="text-sm font-semibold text-mnt-primary">Tell me how you use Maintenant</h2>
+      <p class="mt-1 text-xs leading-relaxed text-mnt-muted">
+        Two minutes, read by the developer, quoted only if you allow it.
+      </p>
+      <a
+        :href="feedbackUrl"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="mt-3 inline-flex items-center gap-1.5 rounded-lg border border-mnt-default px-3 py-1.5 text-xs font-semibold text-mnt-primary hover:bg-mnt-hover"
+      >
+        Give feedback
+        <ExternalLink class="h-3 w-3" />
+      </a>
+    </section>
   </div>
 </template>
 


### PR DESCRIPTION
Adds a link to the feedback form (https://maintenant.dev/feedback/) from the app.

- New composable `useFeedbackUrl` that builds the URL tagged with `source=app`, the running edition and the version (version omitted while `/api/v1/health` has not answered).
- Header: a `MessageSquare` icon button next to the theme toggle.
- Editions page: a short section at the bottom with a "Give feedback" button.
- README: the form added to the support section.

It is a plain `<a target="_blank">`: the browser opens the form, the instance never contacts maintenant.dev.

Unit tests cover the URL building (edition, version, pending-version case).
