### PR TITLE
feat(resources): tier history windows by edition instead of gating them wholesale

### DIFF
--- a/docs/features/mcp.md
+++ b/docs/features/mcp.md
@@ -140,6 +140,16 @@ The **Edition** column is the minimum a tool needs. Below it, the tool returns a
 That is the same decision the REST API makes, from the same table. Every tool is
 read-only except the ones listed under [Actions](#actions-write).
 
+One tool is not a plain yes or no: `get_top_consumers` ranks either the live
+samples or a history window, and how far back a window may go depends on the
+edition. The live ranking (`period` omitted, or `"current"`) is open everywhere;
+a `period` of `1h`, `6h`, `24h`, `7d`, `30d` or `90d` is held to the same cap as
+the charts (Community up to 6h, Personal up to 30d, Pro up to 90d), and a window
+above it returns `edition_required` carrying `window` and `max_window`.
+See [Resource Metrics](resources.md#historical-charts). An MCP client has no
+interface in front of it, which is exactly why the cap is enforced here and not
+only in the web UI.
+
 ### Monitoring (read)
 
 | Tool | Description | Edition |
@@ -153,7 +163,7 @@ read-only except the ones listed under [Actions](#actions-write).
 | `list_certificates` | TLS certificates with expiration, issuer, chain validity | Community |
 | `list_alerts` | Active alerts (or recent resolved/silenced ones with `active_only: false`) | Community |
 | `get_resources` | Host resource summary: CPU, memory, network, disk | Community |
-| `get_top_consumers` | Containers ranked by CPU or memory usage | Community |
+| `get_top_consumers` | Containers ranked by CPU or memory usage, live or over a history window | Community (see below) |
 | `get_updates` | Available image updates for monitored containers | Community |
 | `get_health` | maintenant version, runtime, and status | Community |
 | `list_agents` | Registered remote agents with connection state and runtime | Personal |

--- a/docs/features/resources.md
+++ b/docs/features/resources.md
@@ -27,21 +27,52 @@ maintenant collects the following metrics for each container:
 
 ## Historical Charts
 
-maintenant stores metric snapshots and displays them as interactive time-series charts (powered by uPlot). Available time ranges:
+maintenant stores metric snapshots and displays them as interactive time-series charts (powered by uPlot). Every edition sees a history: what an edition buys is how far back it goes.
 
-| Range | Description | Edition |
-|-------|-------------|---------|
-| 1 hour | Fine-grained, per-second resolution | Community |
-| 6 hours | Recent activity | Community |
-| 24 hours | Full day view | :material-star-four-points:{ title="Personal" } Personal |
-| 7 days | Weekly trends | :material-star-four-points:{ title="Personal" } Personal |
-| 30 days | Monthly trends | :material-star-four-points:{ title="Personal" } Personal |
+| Window | Edition | Served from | Granularity |
+|--------|---------|-------------|-------------|
+| 1 hour | Community | raw samples | raw |
+| 6 hours | Community | raw samples | 1 minute |
+| 24 hours | :material-star-four-points:{ title="Personal" } Personal | raw samples | 5 minutes |
+| 7 days | :material-star-four-points:{ title="Personal" } Personal | hourly rollup | 1 hour |
+| 30 days | :material-star-four-points:{ title="Personal" } Personal | hourly rollup | 1 hour |
+| 90 days | :material-star-four-points:{ title="Pro" } Pro | daily rollup | 1 day |
+
+Each window reads a table kept strictly longer than the window itself, so a retention pass can never shorten a chart while you are looking at it. That is why 90 days comes from the daily rollup, kept a year, and not from the hourly one, kept exactly ninety days.
+
+!!! note "Disk I/O on the 90-day window"
+    The daily rollup carries CPU, memory and network, but not the block I/O
+    counters. On the 90-day window only, **Disk I/O reads zero**. Every shorter
+    window has it.
+
+The cap is a duration, not a list. The window catalogue and the edition that opens each entry are reported by the API, so the interface never holds a copy that could drift:
+
+```
+GET /api/v1/edition
+```
+
+```json
+{
+  "resource_history": {
+    "max_window": "6h",
+    "max_window_seconds": 21600,
+    "windows": [
+      { "window": "1h",  "seconds": 3600,    "min_edition": "community" },
+      { "window": "90d", "seconds": 7776000, "min_edition": "pro" }
+    ]
+  }
+}
+```
 
 Access historical data via the API:
 
 ```
 GET /api/v1/containers/{id}/resources/history?range=24h
 ```
+
+A window above your edition's cap is refused with `403 EDITION_REQUIRED`, naming the edition that opens it and your current cap. It is never silently shortened to the cap. A window the product does not know is a `400` instead: a bad request, not an edition question.
+
+The same catalogue and the same cap apply to the [top consumers](#top-consumers-view) and to the `get_top_consumers` MCP tool. There is no window that one surface serves and another refuses.
 
 ---
 
@@ -75,8 +106,11 @@ PUT /api/v1/containers/{id}/resources/alerts
 The top consumers view shows which containers are using the most resources, sorted by CPU or memory usage. Useful for quick triage when your host is under pressure.
 
 ```
-GET /api/v1/resources/top?sort=cpu&limit=10
+GET /api/v1/resources/top?metric=cpu&limit=10           # live ranking, every edition
+GET /api/v1/resources/top?metric=cpu&period=30d&limit=10 # ranked over a history window
 ```
+
+Omitting `period` ranks containers on their latest sample and is open in every edition. Passing one reads history, and the edition cap applies exactly as it does to the per-container charts.
 
 ---
 
@@ -134,3 +168,14 @@ See [Multi-Host Monitoring](multihost.md) for the full agent/server setup.
 
 - [Container Monitoring](containers.md) — Container states and health checks
 - [Alert Engine](alerts.md) — Resource threshold alerts
+
+---
+
+## Changelog
+
+**2026-08-27, history windows per edition.** Until this release the history API
+was open to Personal and above as a whole, so a Community instance saw no chart
+at all, and the 30-day period of the top consumers endpoint was reachable from
+any edition by calling it directly. Both are fixed: Community now sees 1h and
+6h, Pro gains a 90-day window, and every surface enforces the cap server-side.
+The tiering above is what the product serves, and what the pricing page states.

--- a/frontend/src/components/ContainerDetail.vue
+++ b/frontend/src/components/ContainerDetail.vue
@@ -34,7 +34,6 @@ import PostureScoreBadge from './PostureScoreBadge.vue'
 import PostureCategoryBreakdown from './PostureCategoryBreakdown.vue'
 import ResourceCharts from './ResourceCharts.vue'
 import ResourceAlertConfig from './ResourceAlertConfig.vue'
-import FeatureGate from './FeatureGate.vue'
 import { useSecurityStore } from '@/stores/security'
 import { usePostureStore } from '@/stores/posture'
 import { useEdition } from '@/composables/useEdition'
@@ -416,14 +415,10 @@ watch(() => props.containerId, () => {
         <!-- v-if, not v-show: the charts only fetch their history once the tab
              is opened, so the panel costs nothing until then. -->
         <div v-else-if="activeTab === 'resources'" class="space-y-5 p-5">
-          <FeatureGate
-            feature="resource_history"
-            title="Resource History"
-            description="Track CPU, memory, network and block I/O over time, and alert on thresholds."
-          >
-            <ResourceCharts :container-id="containerId" />
-            <ResourceAlertConfig :container-id="containerId" class="mt-5" />
-          </FeatureGate>
+          <!-- Open in every edition: what an edition buys is how far back the
+               charts may look, and the window selector carries that (FR-004c). -->
+          <ResourceCharts :container-id="containerId" />
+          <ResourceAlertConfig :container-id="containerId" class="mt-5" />
         </div>
 
         <!-- INFO TAB -->

--- a/frontend/src/components/ResourceCharts.vue
+++ b/frontend/src/components/ResourceCharts.vue
@@ -12,10 +12,14 @@
 -->
 
 <script setup lang="ts">
-import { ref, watch, onMounted, nextTick } from 'vue'
+import { ref, computed, watch, onMounted, nextTick } from 'vue'
 import { getResourceHistory, type HistoryPoint } from '@/services/resourceApi'
 import { useChart } from '@/composables/useChart'
 import { useResourcesStore } from '@/stores/resources'
+import { useEdition } from '@/composables/useEdition'
+import { ApiError } from '@/services/apiFetch'
+import EditionBadge from '@/components/EditionBadge.vue'
+import { Lock } from 'lucide-vue-next'
 import type uPlot from 'uplot'
 
 const props = defineProps<{
@@ -23,10 +27,12 @@ const props = defineProps<{
 }>()
 
 const resourcesStore = useResourcesStore()
+const { historyWindows, isWindowOpen, requiredEditionForWindow, largestOpenWindow, reload } =
+  useEdition()
 const selectedRange = ref('1h')
-const ranges = ['1h', '6h', '24h', '7d']
 const loading = ref(false)
 const points = ref<HistoryPoint[]>([])
+const closedNotice = ref('')
 
 const cpuEl = ref<HTMLElement | null>(null)
 const memEl = ref<HTMLElement | null>(null)
@@ -125,8 +131,20 @@ async function fetchHistory() {
   try {
     const res = await getResourceHistory(props.containerId, selectedRange.value)
     points.value = res.points || []
-  } catch {
+  } catch (err) {
     points.value = []
+    // A license can expire between two refreshes, and the view must not break
+    // on the window it was already showing. The refusal itself is the signal:
+    // fall back to the largest window still open and say so (FR-021b).
+    if (err instanceof ApiError && err.isEditionRefusal) {
+      const closed = selectedRange.value
+      await reload()
+      const fallback = largestOpenWindow.value
+      if (fallback && fallback !== closed) {
+        closedNotice.value = `${closed} is no longer available on this edition. Showing ${fallback}.`
+        selectedRange.value = fallback
+      }
+    }
   } finally {
     loading.value = false
   }
@@ -163,6 +181,22 @@ function updateCharts() {
   ])
 }
 
+/**
+ * A closed window is shown, never hidden: seeing one hour of history is what
+ * makes thirty days worth wanting. Clicking it does nothing and asks nothing:
+ * the interface does not fire a request it knows will be refused (FR-018).
+ */
+/** The cheapest window the running edition does not open, or null when it opens everything. */
+const firstClosedWindow = computed(() => historyWindows.value.find((w) => !isWindowOpen(w.window)) ?? null)
+
+function selectRange(window: string) {
+  if (!isWindowOpen(window)) return
+  // The fallback notice stands until the user picks a window themselves; the
+  // refetch that follows the fallback must not erase what it just said.
+  closedNotice.value = ''
+  selectedRange.value = window
+}
+
 watch(selectedRange, () => fetchHistory())
 onMounted(() => fetchHistory())
 </script>
@@ -181,16 +215,26 @@ onMounted(() => fetchHistory())
         }"
       >
         <button
-          v-for="r in ranges"
-          :key="r"
-          class="px-3 py-1 text-xs font-medium transition"
+          v-for="w in historyWindows"
+          :key="w.window"
+          :data-test="`range-${w.window}`"
+          :data-locked="isWindowOpen(w.window) ? undefined : 'true'"
+          :disabled="!isWindowOpen(w.window)"
+          class="flex items-center gap-1 px-3 py-1 text-xs font-medium transition"
           :style="{
-            backgroundColor: selectedRange === r ? 'var(--mnt-accent)' : 'var(--mnt-bg-surface)',
-            color: selectedRange === r ? 'var(--mnt-text-inverted)' : 'var(--mnt-text-secondary)',
+            backgroundColor: selectedRange === w.window ? 'var(--mnt-accent)' : 'var(--mnt-bg-surface)',
+            color: selectedRange === w.window
+              ? 'var(--mnt-text-inverted)'
+              : isWindowOpen(w.window)
+                ? 'var(--mnt-text-secondary)'
+                : 'var(--mnt-text-muted)',
+            cursor: isWindowOpen(w.window) ? 'pointer' : 'not-allowed',
+            opacity: isWindowOpen(w.window) ? '1' : '0.6',
           }"
-          @click="selectedRange = r"
+          @click="selectRange(w.window)"
         >
-          {{ r }}
+          {{ w.window }}
+          <Lock v-if="!isWindowOpen(w.window)" class="h-3 w-3" />
         </button>
       </div>
       <div
@@ -198,6 +242,37 @@ onMounted(() => fetchHistory())
         class="ml-2 h-4 w-4 animate-spin rounded-full border-2"
         :style="{ borderColor: 'var(--mnt-border-default)', borderTopColor: 'var(--mnt-accent)' }"
       />
+
+      <!-- What the next window up would cost, in the vocabulary the rest of the
+           interface already uses for gating. -->
+      <router-link
+        v-if="firstClosedWindow"
+        :to="{ name: 'editions' }"
+        class="ml-1 flex items-center gap-1.5 text-xs"
+        :style="{ color: 'var(--mnt-text-muted)' }"
+      >
+        <Lock class="h-3 w-3" />
+        <span>{{ firstClosedWindow.window }} and beyond</span>
+        <EditionBadge
+          v-if="requiredEditionForWindow(firstClosedWindow.window)"
+          :edition="requiredEditionForWindow(firstClosedWindow.window)!"
+        />
+      </router-link>
+    </div>
+
+    <!-- The window closed under the view: said plainly, not as a failure. -->
+    <div
+      v-if="closedNotice"
+      class="rounded px-3 py-2 text-xs"
+      :style="{
+        backgroundColor: 'var(--mnt-bg-elevated)',
+        border: '1px solid var(--mnt-border-subtle)',
+        color: 'var(--mnt-text-secondary)',
+        borderRadius: 'var(--mnt-radius-md)',
+      }"
+      data-test="window-closed-notice"
+    >
+      {{ closedNotice }}
     </div>
 
     <!-- Empty state -->

--- a/frontend/src/components/TopConsumersWidget.vue
+++ b/frontend/src/components/TopConsumersWidget.vue
@@ -16,7 +16,12 @@ import { ref } from 'vue'
 import { useEdition } from '@/composables/useEdition'
 import { Lock } from 'lucide-vue-next'
 
-export type Period = '1h' | '24h' | '7d' | '30d'
+/**
+ * A period is whatever the engine's catalogue declares. It used to be a fixed
+ * union split into a free list and a paid one, which is how the widget ended up
+ * being the only thing standing between an edition and a paid period.
+ */
+export type Period = string
 
 export interface TopConsumer {
   containerId: string
@@ -37,10 +42,7 @@ const emit = defineEmits<{
   'update:period': [value: Period]
 }>()
 
-const { hasFeature } = useEdition()
-
-const cePeriods: Period[] = ['1h']
-const proPeriods: Period[] = ['24h', '7d', '30d']
+const { historyWindows, isWindowOpen } = useEdition()
 
 const activeMetric = ref<'cpu' | 'memory'>(props.metric)
 const activePeriod = ref<Period>(props.period)
@@ -51,7 +53,9 @@ function switchMetric(m: 'cpu' | 'memory') {
 }
 
 function switchPeriod(p: Period) {
-  if (proPeriods.includes(p) && !hasFeature('resource_history')) return
+  // The server refuses a closed period anyway; not asking is what keeps the
+  // interface from firing a request it knows will come back refused.
+  if (!isWindowOpen(p)) return
   activePeriod.value = p
   emit('update:period', p)
 }
@@ -101,33 +105,27 @@ function formatValue(consumer: TopConsumer): string {
 
       <div class="flex gap-1">
         <button
-          v-for="p in cePeriods"
-          :key="p"
-          class="rounded-full px-2.5 py-1 text-xs font-medium transition cursor-pointer"
-          :style="{
-            backgroundColor: activePeriod === p ? 'var(--mnt-accent)' : 'var(--mnt-bg-elevated)',
-            color: activePeriod === p ? 'var(--mnt-text-inverted)' : 'var(--mnt-text-secondary)',
-            border: activePeriod === p ? '1px solid var(--mnt-accent)' : '1px solid var(--mnt-border-default)',
-          }"
-          @click="switchPeriod(p)"
-        >
-          {{ p }}
-        </button>
-        <button
-          v-for="p in proPeriods"
-          :key="p"
+          v-for="w in historyWindows"
+          :key="w.window"
+          :data-test="`period-${w.window}`"
+          :data-locked="isWindowOpen(w.window) ? undefined : 'true'"
+          :disabled="!isWindowOpen(w.window)"
           class="rounded-full px-2.5 py-1 text-xs font-medium transition flex items-center gap-1"
           :style="{
-            backgroundColor: hasFeature('resource_history') && activePeriod === p ? 'var(--mnt-accent)' : 'var(--mnt-bg-elevated)',
-            color: hasFeature('resource_history') && activePeriod === p ? 'var(--mnt-text-inverted)' : hasFeature('resource_history') ? 'var(--mnt-text-secondary)' : 'var(--mnt-text-muted)',
-            border: hasFeature('resource_history') && activePeriod === p ? '1px solid var(--mnt-accent)' : '1px solid var(--mnt-border-default)',
-            cursor: hasFeature('resource_history') ? 'pointer' : 'not-allowed',
-            opacity: hasFeature('resource_history') ? '1' : '0.5',
+            backgroundColor: activePeriod === w.window ? 'var(--mnt-accent)' : 'var(--mnt-bg-elevated)',
+            color: activePeriod === w.window
+              ? 'var(--mnt-text-inverted)'
+              : isWindowOpen(w.window)
+                ? 'var(--mnt-text-secondary)'
+                : 'var(--mnt-text-muted)',
+            border: activePeriod === w.window ? '1px solid var(--mnt-accent)' : '1px solid var(--mnt-border-default)',
+            cursor: isWindowOpen(w.window) ? 'pointer' : 'not-allowed',
+            opacity: isWindowOpen(w.window) ? '1' : '0.5',
           }"
-          @click="switchPeriod(p)"
+          @click="switchPeriod(w.window)"
         >
-          {{ p }}
-          <Lock v-if="!hasFeature('resource_history')" :size="9" />
+          {{ w.window }}
+          <Lock v-if="!isWindowOpen(w.window)" :size="9" />
         </button>
       </div>
     </div>

--- a/frontend/src/components/__tests__/ContainerDetail.spec.ts
+++ b/frontend/src/components/__tests__/ContainerDetail.spec.ts
@@ -150,14 +150,17 @@ describe('ContainerDetail — Resources tab', () => {
     expect(wrapper.find('[data-test="resource-alerts"]').exists()).toBe(true)
   })
 
-  it('gates the tab content behind the resource_history feature', async () => {
+  // The history is no longer all-or-nothing: the tab opens in every edition and
+  // the window selector carries the cap (FR-004c).
+  it('opens the tab without an edition gate', async () => {
     const wrapper = mountDetail()
     await settle(wrapper)
 
     await resourcesTab(wrapper)!.trigger('click')
     await wrapper.vm.$nextTick()
 
-    expect(wrapper.find('[data-feature="resource_history"]').exists()).toBe(true)
+    expect(wrapper.find('[data-feature="resource_history"]').exists()).toBe(false)
+    expect(wrapper.find('[data-test="resource-charts"]').exists()).toBe(true)
   })
 
   it('leaves the Details tab intact', async () => {

--- a/frontend/src/components/__tests__/ResourceCharts.spec.ts
+++ b/frontend/src/components/__tests__/ResourceCharts.spec.ts
@@ -1,0 +1,189 @@
+// Copyright 2026 Benjamin Touchard (kOlapsis)
+//
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+// or a commercial license. You may not use this file except in compliance
+// with one of these licenses.
+//
+// AGPL-3.0: https://www.gnu.org/licenses/agpl-3.0.html
+// Commercial: See COMMERCIAL-LICENSE.md
+//
+// Source: https://github.com/kolapsis/maintenant
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { ref, computed } from 'vue'
+import ResourceCharts from '@/components/ResourceCharts.vue'
+import { getResourceHistory } from '@/services/resourceApi'
+import { ApiError } from '@/services/apiFetch'
+
+vi.mock('@/services/resourceApi', () => ({
+  getResourceHistory: vi.fn().mockResolvedValue({ points: [] }),
+}))
+
+// uPlot touches matchMedia at import time and is unavailable under jsdom.
+vi.mock('@/composables/useChart', () => ({
+  useChart: () => ({
+    ready: ref(false),
+    create: vi.fn(),
+    destroy: vi.fn(),
+    setData: vi.fn(),
+  }),
+}))
+
+// The catalogue the engine would report to a Community instance: the whole
+// product, with the edition that opens each window.
+const CATALOG = [
+  { window: '1h', seconds: 3600, min_edition: 'community' },
+  { window: '6h', seconds: 21600, min_edition: 'community' },
+  { window: '24h', seconds: 86400, min_edition: 'personal' },
+  { window: '7d', seconds: 604800, min_edition: 'personal' },
+  { window: '30d', seconds: 2592000, min_edition: 'personal' },
+  { window: '90d', seconds: 7776000, min_edition: 'pro' },
+]
+
+const maxSeconds = ref(21600) // Community
+const reload = vi.fn()
+
+vi.mock('@/composables/useEdition', () => ({
+  useEdition: () => {
+    const historyWindows = computed(() => CATALOG)
+    const isWindowOpen = (name: string) => {
+      const spec = CATALOG.find((w) => w.window === name)
+      return !!spec && spec.seconds <= maxSeconds.value
+    }
+    return {
+      historyWindows,
+      isWindowOpen,
+      requiredEditionForWindow: (name: string) =>
+        CATALOG.find((w) => w.window === name)?.min_edition ?? null,
+      largestOpenWindow: computed(
+        () => CATALOG.filter((w) => w.seconds <= maxSeconds.value).slice(-1)[0]?.window ?? '',
+      ),
+      reload,
+    }
+  },
+}))
+
+function mountCharts() {
+  return mount(ResourceCharts, {
+    props: { containerId: 'c1' },
+    global: {
+      stubs: { RouterLink: { template: '<a><slot /></a>' }, EditionBadge: true },
+    },
+  })
+}
+
+describe('ResourceCharts window selector', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    maxSeconds.value = 21600
+    reload.mockClear()
+    vi.mocked(getResourceHistory).mockReset()
+    vi.mocked(getResourceHistory).mockResolvedValue({ points: [] } as never)
+  })
+
+  // FR-017: a closed window is shown, not hidden. Seeing one hour of history is
+  // what makes thirty days worth wanting.
+  it('renders every window of the catalogue, open or not', () => {
+    const wrapper = mountCharts()
+    for (const w of CATALOG) {
+      expect(wrapper.find(`[data-test="range-${w.window}"]`).exists()).toBe(true)
+    }
+  })
+
+  it('marks the windows the edition does not open', () => {
+    const wrapper = mountCharts()
+
+    expect(wrapper.find('[data-test="range-1h"]').attributes('data-locked')).toBeUndefined()
+    expect(wrapper.find('[data-test="range-6h"]').attributes('data-locked')).toBeUndefined()
+
+    for (const closed of ['24h', '7d', '30d', '90d']) {
+      const button = wrapper.find(`[data-test="range-${closed}"]`)
+      expect(button.attributes('data-locked')).toBe('true')
+      expect(button.attributes('disabled')).toBeDefined()
+    }
+  })
+
+  // FR-018: the interface never fires a request it knows will be refused.
+  it('does not fetch when a closed window is clicked', async () => {
+    const wrapper = mountCharts()
+    await wrapper.vm.$nextTick()
+    vi.mocked(getResourceHistory).mockClear()
+
+    await wrapper.find('[data-test="range-30d"]').trigger('click')
+    await wrapper.vm.$nextTick()
+
+    expect(getResourceHistory).not.toHaveBeenCalled()
+  })
+
+  it('fetches when an open window is clicked', async () => {
+    const wrapper = mountCharts()
+    await wrapper.vm.$nextTick()
+    vi.mocked(getResourceHistory).mockClear()
+
+    await wrapper.find('[data-test="range-6h"]').trigger('click')
+    await wrapper.vm.$nextTick()
+
+    expect(getResourceHistory).toHaveBeenCalledWith('c1', '6h')
+  })
+
+  // The cap comes from the server, so a Personal instance opens more without the
+  // component knowing anything about editions.
+  it('opens the windows a higher edition unlocks', () => {
+    maxSeconds.value = 2592000 // Personal
+    const wrapper = mountCharts()
+
+    expect(wrapper.find('[data-test="range-30d"]').attributes('data-locked')).toBeUndefined()
+    expect(wrapper.find('[data-test="range-90d"]').attributes('data-locked')).toBe('true')
+  })
+})
+
+// A license can expire between two refreshes. The refusal is the signal: the
+// view falls back rather than breaking (FR-021b, US5).
+describe('ResourceCharts when the window closes under the view', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    reload.mockClear()
+    vi.mocked(getResourceHistory).mockReset()
+  })
+
+  it('falls back to the largest open window and says so', async () => {
+    // Pro at mount: 90d is selectable.
+    maxSeconds.value = 7776000
+    vi.mocked(getResourceHistory).mockResolvedValue({ points: [] } as never)
+
+    const wrapper = mountCharts()
+    await wrapper.vm.$nextTick()
+    await wrapper.find('[data-test="range-90d"]').trigger('click')
+    await wrapper.vm.$nextTick()
+
+    // The license drops to Community, and the next refresh is refused.
+    vi.mocked(getResourceHistory).mockRejectedValue(
+      new ApiError(403, { code: 'EDITION_REQUIRED', message: 'nope', required_edition: 'pro' }, 'nope'),
+    )
+    reload.mockImplementation(async () => {
+      maxSeconds.value = 21600
+    })
+
+    await wrapper.find('[data-test="range-30d"]').trigger('click')
+    await new Promise((r) => setTimeout(r, 0))
+    await wrapper.vm.$nextTick()
+
+    expect(reload).toHaveBeenCalled()
+    const notice = wrapper.find('[data-test="window-closed-notice"]')
+    expect(notice.exists()).toBe(true)
+    expect(notice.text()).toContain('6h')
+  })
+
+  it('does not show the notice for an ordinary failure', async () => {
+    vi.mocked(getResourceHistory).mockRejectedValue(new Error('network down'))
+
+    const wrapper = mountCharts()
+    await new Promise((r) => setTimeout(r, 0))
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('[data-test="window-closed-notice"]').exists()).toBe(false)
+    expect(reload).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/components/__tests__/TopConsumersWidget.spec.ts
+++ b/frontend/src/components/__tests__/TopConsumersWidget.spec.ts
@@ -1,0 +1,91 @@
+// Copyright 2026 Benjamin Touchard (kOlapsis)
+//
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+// or a commercial license. You may not use this file except in compliance
+// with one of these licenses.
+//
+// AGPL-3.0: https://www.gnu.org/licenses/agpl-3.0.html
+// Commercial: See COMMERCIAL-LICENSE.md
+//
+// Source: https://github.com/kolapsis/maintenant
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { ref, computed } from 'vue'
+import TopConsumersWidget from '@/components/TopConsumersWidget.vue'
+
+const CATALOG = [
+  { window: '1h', seconds: 3600, min_edition: 'community' },
+  { window: '6h', seconds: 21600, min_edition: 'community' },
+  { window: '24h', seconds: 86400, min_edition: 'personal' },
+  { window: '7d', seconds: 604800, min_edition: 'personal' },
+  { window: '30d', seconds: 2592000, min_edition: 'personal' },
+  { window: '90d', seconds: 7776000, min_edition: 'pro' },
+]
+
+const maxSeconds = ref(21600) // Community
+
+vi.mock('@/composables/useEdition', () => ({
+  useEdition: () => ({
+    historyWindows: computed(() => CATALOG),
+    isWindowOpen: (name: string) => {
+      const spec = CATALOG.find((w) => w.window === name)
+      return !!spec && spec.seconds <= maxSeconds.value
+    },
+    requiredEditionForWindow: (name: string) =>
+      CATALOG.find((w) => w.window === name)?.min_edition ?? null,
+  }),
+}))
+
+function mountWidget() {
+  return mount(TopConsumersWidget, {
+    props: { metric: 'cpu' as const, period: '1h', consumers: [] },
+  })
+}
+
+describe('TopConsumersWidget periods', () => {
+  beforeEach(() => {
+    maxSeconds.value = 21600
+  })
+
+  // The widget used to hold its own free/paid split, which is what let a
+  // direct call reach a paid period the server never checked.
+  it('builds its periods from the catalogue, not from a hardcoded list', () => {
+    const wrapper = mountWidget()
+    for (const w of CATALOG) {
+      expect(wrapper.find(`[data-test="period-${w.window}"]`).exists()).toBe(true)
+    }
+  })
+
+  it('locks the periods the edition does not open', () => {
+    const wrapper = mountWidget()
+
+    expect(wrapper.find('[data-test="period-6h"]').attributes('data-locked')).toBeUndefined()
+    for (const closed of ['24h', '7d', '30d', '90d']) {
+      const button = wrapper.find(`[data-test="period-${closed}"]`)
+      expect(button.attributes('data-locked')).toBe('true')
+      expect(button.attributes('disabled')).toBeDefined()
+    }
+  })
+
+  it('does not emit for a locked period', async () => {
+    const wrapper = mountWidget()
+    await wrapper.find('[data-test="period-30d"]').trigger('click')
+    expect(wrapper.emitted('update:period')).toBeUndefined()
+  })
+
+  it('emits for an open period', async () => {
+    const wrapper = mountWidget()
+    await wrapper.find('[data-test="period-6h"]').trigger('click')
+    expect(wrapper.emitted('update:period')).toEqual([['6h']])
+  })
+
+  it('follows the cap the server reports', async () => {
+    maxSeconds.value = 7776000 // Pro
+    const wrapper = mountWidget()
+
+    expect(wrapper.find('[data-test="period-90d"]').attributes('data-locked')).toBeUndefined()
+    await wrapper.find('[data-test="period-90d"]').trigger('click')
+    expect(wrapper.emitted('update:period')).toEqual([['90d']])
+  })
+})

--- a/frontend/src/composables/useEdition.ts
+++ b/frontend/src/composables/useEdition.ts
@@ -17,6 +17,7 @@ import {
   type EditionResponse,
   type LicenseStatus,
   type QuotaResource,
+  type HistoryWindowSpec,
 } from '@/services/editionApi'
 import { sseBus } from '@/services/sseBus'
 import { onProbePayload } from '@/services/authGuard'
@@ -234,6 +235,44 @@ export function useEdition() {
     })
   }
 
+  /**
+   * The resource-history catalogue, exactly as the engine declares it. An
+   * engine that does not report one gives an empty catalogue: the interface
+   * shows what it knows and invents nothing, which is the whole point of
+   * reading this from the server rather than from a table compiled in here.
+   */
+  const historyWindows = computed<HistoryWindowSpec[]>(
+    () => edition.value?.resource_history?.windows ?? [],
+  )
+
+  /** The largest window the running edition opens, or '' when unknown. */
+  const maxHistoryWindow = computed(() => edition.value?.resource_history?.max_window ?? '')
+
+  const maxHistoryWindowSeconds = computed(
+    () => edition.value?.resource_history?.max_window_seconds ?? 0,
+  )
+
+  function isWindowOpen(name: string): boolean {
+    const spec = historyWindows.value.find((w) => w.window === name)
+    if (!spec) return false
+    return spec.seconds <= maxHistoryWindowSeconds.value
+  }
+
+  /** The edition that opens a window, or null when this build has no catalogue. */
+  function requiredEditionForWindow(name: string): Edition | null {
+    return historyWindows.value.find((w) => w.window === name)?.min_edition ?? null
+  }
+
+  /**
+   * The fallback a view drops to when the window it was showing closes under
+   * it. The catalogue is ordered by duration, so the last open entry is the
+   * largest one.
+   */
+  const largestOpenWindow = computed<string>(() => {
+    const open = historyWindows.value.filter((w) => w.seconds <= maxHistoryWindowSeconds.value)
+    return open.length > 0 ? open[open.length - 1]!.window : ''
+  })
+
   const personalization = computed(() => hasFeature('personalization'))
 
   return {
@@ -249,6 +288,12 @@ export function useEdition() {
     organisationName,
     statusURL,
     hasFeature,
+    historyWindows,
+    maxHistoryWindow,
+    maxHistoryWindowSeconds,
+    isWindowOpen,
+    requiredEditionForWindow,
+    largestOpenWindow,
     personalization,
     load,
     reload,

--- a/frontend/src/pages/EditionsPage.vue
+++ b/frontend/src/pages/EditionsPage.vue
@@ -65,7 +65,6 @@ const CAPABILITY_LABELS: Record<string, string> = {
   security_posture: 'Unified security posture',
   incidents: 'Status page incidents',
   changelog: 'Update changelog',
-  resource_history: 'Container resource history',
   alert_advanced_filters: 'Advanced trigger filters',
   ocsp_stapling: 'OCSP stapling',
   slack: 'Slack channel',
@@ -108,6 +107,10 @@ const rows = computed(() => {
   const entries = Object.entries(registry) as [string, Edition][]
 
   return entries
+    // resource_history is open in every edition; what differs is how far back,
+    // and a checkmark in all three columns would say the opposite of the truth.
+    // It gets its own row below, showing the cap per tier.
+    .filter(([capability]) => capability !== 'resource_history')
     .map(([capability, min]) => ({
       capability,
       label: CAPABILITY_LABELS[capability] ?? capability,
@@ -115,6 +118,25 @@ const rows = computed(() => {
       rank: RANK[min as Tier] ?? 99,
     }))
     .sort((a, b) => a.rank - b.rank || a.label.localeCompare(b.label))
+})
+
+/**
+ * The history cap per tier, derived from the catalogue the engine reports: for
+ * each tier, the largest window whose minimum edition that tier reaches. The
+ * three columns are computed, never written down, so this page cannot announce
+ * a window the server would refuse.
+ */
+const historyCapByTier = computed<Record<Tier, string>>(() => {
+  const windows = edition.value?.resource_history?.windows ?? []
+  const caps = { community: '', personal: '', pro: '' } as Record<Tier, string>
+
+  for (const tier of TIERS) {
+    for (const w of windows) {
+      const minRank = RANK[w.min_edition as Tier]
+      if (minRank !== undefined && RANK[tier] >= minRank) caps[tier] = w.window
+    }
+  }
+  return caps
 })
 
 function includedIn(minEdition: Edition, tier: Tier): boolean {
@@ -249,6 +271,20 @@ function isUpgrade(tier: Tier): boolean {
             <th colspan="4" class="px-4 py-3 text-left font-semibold text-mnt-primary">
               Features
             </th>
+          </tr>
+
+          <!-- A duration, not a checkmark: every edition sees a history, and
+               what it buys is how far back it goes (FR-004d). -->
+          <tr v-if="historyCapByTier.community" class="border-b border-mnt-subtle">
+            <td class="px-4 py-2.5 text-mnt-secondary">Container resource history</td>
+            <td
+              v-for="tier in TIERS"
+              :key="tier"
+              class="px-4 py-2.5 text-center"
+              :class="isActive(tier) ? 'text-mnt-primary font-medium' : 'text-mnt-muted'"
+            >
+              up to {{ historyCapByTier[tier] }}
+            </td>
           </tr>
 
           <tr

--- a/frontend/src/services/editionApi.ts
+++ b/frontend/src/services/editionApi.ts
@@ -34,6 +34,25 @@ export type QuotaResource =
  */
 export type Edition = 'community' | 'personal' | 'pro' | (string & {})
 
+/**
+ * One window of the resource-history catalogue, as the engine declares it. The
+ * whole catalogue is reported in every edition (it describes the product, not
+ * the running tier), which is what lets the interface show a closed window and
+ * name the edition that opens it without holding a table of its own.
+ */
+export interface HistoryWindowSpec {
+  window: string
+  seconds: number
+  min_edition: Edition
+}
+
+export interface ResourceHistoryContract {
+  /** The largest window the running edition opens, e.g. "6h". */
+  max_window: string
+  max_window_seconds: number
+  windows: HistoryWindowSpec[]
+}
+
 export interface EditionResponse {
   edition: Edition
   organisation_name: string
@@ -42,6 +61,8 @@ export interface EditionResponse {
   /** capability -> minimum edition that opens it, projected from the backend registry */
   feature_editions?: Record<string, Edition>
   quotas?: Partial<Record<QuotaResource, QuotaEntry>>
+  /** Absent on an engine older than the tiered history: no catalogue, no cap. */
+  resource_history?: ResourceHistoryContract
 }
 
 /**
@@ -57,6 +78,9 @@ export interface ApiErrorDetail {
   resource?: QuotaResource | string
   limit?: number
   required_edition?: Edition
+  /** EDITION_REQUIRED on a history window: what was asked, and the current cap. */
+  window?: string
+  max_window?: string
 }
 
 export function fetchEdition(): Promise<EditionResponse> {

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -81,7 +81,10 @@ func Run(ctx context.Context, cfg AgentConfig, logger *slog.Logger) error {
 
 	// From here the agent is enrolled and about to stream: report liveness so the
 	// container healthcheck has something to read (the agent serves no HTTP).
-	StartHealthReporter(ctx, cfg.DataDir, HealthInterval, logger)
+	// Waiting on the reporter before returning keeps the data directory from
+	// being written to after the agent has handed control back.
+	healthStopped := StartHealthReporter(ctx, cfg.DataDir, HealthInterval, logger)
+	defer func() { <-healthStopped }()
 
 	err = RunWithReconnect(ctx, grpcClient, id, logger, func(ctx context.Context, stream *PushStream) error {
 		logger.Info("agent: stream authenticated, starting collector", "agent_id", id.AgentID)

--- a/internal/agent/health.go
+++ b/internal/agent/health.go
@@ -58,13 +58,17 @@ func WriteHealth(dataDir string, t time.Time) error {
 	return nil
 }
 
-// StartHealthReporter refreshes the liveness file every interval until ctx is done.
+// StartHealthReporter refreshes the liveness file every interval until ctx is
+// done. The returned channel is closed once the reporter has stopped writing,
+// so a caller that needs the directory settled can wait for it: cancelling the
+// context only asks the goroutine to stop, it does not mean an in-flight write
+// has landed.
 //
 // Reachability of the server is deliberately not part of the signal: an agent
 // that cannot reach the server is already reported as disconnected there, and
 // letting an orchestrator restart the agent over it would fix nothing while
 // hiding the actual outage.
-func StartHealthReporter(ctx context.Context, dataDir string, interval time.Duration, logger *slog.Logger) {
+func StartHealthReporter(ctx context.Context, dataDir string, interval time.Duration, logger *slog.Logger) <-chan struct{} {
 	report := func() {
 		if err := WriteHealth(dataDir, time.Now()); err != nil {
 			logger.Warn("agent: liveness file refresh failed", "err", err)
@@ -72,7 +76,9 @@ func StartHealthReporter(ctx context.Context, dataDir string, interval time.Dura
 	}
 	report()
 
+	done := make(chan struct{})
 	go func() {
+		defer close(done)
 		t := time.NewTicker(interval)
 		defer t.Stop()
 		for {
@@ -80,10 +86,18 @@ func StartHealthReporter(ctx context.Context, dataDir string, interval time.Dura
 			case <-ctx.Done():
 				return
 			case <-t.C:
+				// A cancellation racing a tick leaves both cases ready and the
+				// select picks at random, so re-check before writing: without
+				// it the reporter can recreate the file after its owner
+				// believes it has stopped.
+				if ctx.Err() != nil {
+					return
+				}
 				report()
 			}
 		}
 	}()
+	return done
 }
 
 // CheckHealth reports whether an agent refreshed its liveness file within maxAge.

--- a/internal/agent/health_test.go
+++ b/internal/agent/health_test.go
@@ -68,7 +68,11 @@ func TestStartHealthReporter_WritesImmediatelyThenRefreshes(t *testing.T) {
 	dir := t.TempDir()
 	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError}))
 
-	StartHealthReporter(t.Context(), dir, 10*time.Millisecond, logger)
+	// Registered after t.TempDir, so cleanups run it first: the reporter is
+	// stopped before the directory is removed. Without it the goroutine can
+	// recreate the liveness file mid-RemoveAll and fail the cleanup.
+	stopped := StartHealthReporter(t.Context(), dir, 10*time.Millisecond, logger)
+	t.Cleanup(func() { <-stopped })
 	require.NoError(t, CheckHealth(dir, HealthMaxAge, time.Now()),
 		"liveness must be published before the first tick")
 

--- a/internal/api/v1/edition_conformance_test.go
+++ b/internal/api/v1/edition_conformance_test.go
@@ -118,6 +118,70 @@ func TestConformance_SMTPSeparatesPermissionFromConfiguration(t *testing.T) {
 		unconfigured["feature_editions"].(map[string]any)["smtp"])
 }
 
+// TestConformance_HistoryWindowsMatchWhatTheEndpointsAccept is FR-016 and
+// SC-003: for each edition, the set of windows the interface is told are open
+// must be exactly the set both history endpoints actually serve. A drift here
+// is the defect the whole feature exists to prevent: a window offered and then
+// refused, or refused and quietly served.
+func TestConformance_HistoryWindowsMatchWhatTheEndpointsAccept(t *testing.T) {
+	for _, edition := range []extension.Edition{extension.Community, extension.Personal, extension.Pro} {
+		t.Run(string(edition), func(t *testing.T) {
+			withEdition(t, edition)
+
+			body := editionResponse(t, true)
+			history, ok := body["resource_history"].(map[string]any)
+			require.True(t, ok, "the edition response carries no resource_history object")
+
+			windows, ok := history["windows"].([]any)
+			require.True(t, ok)
+			require.Len(t, windows, 6)
+
+			maxSeconds, ok := history["max_window_seconds"].(float64)
+			require.True(t, ok)
+
+			// max_window is always one of the catalogue's own names, never empty.
+			maxName, _ := history["max_window"].(string)
+			require.NotEmpty(t, maxName)
+
+			announcedOpen := map[string]bool{}
+			foundMax := false
+			for _, raw := range windows {
+				spec := raw.(map[string]any)
+				name := spec["window"].(string)
+				seconds := spec["seconds"].(float64)
+				announcedOpen[name] = seconds <= maxSeconds
+				if name == maxName {
+					foundMax = true
+				}
+
+				// The two ways of saying the same thing must agree: "within the
+				// cap" and "the edition ranks at or above the window's minimum".
+				minEdition := extension.Edition(spec["min_edition"].(string))
+				assert.Equal(t, edition.AtLeast(minEdition), announcedOpen[name],
+					"window %q: cap says %v, edition ranking says %v",
+					name, announcedOpen[name], edition.AtLeast(minEdition))
+			}
+			assert.True(t, foundMax, "max_window %q is not in the catalogue", maxName)
+
+			for name, open := range announcedOpen {
+				historyStub := &stubHistoryService{}
+				gotHistory := historyRequest(t, historyStub, name).Code
+
+				topStub := &stubTopService{}
+				gotTop := topRequest(t, topStub, "period="+name).Code
+
+				if open {
+					assert.Equal(t, http.StatusOK, gotHistory, "%s announced open, history refused it", name)
+					assert.Equal(t, http.StatusOK, gotTop, "%s announced open, top consumers refused it", name)
+					continue
+				}
+				assert.Equal(t, http.StatusForbidden, gotHistory, "%s announced closed, history served it", name)
+				assert.Equal(t, http.StatusForbidden, gotTop, "%s announced closed, top consumers served it", name)
+			}
+		})
+	}
+}
+
 // TestConformance_QuotasReportRealUsage: `used` used to be pinned to 0 on Pro,
 // so an instance running fifty endpoints reported none. Every edition now
 // counts, and the limit always comes from extension.Limit.

--- a/internal/api/v1/middleware.go
+++ b/internal/api/v1/middleware.go
@@ -175,6 +175,37 @@ func requireCapability(c extension.Capability, next http.HandlerFunc) http.Handl
 	}
 }
 
+// resolveHistoryWindow turns a window parameter into a window the running
+// edition actually opens, and writes the refusal itself when it cannot.
+//
+// It is the single place both history endpoints decide from, so they cannot
+// drift: a window the product does not know is a bad request, a window it knows
+// but the edition does not open is an edition refusal, and the two never look
+// alike. Nothing here falls back to the cap: a caller asking for more than it
+// gets has to be told, not quietly served less.
+func resolveHistoryWindow(w http.ResponseWriter, name, invalidCode string) (extension.HistoryWindow, bool) {
+	window, known := extension.ResolveHistoryWindow(name)
+	if !known {
+		WriteError(w, http.StatusBadRequest, invalidCode,
+			"Window must be one of "+extension.HistoryWindowNames())
+		return extension.HistoryWindow{}, false
+	}
+
+	if allowed, required := extension.AllowsHistoryWindow(window); !allowed {
+		WriteErrorDetail(w, http.StatusForbidden, ErrorDetail{
+			Code:            "EDITION_REQUIRED",
+			Message:         "The " + window.Name + " window requires the " + titleEdition(required) + " edition.",
+			Feature:         string(extension.CapResourceHistory),
+			RequiredEdition: string(required),
+			Window:          window.Name,
+			MaxWindow:       extension.MaxHistoryWindow().Name,
+		})
+		return extension.HistoryWindow{}, false
+	}
+
+	return window, true
+}
+
 // refuseCapability writes the same refusal as requireCapability, for handlers
 // that check a capability partway through rather than at the door.
 func refuseCapability(w http.ResponseWriter, c extension.Capability) {

--- a/internal/api/v1/resources.go
+++ b/internal/api/v1/resources.go
@@ -12,6 +12,7 @@
 package v1
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"runtime"
@@ -21,15 +22,23 @@ import (
 	"github.com/kolapsis/maintenant/internal/uid"
 )
 
+// ResourceHistoryService is what the history endpoint reads, and no more. It
+// exists so the window gate can be exercised without standing up a store, a
+// runtime and a container service behind it.
+type ResourceHistoryService interface {
+	GetHistory(ctx context.Context, containerID string, window string) ([]*resource.ResourceSnapshot, resource.Granularity, error)
+}
+
 // ResourceHandler handles resource monitoring HTTP endpoints.
 type ResourceHandler struct {
 	service *resource.Service
+	history ResourceHistoryService
 	agents  AgentDirectory // optional — names hosts in the /resources/hosts list
 }
 
 // NewResourceHandler creates a new resource handler.
 func NewResourceHandler(service *resource.Service) *ResourceHandler {
-	return &ResourceHandler{service: service}
+	return &ResourceHandler{service: service, history: service}
 }
 
 // SetAgentDirectory wires the agent directory so /resources/hosts can label
@@ -262,14 +271,14 @@ func (h *ResourceHandler) HandleGetHistory(w http.ResponseWriter, r *http.Reques
 		timeRange = "1h"
 	}
 
-	switch timeRange {
-	case "1h", "6h", "24h", "7d":
-	default:
-		WriteError(w, http.StatusBadRequest, "INVALID_RANGE", "Range must be 1h, 6h, 24h, or 7d")
+	// The window is both validated and gated here: the route itself is open in
+	// every edition, and what an edition buys is how far back it may look.
+	window, ok := resolveHistoryWindow(w, timeRange, "INVALID_RANGE")
+	if !ok {
 		return
 	}
 
-	snaps, granularity, err := h.service.GetHistory(r.Context(), id, timeRange)
+	snaps, granularity, err := h.history.GetHistory(r.Context(), id, window.Name)
 	if err != nil {
 		WriteStoreError(w, err, "Failed to fetch resource history")
 		return
@@ -291,7 +300,7 @@ func (h *ResourceHandler) HandleGetHistory(w http.ResponseWriter, r *http.Reques
 
 	WriteJSON(w, http.StatusOK, map[string]interface{}{
 		"container_id": id,
-		"range":        timeRange,
+		"range":        window.Name,
 		"granularity":  granularity,
 		"points":       points,
 	})

--- a/internal/api/v1/resources_top.go
+++ b/internal/api/v1/resources_top.go
@@ -14,7 +14,6 @@ package v1
 import (
 	"context"
 	"net/http"
-	"sort"
 	"strconv"
 
 	"github.com/kolapsis/maintenant/internal/resource"
@@ -22,8 +21,8 @@ import (
 
 // ResourceTopService abstracts the resource service for top consumers.
 type ResourceTopService interface {
-	GetAllLatestSnapshots() map[string]*resource.ResourceSnapshot
 	GetContainerName(containerID string) string
+	TopConsumersNow(metric string, limit int, agentID *string) []resource.TopConsumerRow
 	GetTopConsumersByPeriod(ctx context.Context, metric, period string, limit int, agentID *string) ([]resource.TopConsumerRow, error)
 }
 
@@ -46,7 +45,7 @@ type TopConsumer struct {
 	Rank          int     `json:"rank"`
 }
 
-// HandleGetTopConsumers handles GET /api/v1/resources/top?metric=cpu|memory&limit=5&period=1h|24h|7d|30d.
+// HandleGetTopConsumers handles GET /api/v1/resources/top?metric=cpu|memory&limit=5&period=<window>.
 func (h *ResourceTopHandler) HandleGetTopConsumers(w http.ResponseWriter, r *http.Request) {
 	metric := r.URL.Query().Get("metric")
 	if metric != "cpu" && metric != "memory" {
@@ -66,13 +65,23 @@ func (h *ResourceTopHandler) HandleGetTopConsumers(w http.ResponseWriter, r *htt
 
 	hostFilter := parseHostFilter(r)
 
+	// No period at all is the realtime ranking, open in every edition: the cap
+	// is about history, not about live metrics (FR-024).
 	period := r.URL.Query().Get("period")
-	if period == "1h" || period == "24h" || period == "7d" || period == "30d" {
-		h.handlePeriodQuery(w, r, metric, period, limit, hostFilter)
+	if period == "" {
+		h.handleRealtimeQuery(w, metric, limit, hostFilter)
 		return
 	}
 
-	h.handleRealtimeQuery(w, metric, limit, hostFilter)
+	// Same catalogue and same cap as the per-container chart, decided in the
+	// same place. This endpoint served its 30d period to any edition until now
+	// (FR-014): the refusal below is what closes that.
+	window, ok := resolveHistoryWindow(w, period, "INVALID_PERIOD")
+	if !ok {
+		return
+	}
+
+	h.handlePeriodQuery(w, r, metric, window.Name, limit, hostFilter)
 }
 
 func (h *ResourceTopHandler) handlePeriodQuery(w http.ResponseWriter, r *http.Request, metric, period string, limit int, agentID *string) {
@@ -101,49 +110,15 @@ func (h *ResourceTopHandler) handlePeriodQuery(w http.ResponseWriter, r *http.Re
 }
 
 func (h *ResourceTopHandler) handleRealtimeQuery(w http.ResponseWriter, metric string, limit int, agentID *string) {
-	all := h.svc.GetAllLatestSnapshots()
+	rows := h.svc.TopConsumersNow(metric, limit, agentID)
 
-	type entry struct {
-		id      string
-		value   float64
-		percent float64
-	}
-	entries := make([]entry, 0, len(all))
-	for cID, snap := range all {
-		if !hostMatches(snap.AgentID, agentID) {
-			continue
-		}
-		var value, pct float64
-		switch metric {
-		case "cpu":
-			value = snap.CPUPercent
-			pct = snap.CPUPercent
-		case "memory":
-			value = float64(snap.MemUsed)
-			pct = 0.0
-			if snap.MemLimit > 0 {
-				pct = float64(snap.MemUsed) / float64(snap.MemLimit) * 100.0
-			}
-		}
-		entries = append(entries, entry{id: cID, value: value, percent: pct})
-	}
-
-	sort.Slice(entries, func(i, j int) bool {
-		return entries[i].value > entries[j].value
-	})
-
-	if limit > len(entries) {
-		limit = len(entries)
-	}
-	consumers := make([]TopConsumer, 0, limit)
-	for i := 0; i < limit; i++ {
-		e := entries[i]
-		name := h.svc.GetContainerName(e.id)
+	consumers := make([]TopConsumer, 0, len(rows))
+	for i, row := range rows {
 		consumers = append(consumers, TopConsumer{
-			ContainerID:   e.id,
-			ContainerName: name,
-			Value:         e.value,
-			Percent:       e.percent,
+			ContainerID:   row.ContainerID,
+			ContainerName: row.ContainerName,
+			Value:         row.AvgValue,
+			Percent:       row.AvgPercent,
 			Rank:          i + 1,
 		})
 	}

--- a/internal/api/v1/resources_top_test.go
+++ b/internal/api/v1/resources_top_test.go
@@ -16,6 +16,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sort"
 	"testing"
 	"time"
 
@@ -32,6 +33,36 @@ type mockResourceTopService struct {
 
 func (m *mockResourceTopService) GetAllLatestSnapshots() map[string]*resource.ResourceSnapshot {
 	return m.snapshots
+}
+
+// TopConsumersNow mirrors what the real service does with the latest samples,
+// so these tests keep exercising the ranking the endpoint reports.
+func (m *mockResourceTopService) TopConsumersNow(metric string, limit int, agentID *string) []resource.TopConsumerRow {
+	rows := make([]resource.TopConsumerRow, 0, len(m.snapshots))
+	for id, snap := range m.snapshots {
+		if !hostMatches(snap.AgentID, agentID) {
+			continue
+		}
+		var value, percent float64
+		switch metric {
+		case "cpu":
+			value, percent = snap.CPUPercent, snap.CPUPercent
+		case "memory":
+			value = float64(snap.MemUsed)
+			if snap.MemLimit > 0 {
+				percent = float64(snap.MemUsed) / float64(snap.MemLimit) * 100.0
+			}
+		}
+		rows = append(rows, resource.TopConsumerRow{
+			ContainerID: id, ContainerName: m.GetContainerName(id),
+			AvgValue: value, AvgPercent: percent,
+		})
+	}
+	sort.Slice(rows, func(i, j int) bool { return rows[i].AvgValue > rows[j].AvgValue })
+	if limit < len(rows) {
+		rows = rows[:limit]
+	}
+	return rows
 }
 
 func (m *mockResourceTopService) GetContainerName(containerID string) string {

--- a/internal/api/v1/resources_window_test.go
+++ b/internal/api/v1/resources_window_test.go
@@ -1,0 +1,232 @@
+// Copyright 2026 Benjamin Touchard (kOlapsis)
+//
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+// or a commercial license. You may not use this file except in compliance
+// with one of these licenses.
+//
+// AGPL-3.0: https://www.gnu.org/licenses/agpl-3.0.html
+// Commercial: See COMMERCIAL-LICENSE.md
+//
+// Source: https://github.com/kolapsis/maintenant
+
+package v1
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kolapsis/maintenant/internal/extension"
+	"github.com/kolapsis/maintenant/internal/resource"
+)
+
+// This file is the matrix of contracts/resource-history.md and
+// contracts/resource-top.md: for every edition and every window, both history
+// endpoints must answer the same way. A window the product does not know is a
+// bad request; one it knows but the edition does not open is an edition
+// refusal; and the two are never confused.
+
+// stubHistoryService serves one point for any window, so the test measures the
+// gate and not the data.
+type stubHistoryService struct {
+	calls []string
+}
+
+func (s *stubHistoryService) GetHistory(_ context.Context, _ string, window string) ([]*resource.ResourceSnapshot, resource.Granularity, error) {
+	s.calls = append(s.calls, window)
+	return []*resource.ResourceSnapshot{{ContainerID: "c1", CPUPercent: 12, Timestamp: time.Now()}}, resource.Granularity1h, nil
+}
+
+func historyRequest(t *testing.T, svc *stubHistoryService, window string) *httptest.ResponseRecorder {
+	t.Helper()
+	h := &ResourceHandler{history: svc}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/containers/c1/resources/history?range="+window, nil)
+	req.SetPathValue("id", "c1")
+	rec := httptest.NewRecorder()
+	h.HandleGetHistory(rec, req)
+	return rec
+}
+
+func decodeError(t *testing.T, rec *httptest.ResponseRecorder) map[string]any {
+	t.Helper()
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	detail, ok := body["error"].(map[string]any)
+	require.True(t, ok, "refusal has no error object: %s", rec.Body.String())
+
+	// FR-012: a refusal never carries data. Truncating to the cap silently, or
+	// answering with a partial series, is exactly what the specification bans.
+	assert.NotContains(t, body, "points", "a refusal must not carry points")
+	return detail
+}
+
+// windowMatrix is the table both endpoints are held to. An empty required
+// edition means the window is open.
+var windowMatrix = map[extension.Edition]map[string]string{
+	extension.Community: {
+		"1h": "", "6h": "",
+		"24h": "personal", "7d": "personal", "30d": "personal",
+		"90d": "pro",
+	},
+	extension.Personal: {
+		"1h": "", "6h": "", "24h": "", "7d": "", "30d": "",
+		"90d": "pro",
+	},
+	extension.Pro: {
+		"1h": "", "6h": "", "24h": "", "7d": "", "30d": "", "90d": "",
+	},
+}
+
+func TestHistoryWindows_Matrix(t *testing.T) {
+	for edition, windows := range windowMatrix {
+		for window, required := range windows {
+			t.Run(string(edition)+"/"+window, func(t *testing.T) {
+				withEdition(t, edition)
+				svc := &stubHistoryService{}
+				rec := historyRequest(t, svc, window)
+
+				if required == "" {
+					require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+					assert.Equal(t, []string{window}, svc.calls, "the window must reach the service verbatim")
+					return
+				}
+
+				require.Equal(t, http.StatusForbidden, rec.Code, "body: %s", rec.Body.String())
+				assert.Empty(t, svc.calls, "a refused window must never reach the service")
+
+				detail := decodeError(t, rec)
+				assert.Equal(t, "EDITION_REQUIRED", detail["code"])
+				assert.Equal(t, required, detail["required_edition"])
+				assert.Equal(t, window, detail["window"])
+				assert.Equal(t, string(extension.CapResourceHistory), detail["feature"])
+
+				// The cap is the running edition's own, not the required one's:
+				// it is what the interface shows as "you have up to this".
+				expectedCap := map[extension.Edition]string{
+					extension.Community: "6h", extension.Personal: "30d", extension.Pro: "90d",
+				}[edition]
+				assert.Equal(t, expectedCap, detail["max_window"])
+			})
+		}
+	}
+}
+
+// stubTopService records which periods reach the store layer.
+type stubTopService struct {
+	mockResourceTopService
+	calls []string
+}
+
+func (s *stubTopService) GetTopConsumersByPeriod(_ context.Context, _ string, period string, _ int, _ *string) ([]resource.TopConsumerRow, error) {
+	s.calls = append(s.calls, period)
+	return []resource.TopConsumerRow{{ContainerID: "c1", AvgValue: 10, AvgPercent: 10}}, nil
+}
+
+func topRequest(t *testing.T, svc *stubTopService, query string) *httptest.ResponseRecorder {
+	t.Helper()
+	h := NewResourceTopHandler(svc)
+	rec := httptest.NewRecorder()
+	h.HandleGetTopConsumers(rec, httptest.NewRequest(http.MethodGet, "/api/v1/resources/top?metric=cpu&"+query, nil))
+	return rec
+}
+
+// The same matrix on the top consumers. Community x 30d is the bypass this
+// feature closes: it answered 200 to any edition before (FR-014).
+func TestTopConsumerWindows_Matrix(t *testing.T) {
+	for edition, windows := range windowMatrix {
+		for window, required := range windows {
+			t.Run(string(edition)+"/"+window, func(t *testing.T) {
+				withEdition(t, edition)
+				svc := &stubTopService{}
+				rec := topRequest(t, svc, "period="+window)
+
+				if required == "" {
+					require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+					assert.Equal(t, []string{window}, svc.calls)
+					return
+				}
+
+				require.Equal(t, http.StatusForbidden, rec.Code, "body: %s", rec.Body.String())
+				assert.Empty(t, svc.calls, "a refused window must never reach the store")
+
+				detail := decodeError(t, rec)
+				assert.Equal(t, "EDITION_REQUIRED", detail["code"])
+				assert.Equal(t, required, detail["required_edition"])
+				assert.Equal(t, window, detail["window"])
+			})
+		}
+	}
+}
+
+// The host filter is not a way around the cap.
+func TestTopConsumerWindows_HostFilterDoesNotOpenTheCap(t *testing.T) {
+	withEdition(t, extension.Community)
+	for _, host := range []string{"", "local", "agent-9"} {
+		svc := &stubTopService{}
+		rec := topRequest(t, svc, "period=30d&agent_id="+host)
+		assert.Equal(t, http.StatusForbidden, rec.Code, "agent_id=%q", host)
+		assert.Empty(t, svc.calls)
+	}
+}
+
+// An unknown period is a bad request now, where it used to fall through to the
+// realtime ranking without saying anything (FR-011).
+func TestTopConsumerWindows_UnknownPeriodIsABadRequest(t *testing.T) {
+	withEdition(t, extension.Pro)
+	svc := &stubTopService{}
+	rec := topRequest(t, svc, "period=2d")
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Equal(t, "INVALID_PERIOD", decodeError(t, rec)["code"])
+	assert.Empty(t, svc.calls)
+}
+
+// No period at all is the realtime ranking, open everywhere (FR-024).
+func TestTopConsumerWindows_RealtimeStaysOpen(t *testing.T) {
+	for _, edition := range []extension.Edition{extension.Community, extension.Personal, extension.Pro} {
+		withEdition(t, edition)
+		svc := &stubTopService{}
+		rec := topRequest(t, svc, "")
+
+		assert.Equal(t, http.StatusOK, rec.Code, "edition %q", edition)
+		assert.Empty(t, svc.calls, "the realtime ranking does not read history")
+	}
+}
+
+// A window the product does not know is a bad request, distinct from an edition
+// refusal by both code and status (FR-011).
+func TestHistoryWindows_UnknownWindowIsABadRequest(t *testing.T) {
+	for _, edition := range []extension.Edition{extension.Community, extension.Personal, extension.Pro} {
+		for _, window := range []string{"12h", "2d", "365d", "1H"} {
+			t.Run(string(edition)+"/"+window, func(t *testing.T) {
+				withEdition(t, edition)
+				svc := &stubHistoryService{}
+				rec := historyRequest(t, svc, window)
+
+				require.Equal(t, http.StatusBadRequest, rec.Code)
+				assert.Empty(t, svc.calls)
+				assert.Equal(t, "INVALID_RANGE", decodeError(t, rec)["code"])
+			})
+		}
+	}
+}
+
+// An absent range keeps its historical default rather than becoming an error.
+func TestHistoryWindows_AbsentRangeDefaultsToOneHour(t *testing.T) {
+	withEdition(t, extension.Community)
+	svc := &stubHistoryService{}
+	h := &ResourceHandler{history: svc}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/containers/c1/resources/history", nil)
+	req.SetPathValue("id", "c1")
+	rec := httptest.NewRecorder()
+	h.HandleGetHistory(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, []string{"1h"}, svc.calls)
+}

--- a/internal/api/v1/router.go
+++ b/internal/api/v1/router.go
@@ -59,6 +59,8 @@ type ErrorDetail struct {
 	Resource        string `json:"resource,omitempty"`         // QUOTA_EXCEEDED, HOST_LIMIT_REACHED
 	Limit           *int   `json:"limit,omitempty"`            // QUOTA_EXCEEDED, HOST_LIMIT_REACHED
 	RequiredEdition string `json:"required_edition,omitempty"` // both
+	Window          string `json:"window,omitempty"`           // EDITION_REQUIRED on a history window
+	MaxWindow       string `json:"max_window,omitempty"`       // the running edition's cap
 }
 
 // HandlerDeps holds all dependencies needed to build the API handler.
@@ -282,7 +284,9 @@ func NewRouter(d HandlerDeps) *Router {
 			rh.SetAgentDirectory(agentStoreDirectory{store: d.AgentStore})
 		}
 		r.mux.HandleFunc("GET /api/v1/containers/{id}/resources/current", rh.HandleGetCurrent)
-		r.mux.HandleFunc("GET /api/v1/containers/{id}/resources/history", requireCapability(extension.CapResourceHistory, rh.HandleGetHistory))
+		// Open in every edition: the handler caps the window instead of the
+		// route refusing the whole history (FR-002).
+		r.mux.HandleFunc("GET /api/v1/containers/{id}/resources/history", rh.HandleGetHistory)
 		r.mux.HandleFunc("GET /api/v1/resources/summary", rh.HandleGetSummary)
 		r.mux.HandleFunc("GET /api/v1/resources/hosts", rh.HandleGetHosts)
 		r.mux.HandleFunc("GET /api/v1/containers/{id}/resources/alerts", rh.HandleGetAlertConfig)
@@ -821,6 +825,12 @@ func (r *Router) handleGetEdition(smtpConfigured bool, d HandlerDeps) http.Handl
 		// is ready. The two refusals must stay distinguishable (FR-015).
 		features[string(extension.CapSMTP)] = extension.Allows(extension.CapSMTP) && smtpConfigured
 
+		// The history cap is a duration, not a flag, so it travels beside the
+		// capabilities rather than among them. The catalogue is the same in
+		// every edition: it describes the product, which is what lets the
+		// interface show a closed window and name what would open it.
+		maxWindow := extension.MaxHistoryWindow()
+
 		WriteJSON(w, http.StatusOK, map[string]interface{}{
 			"edition":           string(extension.CurrentEdition()),
 			"organisation_name": r.organisationName,
@@ -828,6 +838,11 @@ func (r *Router) handleGetEdition(smtpConfigured bool, d HandlerDeps) http.Handl
 			"features":          features,
 			"feature_editions":  featureEditions,
 			"quotas":            r.computeQuotas(ctx, d),
+			"resource_history": map[string]interface{}{
+				"max_window":         maxWindow.Name,
+				"max_window_seconds": int64(maxWindow.Duration / time.Second),
+				"windows":            extension.HistoryWindowCatalog(),
+			},
 		})
 	}
 }

--- a/internal/extension/capability.go
+++ b/internal/extension/capability.go
@@ -24,6 +24,10 @@ const (
 	CapAlertRouting   Capability = "alert_routing"
 	CapSwarmDashboard Capability = "swarm_dashboard"
 	CapK8sCluster     Capability = "k8s_cluster"
+	// CapResourceHistory is the right to see a history at all, which every
+	// edition now has. What separates the editions is how far back they may
+	// look, and that is a duration. See history_window.go.
+	CapResourceHistory Capability = "resource_history"
 
 	// Personal
 	CapMultihost            Capability = "multihost"
@@ -32,7 +36,6 @@ const (
 	CapChangelog            Capability = "changelog"
 	CapIncidents            Capability = "incidents"
 	CapSMTP                 Capability = "smtp"
-	CapResourceHistory      Capability = "resource_history"
 	CapAlertAdvancedFilters Capability = "alert_advanced_filters"
 	CapSecurityPosture      Capability = "security_posture"
 	CapOCSPStapling         Capability = "ocsp_stapling"
@@ -51,9 +54,10 @@ const (
 // middleware, the MCP tools and the /api/v1/edition response all read it, which
 // is what keeps the three surfaces from drifting apart.
 var minEdition = map[Capability]Edition{
-	CapAlertRouting:   Community,
-	CapSwarmDashboard: Community,
-	CapK8sCluster:     Community,
+	CapAlertRouting:    Community,
+	CapSwarmDashboard:  Community,
+	CapK8sCluster:      Community,
+	CapResourceHistory: Community,
 
 	CapMultihost:            Personal,
 	CapCVEEnrichment:        Personal,
@@ -61,7 +65,6 @@ var minEdition = map[Capability]Edition{
 	CapChangelog:            Personal,
 	CapIncidents:            Personal,
 	CapSMTP:                 Personal,
-	CapResourceHistory:      Personal,
 	CapAlertAdvancedFilters: Personal,
 	CapSecurityPosture:      Personal,
 	CapOCSPStapling:         Personal,

--- a/internal/extension/capability_test.go
+++ b/internal/extension/capability_test.go
@@ -52,10 +52,13 @@ func TestCatalog_ReturnsACopy(t *testing.T) {
 // silently change price.
 func TestMinEdition_TierMembership(t *testing.T) {
 	tiers := map[Edition][]Capability{
-		Community: {CapAlertRouting, CapSwarmDashboard, CapK8sCluster},
+		// resource_history is the right to see a history at all, which every
+		// edition has. What the paid editions buy is how far back: a duration,
+		// held in history_window.go, not a flag.
+		Community: {CapAlertRouting, CapSwarmDashboard, CapK8sCluster, CapResourceHistory},
 		Personal: {
 			CapMultihost, CapCVEEnrichment, CapRiskScoring, CapChangelog,
-			CapIncidents, CapSMTP, CapResourceHistory, CapAlertAdvancedFilters,
+			CapIncidents, CapSMTP, CapAlertAdvancedFilters,
 			CapSecurityPosture, CapOCSPStapling,
 		},
 		Pro: {

--- a/internal/extension/history_window.go
+++ b/internal/extension/history_window.go
@@ -1,0 +1,140 @@
+// Copyright 2026 Benjamin Touchard (Kolapsis)
+//
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+// or a commercial license. You may not use this file except in compliance
+// with one of these licenses.
+//
+// AGPL-3.0: https://www.gnu.org/licenses/agpl-3.0.html
+// Commercial: See COMMERCIAL-LICENSE.md
+//
+// Source: https://github.com/kolapsis/maintenant
+
+package extension
+
+import (
+	"strings"
+	"time"
+)
+
+// HistoryWindow is one of the resource-history ranges the product knows how to
+// serve. The name is what travels on the wire (the `range` and `period` query
+// parameters); the duration is the only thing ever compared to an edition cap.
+type HistoryWindow struct {
+	Name     string
+	Duration time.Duration
+}
+
+// HistoryWindowSpec is how one window is projected to the interface by
+// GET /api/v1/edition. It carries the edition that opens the window so the
+// frontend never has to hold an edition table of its own.
+type HistoryWindowSpec struct {
+	Window     string `json:"window"`
+	Seconds    int64  `json:"seconds"`
+	MinEdition string `json:"min_edition"`
+}
+
+// editionHistoryCap is how far back each edition may look. Three entries, and
+// the only place a change of the commercial tiering has to touch. It is a
+// duration and not a list of windows on purpose: adding a window to the product
+// must not require editing this table.
+var editionHistoryCap = map[Edition]time.Duration{
+	Community: 6 * time.Hour,
+	Personal:  30 * 24 * time.Hour,
+	Pro:       90 * 24 * time.Hour,
+}
+
+// historyWindows are the windows the product serves, ordered by duration.
+// Adding one here adds neither a capability nor an entry in editionHistoryCap:
+// the edition that opens it is derived, never written down.
+var historyWindows = []HistoryWindow{
+	{Name: "1h", Duration: time.Hour},
+	{Name: "6h", Duration: 6 * time.Hour},
+	{Name: "24h", Duration: 24 * time.Hour},
+	{Name: "7d", Duration: 7 * 24 * time.Hour},
+	{Name: "30d", Duration: 30 * 24 * time.Hour},
+	{Name: "90d", Duration: 90 * 24 * time.Hour},
+}
+
+// editionOrder is the ascending edition order the derivation walks.
+var editionOrder = []Edition{Community, Personal, Pro}
+
+// historyCap returns how far back e may look. An edition this binary does not
+// know falls back to the Community cap rather than to zero: it keeps
+// MaxHistoryWindow from returning an empty window, and it falls on the safe
+// side, since an unreadable edition opens nothing that is paid for.
+func historyCap(e Edition) time.Duration {
+	if d, ok := editionHistoryCap[e]; ok {
+		return d
+	}
+	return editionHistoryCap[Community]
+}
+
+// MinEditionForHistoryWindow returns the lowest edition whose cap covers w.
+// Nothing writes this mapping by hand, so nothing can contradict it.
+func MinEditionForHistoryWindow(w HistoryWindow) Edition {
+	for _, e := range editionOrder {
+		if historyCap(e) >= w.Duration {
+			return e
+		}
+	}
+	// A window past every cap is not one we hand out.
+	return Pro
+}
+
+// MaxHistoryWindow returns the largest window the running edition opens. The
+// catalogue always starts below the lowest cap, so this always resolves.
+func MaxHistoryWindow() HistoryWindow {
+	limit := historyCap(CurrentEdition())
+	max := historyWindows[0]
+	for _, w := range historyWindows {
+		if w.Duration <= limit {
+			max = w
+		}
+	}
+	return max
+}
+
+// ResolveHistoryWindow looks a window up by name. The second result reports
+// whether the product knows it at all: a window nobody declared is a bad
+// request, which is a different refusal from one the edition does not open.
+func ResolveHistoryWindow(name string) (HistoryWindow, bool) {
+	for _, w := range historyWindows {
+		if w.Name == name {
+			return w, true
+		}
+	}
+	return HistoryWindow{}, false
+}
+
+// AllowsHistoryWindow reports whether the running edition opens w, and names the
+// edition that would open it when it does not.
+func AllowsHistoryWindow(w HistoryWindow) (bool, Edition) {
+	required := MinEditionForHistoryWindow(w)
+	return w.Duration <= historyCap(CurrentEdition()), required
+}
+
+// HistoryWindowCatalog returns the whole catalogue, with the edition that opens
+// each window. It is identical in every edition: it describes the product, not
+// the running tier, which is what lets the interface show a closed window and
+// name what would open it.
+func HistoryWindowCatalog() []HistoryWindowSpec {
+	out := make([]HistoryWindowSpec, 0, len(historyWindows))
+	for _, w := range historyWindows {
+		out = append(out, HistoryWindowSpec{
+			Window:     w.Name,
+			Seconds:    int64(w.Duration / time.Second),
+			MinEdition: string(MinEditionForHistoryWindow(w)),
+		})
+	}
+	return out
+}
+
+// HistoryWindowNames lists the catalogue for a refusal message, so the message
+// cannot drift from what the resolver accepts.
+func HistoryWindowNames() string {
+	names := make([]string, 0, len(historyWindows))
+	for _, w := range historyWindows {
+		names = append(names, w.Name)
+	}
+	return strings.Join(names, ", ")
+}

--- a/internal/extension/history_window_test.go
+++ b/internal/extension/history_window_test.go
@@ -1,0 +1,133 @@
+package extension
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The catalogue is ordered by duration. The order is not decoration: it carries
+// the window selector and the "largest open window" fallback.
+func TestHistoryWindowCatalog_IsOrderedByDuration(t *testing.T) {
+	catalog := HistoryWindowCatalog()
+	require.Len(t, catalog, 6)
+	for i := 1; i < len(catalog); i++ {
+		assert.Greater(t, catalog[i].Seconds, catalog[i-1].Seconds,
+			"catalogue is out of order at %q", catalog[i].Window)
+	}
+	assert.Equal(t, "1h", catalog[0].Window)
+	assert.Equal(t, "90d", catalog[len(catalog)-1].Window)
+}
+
+// The minimum edition of every window is derived from the three caps. This is
+// the table the specification states, and nothing writes it by hand.
+func TestMinEditionForHistoryWindow_IsDerivedFromTheCaps(t *testing.T) {
+	want := map[string]Edition{
+		"1h": Community, "6h": Community,
+		"24h": Personal, "7d": Personal, "30d": Personal,
+		"90d": Pro,
+	}
+	for name, expected := range want {
+		w, ok := ResolveHistoryWindow(name)
+		require.True(t, ok, "window %q is not in the catalogue", name)
+		assert.Equal(t, expected, MinEditionForHistoryWindow(w), "window %q", name)
+	}
+}
+
+// The catalogue projection carries the same derivation, and it is identical in
+// every edition: it describes the product, not the running tier.
+func TestHistoryWindowCatalog_IsTheSameInEveryEdition(t *testing.T) {
+	var first []HistoryWindowSpec
+	for _, e := range []Edition{Community, Personal, Pro} {
+		withEdition(t, e)
+		catalog := HistoryWindowCatalog()
+		if first == nil {
+			first = catalog
+			continue
+		}
+		assert.Equal(t, first, catalog, "catalogue changed under edition %q", e)
+	}
+}
+
+func TestMaxHistoryWindow_PerEdition(t *testing.T) {
+	for edition, want := range map[Edition]string{
+		Community: "6h",
+		Personal:  "30d",
+		Pro:       "90d",
+	} {
+		withEdition(t, edition)
+		assert.Equal(t, want, MaxHistoryWindow().Name, "edition %q", edition)
+	}
+}
+
+func TestAllowsHistoryWindow_MatchesTheCaps(t *testing.T) {
+	type want struct {
+		allowed  bool
+		required Edition
+	}
+	matrix := map[Edition]map[string]want{
+		Community: {
+			"1h": {true, Community}, "6h": {true, Community},
+			"24h": {false, Personal}, "7d": {false, Personal}, "30d": {false, Personal},
+			"90d": {false, Pro},
+		},
+		Personal: {
+			"1h": {true, Community}, "6h": {true, Community},
+			"24h": {true, Personal}, "7d": {true, Personal}, "30d": {true, Personal},
+			"90d": {false, Pro},
+		},
+		Pro: {
+			"1h": {true, Community}, "6h": {true, Community},
+			"24h": {true, Personal}, "7d": {true, Personal}, "30d": {true, Personal},
+			"90d": {true, Pro},
+		},
+	}
+	for edition, windows := range matrix {
+		withEdition(t, edition)
+		for name, expected := range windows {
+			w, ok := ResolveHistoryWindow(name)
+			require.True(t, ok)
+			allowed, required := AllowsHistoryWindow(w)
+			assert.Equal(t, expected.allowed, allowed, "%s / %s", edition, name)
+			assert.Equal(t, expected.required, required, "%s / %s required edition", edition, name)
+		}
+	}
+}
+
+// A window nobody declared is not resolved at all. The caller turns that into a
+// bad request, which is a different refusal from one the edition does not open.
+func TestResolveHistoryWindow_RejectsWhatTheProductDoesNotServe(t *testing.T) {
+	for _, name := range []string{"12h", "2d", "", "1H", "365d"} {
+		_, ok := ResolveHistoryWindow(name)
+		assert.False(t, ok, "window %q should not resolve", name)
+	}
+}
+
+// An edition absent from the cap table falls back to the Community floor, never
+// to zero. Unreachable from the server, which reports its own edition, but it
+// is what keeps max_window from being empty in the /api/v1/edition contract.
+func TestMaxHistoryWindow_UnknownEditionFallsBackToTheFloor(t *testing.T) {
+	withEdition(t, Edition("enterprise-2030"))
+
+	assert.Equal(t, "6h", MaxHistoryWindow().Name)
+
+	paid, ok := ResolveHistoryWindow("30d")
+	require.True(t, ok)
+	allowed, required := AllowsHistoryWindow(paid)
+	assert.False(t, allowed, "an unreadable edition opens nothing that is paid for")
+	assert.Equal(t, Personal, required)
+}
+
+func TestHistoryWindowNames_ListsTheWholeCatalogue(t *testing.T) {
+	assert.Equal(t, "1h, 6h, 24h, 7d, 30d, 90d", HistoryWindowNames())
+}
+
+// The caps themselves, asserted once so a change of tiering is a deliberate act
+// and not a silent edit.
+func TestEditionHistoryCap_IsTheAnnouncedTiering(t *testing.T) {
+	assert.Equal(t, 6*time.Hour, editionHistoryCap[Community])
+	assert.Equal(t, 30*24*time.Hour, editionHistoryCap[Personal])
+	assert.Equal(t, 90*24*time.Hour, editionHistoryCap[Pro])
+}

--- a/internal/mcp/tools_read.go
+++ b/internal/mcp/tools_read.go
@@ -128,7 +128,7 @@ type listAlertsInput struct {
 type getResourcesInput struct{}
 type getTopConsumersInput struct {
 	Metric string `json:"metric" jsonschema:"Resource metric to sort by: cpu or memory"`
-	Period string `json:"period,omitempty" jsonschema:"Time period for ranking: current, 1h, or 24h"`
+	Period string `json:"period,omitempty" jsonschema:"Time period for ranking: current (live), or one of 1h, 6h, 24h, 7d, 30d, 90d. How far back a history window may go depends on the edition."`
 	Limit  int    `json:"limit,omitempty" jsonschema:"Maximum number of containers to return, default 10"`
 }
 type listEndpointsInput struct {
@@ -307,15 +307,28 @@ func getTopConsumersHandler(svc *Services) gomcp.ToolHandlerFor[getTopConsumersI
 		if input.Metric != "cpu" && input.Metric != "memory" {
 			return errResult("invalid input: metric must be 'cpu' or 'memory'")
 		}
-		period := input.Period
-		if period == "" {
-			period = "current"
-		}
 		limit := input.Limit
 		if limit <= 0 {
 			limit = 10
 		}
-		rows, err := svc.Resources.GetTopConsumersByPeriod(ctx, input.Metric, period, limit, nil)
+
+		// No period, or the live ranking: open in every edition, and the only
+		// path that used to be reachable here at all: "current" was passed
+		// straight to the store, which has never known that value.
+		period := input.Period
+		if period == "" || period == "current" {
+			return jsonResult(svc.Resources.TopConsumersNow(input.Metric, limit, nil))
+		}
+
+		window, known := extension.ResolveHistoryWindow(period)
+		if !known {
+			return errResult("invalid input: period must be 'current' or one of " + extension.HistoryWindowNames())
+		}
+		if allowed, required := extension.AllowsHistoryWindow(window); !allowed {
+			return refuseHistoryWindow(window, required)
+		}
+
+		rows, err := svc.Resources.GetTopConsumersByPeriod(ctx, input.Metric, window.Name, limit, nil)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to get top consumers: %w", err)
 		}

--- a/internal/mcp/tools_read_test.go
+++ b/internal/mcp/tools_read_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/kolapsis/maintenant/internal/alert"
+	"github.com/kolapsis/maintenant/internal/extension"
 	"github.com/kolapsis/maintenant/internal/uid"
 	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/assert"
@@ -221,3 +222,51 @@ func TestGetEndpointHistoryInput_DefaultLimit(t *testing.T) {
 	assert.Equal(t, "5", input.EndpointID)
 	assert.Equal(t, 0, input.Limit, "Limit should default to zero (handler applies default of 50)")
 }
+
+// --- get_top_consumers: the history cap applies here too (FR-015a) ---
+
+func pinEdition(t *testing.T, e extension.Edition) {
+	t.Helper()
+	original := extension.CurrentEdition
+	extension.CurrentEdition = func() extension.Edition { return e }
+	t.Cleanup(func() { extension.CurrentEdition = original })
+}
+
+// This surface has no interface in front of it, so a cap enforced only in the
+// frontend would not exist here at all.
+func TestGetTopConsumers_RefusesAWindowAboveTheCap(t *testing.T) {
+	pinEdition(t, extension.Community)
+
+	// Services is deliberately empty: a refused window must never reach the
+	// store, so a nil resource service is enough to prove it.
+	handler := getTopConsumersHandler(&Services{})
+	result, _, err := handler(context.Background(), nil, getTopConsumersInput{Metric: "cpu", Period: "30d"})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.True(t, result.IsError)
+
+	text := textFromContent(t, result.Content)
+	assert.Contains(t, text, "edition_required")
+	assert.Contains(t, text, `"required_edition":"personal"`)
+	assert.Contains(t, text, `"window":"30d"`)
+	assert.Contains(t, text, `"max_window":"6h"`)
+}
+
+func TestGetTopConsumers_RefusesAWindowTheProductDoesNotKnow(t *testing.T) {
+	pinEdition(t, extension.Pro)
+
+	handler := getTopConsumersHandler(&Services{})
+	result, _, err := handler(context.Background(), nil, getTopConsumersInput{Metric: "cpu", Period: "2d"})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.True(t, result.IsError)
+
+	text := textFromContent(t, result.Content)
+	assert.Contains(t, text, "invalid input")
+	assert.NotContains(t, text, "edition_required", "a bad request is not an edition question")
+}
+
+// The live ranking (period absent or "current") never reaches the store: it is
+// answered by resource.Service.TopConsumersNow, covered in that package. Before
+// this feature, "current" was handed to the store, which has never known that
+// value, so the tool failed every time it was called without a period.

--- a/internal/mcp/tools_write.go
+++ b/internal/mcp/tools_write.go
@@ -99,6 +99,21 @@ type resumeMonitorInput struct {
 // REST requireCapability middleware does — same table, same names, so a
 // capability resolves identically whichever surface asks. The refusal names the
 // edition required; it does not advertise.
+// refuseHistoryWindow is the checkCapability of a history window: same shape of
+// answer, but the thing refused is a duration, not a flag. This surface has no
+// interface in front of it, which is exactly why the cap has to live here too.
+func refuseHistoryWindow(w extension.HistoryWindow, required extension.Edition) (*gomcp.CallToolResult, any, error) {
+	msg := fmt.Sprintf(
+		`{"error":"edition_required","feature":%q,"window":%q,"max_window":%q,"required_edition":%q,"message":"The %s window requires the %s edition of Maintenant."}`,
+		string(extension.CapResourceHistory), w.Name, extension.MaxHistoryWindow().Name,
+		string(required), w.Name, titleEdition(required),
+	)
+	return &gomcp.CallToolResult{
+		Content: []gomcp.Content{&gomcp.TextContent{Text: msg}},
+		IsError: true,
+	}, nil, nil
+}
+
 func checkCapability(c extension.Capability) (*gomcp.CallToolResult, any, error) {
 	if extension.Allows(c) {
 		return nil, nil, nil

--- a/internal/resource/service.go
+++ b/internal/resource/service.go
@@ -15,12 +15,14 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"sort"
 	"sync"
 	"time"
 
 	"github.com/kolapsis/maintenant/internal/container"
 	"github.com/kolapsis/maintenant/internal/event"
 	"github.com/kolapsis/maintenant/internal/runtime"
+	"github.com/kolapsis/maintenant/internal/uid"
 )
 
 // EventCallback is the function signature for SSE event broadcasting.
@@ -130,14 +132,28 @@ func (s *Service) GetContainerName(containerID string) string {
 
 // GetHistory returns historical resource snapshots for charting.
 //
-// Ranges up to 24h group raw samples on the fly; 7d reads the hourly rollup,
-// which already holds exactly the buckets that range displays. That is what
-// keeps the raw retention window short — see DefaultSnapshotRetention.
+// Ranges up to 24h group raw samples on the fly; 7d and 30d read the hourly
+// rollup, which already holds exactly the buckets those ranges display. That is
+// what keeps the raw retention window short. See DefaultSnapshotRetention.
+//
+// Every range reads a table kept strictly longer than the range itself, so a
+// retention pass can never amputate a read in progress.
 func (s *Service) GetHistory(ctx context.Context, containerID string, timeRange string) ([]*ResourceSnapshot, Granularity, error) {
 	now := time.Now()
 
-	if timeRange == "7d" {
-		snaps, err := s.store.ListHourlyInRange(ctx, containerID, now.Add(-7*24*time.Hour), now)
+	switch timeRange {
+	case "90d":
+		snaps, err := s.store.ListDailyInRange(ctx, containerID, now.AddDate(0, 0, -90), now)
+		if err != nil {
+			return nil, "", err
+		}
+		return snaps, Granularity1d, nil
+	case "7d", "30d":
+		days := 7
+		if timeRange == "30d" {
+			days = 30
+		}
+		snaps, err := s.store.ListHourlyInRange(ctx, containerID, now.AddDate(0, 0, -days), now)
 		if err != nil {
 			return nil, "", err
 		}
@@ -173,6 +189,56 @@ func (s *Service) GetAlertConfig(ctx context.Context, containerID string) (*Reso
 // UpsertAlertConfig creates or updates alert configuration.
 func (s *Service) UpsertAlertConfig(ctx context.Context, cfg *ResourceAlertConfig) error {
 	return s.store.UpsertAlertConfig(ctx, cfg)
+}
+
+// TopConsumersNow ranks containers on their latest sample rather than on a
+// history window. It is open in every edition: what the tiering caps is how far
+// back a history goes, not the live picture.
+//
+// agentID filters by host with the same convention as the historical ranking.
+func (s *Service) TopConsumersNow(metric string, limit int, agentID *string) []TopConsumerRow {
+	all := s.GetAllLatestSnapshots()
+
+	rows := make([]TopConsumerRow, 0, len(all))
+	for id, snap := range all {
+		if !hostMatchesFilter(snap.AgentID, agentID) {
+			continue
+		}
+		var value, percent float64
+		switch metric {
+		case "cpu":
+			value, percent = snap.CPUPercent, snap.CPUPercent
+		case "memory":
+			value = float64(snap.MemUsed)
+			if snap.MemLimit > 0 {
+				percent = float64(snap.MemUsed) / float64(snap.MemLimit) * 100.0
+			}
+		}
+		rows = append(rows, TopConsumerRow{ContainerID: id, AvgValue: value, AvgPercent: percent})
+	}
+
+	sort.Slice(rows, func(i, j int) bool { return rows[i].AvgValue > rows[j].AvgValue })
+
+	if limit < len(rows) {
+		rows = rows[:limit]
+	}
+	for i := range rows {
+		rows[i].ContainerName = s.GetContainerName(rows[i].ContainerID)
+	}
+	return rows
+}
+
+// hostMatchesFilter reports whether a sample belongs to the host being asked
+// for: nil means every host, "" means the local server, anything else is an
+// agent id.
+func hostMatchesFilter(snapAgent string, filter *string) bool {
+	if filter == nil {
+		return true
+	}
+	if *filter == "" {
+		return snapAgent == "" || snapAgent == uid.LocalAgent
+	}
+	return snapAgent == *filter
 }
 
 // GetTopConsumersByPeriod returns the top resource consumers averaged over a

--- a/internal/resource/service_test.go
+++ b/internal/resource/service_test.go
@@ -35,6 +35,11 @@ type mockResourceStore struct {
 
 	hourlyRows       []*ResourceSnapshot
 	hourlyRangeCalls int
+
+	dailyRows       []*ResourceSnapshot
+	dailyRangeCalls int
+	dailyFrom       time.Time
+	dailyTo         time.Time
 }
 
 func newMockResourceStore() *mockResourceStore {
@@ -84,6 +89,11 @@ func (m *mockResourceStore) ListSnapshotsAggregated(_ context.Context, _ string,
 func (m *mockResourceStore) ListHourlyInRange(_ context.Context, _ string, _, _ time.Time) ([]*ResourceSnapshot, error) {
 	m.hourlyRangeCalls++
 	return m.hourlyRows, nil
+}
+func (m *mockResourceStore) ListDailyInRange(_ context.Context, _ string, from, to time.Time) ([]*ResourceSnapshot, error) {
+	m.dailyRangeCalls++
+	m.dailyFrom, m.dailyTo = from, to
+	return m.dailyRows, nil
 }
 func (m *mockResourceStore) DeleteSnapshotsBefore(_ context.Context, _ time.Time, _ int) (int64, error) {
 	return 0, nil
@@ -685,6 +695,98 @@ func TestService_GetHistory_TimeRangeToGranularityMapping(t *testing.T) {
 			assert.Equal(t, tc.expectedGranularity, gran)
 			assert.Equal(t, tc.expectedGranularity, store.capturedGranularity,
 				"granularity passed to store must match returned granularity")
+		})
+	}
+}
+
+// The 30-day range reads the same hourly rollup as 7d. It must not group raw
+// snapshots, which are kept 48 hours and could not cover a month anyway.
+func TestService_GetHistory_30dReadsHourlyRollup(t *testing.T) {
+	store := &granularityCapturingStore{}
+	store.hourlyRows = []*ResourceSnapshot{
+		{ContainerID: "ctr-1", CPUPercent: 7, Timestamp: time.Now().Add(-20 * 24 * time.Hour)},
+	}
+	svc := newTestService(store, nil, nil)
+
+	snaps, gran, err := svc.GetHistory(context.Background(), "ctr-1", "30d")
+	require.NoError(t, err)
+
+	assert.Equal(t, Granularity1h, gran)
+	assert.Equal(t, 1, store.hourlyRangeCalls, "30d must read resource_hourly")
+	assert.Empty(t, store.capturedGranularity, "30d must not group raw snapshots")
+	require.Len(t, snaps, 1)
+}
+
+// TopConsumersNow ranks the latest samples. It is what answers the live ranking
+// on every surface, and it is open in every edition: the tiering caps how far
+// back a history goes, not the live picture.
+func TestService_TopConsumersNow(t *testing.T) {
+	svc := newTestService(&mockResourceStore{}, buildContainerSvc(newMockContainerStore()), nil)
+	svc.collector = NewCollector(nil, nil, slog.Default())
+	svc.collector.latest = map[string]*ResourceSnapshot{
+		"low":  {ContainerID: "low", CPUPercent: 5, MemUsed: 100, MemLimit: 1000},
+		"high": {ContainerID: "high", CPUPercent: 90, MemUsed: 900, MemLimit: 1000},
+		"mid":  {ContainerID: "mid", CPUPercent: 40, MemUsed: 400, MemLimit: 1000, AgentID: "agent-1"},
+	}
+
+	rows := svc.TopConsumersNow("cpu", 10, nil)
+	require.Len(t, rows, 3)
+	assert.Equal(t, "high", rows[0].ContainerID, "ranked by value, descending")
+	assert.Equal(t, "low", rows[2].ContainerID)
+
+	assert.Len(t, svc.TopConsumersNow("cpu", 2, nil), 2, "the limit caps the ranking")
+
+	mem := svc.TopConsumersNow("memory", 1, nil)
+	require.Len(t, mem, 1)
+	assert.EqualValues(t, 900, mem[0].AvgValue)
+	assert.InDelta(t, 90.0, mem[0].AvgPercent, 0.01, "percent is used over limit")
+
+	agent := "agent-1"
+	scoped := svc.TopConsumersNow("cpu", 10, &agent)
+	require.Len(t, scoped, 1)
+	assert.Equal(t, "mid", scoped[0].ContainerID)
+
+	local := ""
+	assert.Len(t, svc.TopConsumersNow("cpu", 10, &local), 2, "the local host owns the two unlabelled samples")
+}
+
+// The 90-day window must come from the daily rollup, kept a year, and not from
+// the hourly one, kept exactly 90 days: served from there its oldest buckets
+// would fall away mid-read.
+func TestService_GetHistory_90dReadsDailyRollup(t *testing.T) {
+	store := &granularityCapturingStore{}
+	store.dailyRows = []*ResourceSnapshot{
+		{ContainerID: "ctr-1", CPUPercent: 3, Timestamp: time.Now().AddDate(0, 0, -80)},
+	}
+	svc := newTestService(store, nil, nil)
+
+	snaps, gran, err := svc.GetHistory(context.Background(), "ctr-1", "90d")
+	require.NoError(t, err)
+
+	assert.Equal(t, Granularity1d, gran)
+	assert.Equal(t, 1, store.dailyRangeCalls, "90d must read resource_daily")
+	assert.Zero(t, store.hourlyRangeCalls, "90d must not read the hourly rollup")
+	assert.Empty(t, store.capturedGranularity, "90d must not group raw snapshots")
+	require.Len(t, snaps, 1)
+
+	// 90 days of daily buckets is 90 points, in any season: the rollup cuts on
+	// UTC midnight, so a daylight-saving change cannot make it 89 or 91.
+	span := store.dailyTo.Sub(store.dailyFrom)
+	assert.InDelta(t, (90 * 24 * time.Hour).Hours(), span.Hours(), 1.0,
+		"the requested span must be 90 days, not 89 or 91")
+}
+
+// An open window whose data does not cover the whole interval returns what
+// exists, with no error: a young instance is not a fault (FR-009).
+func TestService_GetHistory_OpenButEmptyWindowIsNotAnError(t *testing.T) {
+	for _, window := range []string{"1h", "6h", "24h", "7d", "30d", "90d"} {
+		t.Run(window, func(t *testing.T) {
+			store := &granularityCapturingStore{}
+			svc := newTestService(store, nil, nil)
+
+			snaps, _, err := svc.GetHistory(context.Background(), "ctr-1", window)
+			require.NoError(t, err)
+			assert.Empty(t, snaps)
 		})
 	}
 }

--- a/internal/resource/store.go
+++ b/internal/resource/store.go
@@ -24,6 +24,9 @@ const (
 	Granularity1m  Granularity = "1m"
 	Granularity5m  Granularity = "5m"
 	Granularity1h  Granularity = "1h"
+	// Granularity1d labels the points of the 90-day window. It is not an
+	// on-the-fly bucket size: the daily rollup already holds those buckets.
+	Granularity1d Granularity = "1d"
 )
 
 // DefaultSnapshotRetention is how long raw samples are kept. Only the ranges up
@@ -39,6 +42,7 @@ type ResourceStore interface {
 	ListSnapshots(ctx context.Context, containerID string, from, to time.Time) ([]*ResourceSnapshot, error)
 	ListSnapshotsAggregated(ctx context.Context, containerID string, from, to time.Time, granularity Granularity) ([]*ResourceSnapshot, error)
 	ListHourlyInRange(ctx context.Context, containerID string, from, to time.Time) ([]*ResourceSnapshot, error)
+	ListDailyInRange(ctx context.Context, containerID string, from, to time.Time) ([]*ResourceSnapshot, error)
 
 	GetAlertConfig(ctx context.Context, containerID string) (*ResourceAlertConfig, error)
 	UpsertAlertConfig(ctx context.Context, cfg *ResourceAlertConfig) error

--- a/internal/store/resources.go
+++ b/internal/store/resources.go
@@ -120,6 +120,32 @@ func (s *ResourceStore) ListHourlyInRange(ctx context.Context, containerID strin
 	return collectSnapshots(rows)
 }
 
+// ListDailyInRange returns the daily rollup for a container as snapshots. The
+// 90-day window reads it rather than the hourly rollup, which is kept exactly
+// 90 days: served from there, its oldest buckets would fall away mid-read and
+// two consecutive calls would not cover the same period.
+//
+// The daily schema carries no block I/O columns, so those two counters are 0 on
+// this window. Adding them would need a migration.
+func (s *ResourceStore) ListDailyInRange(ctx context.Context, containerID string, from, to time.Time) ([]*resource.ResourceSnapshot, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT '' AS id, container_id, '' AS agent_id,
+			avg_cpu_percent, avg_mem_used, avg_mem_limit,
+			avg_net_rx_bytes, avg_net_tx_bytes,
+			0 AS avg_block_read_bytes, 0 AS avg_block_write_bytes, bucket
+		FROM resource_daily
+		WHERE container_id = ? AND bucket >= ? AND bucket <= ?
+		ORDER BY bucket`,
+		containerID, from.Unix(), to.Unix())
+	if err != nil {
+		return nil, fmt.Errorf("list daily in range: %w", err)
+	}
+	defer func(rows *sql.Rows) {
+		_ = rows.Close()
+	}(rows)
+	return collectSnapshots(rows)
+}
+
 func (s *ResourceStore) GetAlertConfig(ctx context.Context, containerID string) (*resource.ResourceAlertConfig, error) {
 	row := s.db.QueryRowContext(ctx,
 		`SELECT id, container_id, cpu_threshold, mem_threshold, enabled, alert_state,
@@ -264,8 +290,12 @@ func (s *ResourceStore) GetTopConsumersByPeriod(ctx context.Context, metric stri
 	var table, timeCol, valExpr, pctExpr string
 	var from int64
 	switch period {
-	case "1h":
-		table, timeCol, from = "resource_snapshots", "timestamp", now.Add(-1*time.Hour).Unix()
+	case "1h", "6h":
+		hours := 1
+		if period == "6h" {
+			hours = 6
+		}
+		table, timeCol, from = "resource_snapshots", "timestamp", now.Add(-time.Duration(hours)*time.Hour).Unix()
 		switch metric {
 		case "cpu":
 			valExpr, pctExpr = "AVG(cpu_percent)", "AVG(cpu_percent)"
@@ -275,16 +305,18 @@ func (s *ResourceStore) GetTopConsumersByPeriod(ctx context.Context, metric stri
 		default:
 			return nil, fmt.Errorf("invalid metric: %s", metric)
 		}
-	case "24h", "7d", "30d":
+	case "24h", "7d", "30d", "90d":
 		table, timeCol = "resource_daily", "bucket"
 		switch period {
 		case "24h":
 			table = "resource_hourly"
 			from = now.Add(-24 * time.Hour).Unix()
 		case "7d":
-			from = now.Add(-7 * 24 * time.Hour).Unix()
+			from = now.AddDate(0, 0, -7).Unix()
+		case "90d":
+			from = now.AddDate(0, 0, -90).Unix()
 		default:
-			from = now.Add(-30 * 24 * time.Hour).Unix()
+			from = now.AddDate(0, 0, -30).Unix()
 		}
 		switch metric {
 		case "cpu":

--- a/internal/store/resources_agent_test.go
+++ b/internal/store/resources_agent_test.go
@@ -126,3 +126,84 @@ func TestGetTopConsumersByPeriod_HostFilter(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, []string{agentCID}, ids(agentRows))
 }
+
+// The two periods this feature adds to the top consumers, so both endpoints
+// accept the same catalogue. 6h reads raw samples like 1h, 90d reads the daily
+// rollup like 7d and 30d.
+func TestGetTopConsumersByPeriod_AddedWindows(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	cstore := NewContainerStore(db)
+	rstore := NewResourceStore(db)
+
+	cid := seedHostContainer(t, cstore, "ext-windows", "")
+
+	// Raw sample three hours back: inside 6h, outside 1h.
+	_, err := rstore.InsertSnapshot(ctx, &resource.ResourceSnapshot{
+		ContainerID: cid, CPUPercent: 42, MemUsed: 10, MemLimit: 100,
+		Timestamp: time.Now().Add(-3 * time.Hour),
+	})
+	require.NoError(t, err)
+
+	// Daily bucket sixty days back: inside 90d, outside 30d.
+	require.NoError(t, rstore.InsertDailyRollup(ctx, &resource.RollupRow{
+		ContainerID:   cid,
+		Bucket:        time.Now().UTC().AddDate(0, 0, -60).Truncate(24 * time.Hour),
+		AvgCPUPercent: 77,
+		AvgMemLimit:   100,
+		SampleCount:   24,
+	}))
+
+	sixHours, err := rstore.GetTopConsumersByPeriod(ctx, "cpu", "6h", 10, nil)
+	require.NoError(t, err)
+	require.Len(t, sixHours, 1)
+	assert.EqualValues(t, 42, sixHours[0].AvgValue)
+
+	oneHour, err := rstore.GetTopConsumersByPeriod(ctx, "cpu", "1h", 10, nil)
+	require.NoError(t, err)
+	assert.Empty(t, oneHour, "the sample is older than an hour")
+
+	ninetyDays, err := rstore.GetTopConsumersByPeriod(ctx, "cpu", "90d", 10, nil)
+	require.NoError(t, err)
+	require.Len(t, ninetyDays, 1)
+	assert.EqualValues(t, 77, ninetyDays[0].AvgValue)
+
+	thirtyDays, err := rstore.GetTopConsumersByPeriod(ctx, "cpu", "30d", 10, nil)
+	require.NoError(t, err)
+	assert.Empty(t, thirtyDays, "the bucket is older than thirty days")
+}
+
+// The host filter applies to the added periods like to the others.
+func TestGetTopConsumersByPeriod_AddedWindowsRespectTheHostFilter(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	agentStore := NewAgentStore(db)
+	cstore := NewContainerStore(db)
+	rstore := NewResourceStore(db)
+
+	agentID := "agent-windows"
+	require.NoError(t, agentStore.Insert(ctx, &agent.Agent{
+		AgentID: agentID, PublicKey: make([]byte, 32), Hostname: "h", Label: "edge",
+		OSArch: "linux/amd64", AgentVersion: "dev", DetectedRuntime: "docker",
+		Status: "active", CreatedAt: time.Now(),
+	}))
+
+	localCID := seedHostContainer(t, cstore, "ext-local-w", "")
+	agentCID := seedHostContainer(t, cstore, "ext-agent-w", agentID)
+
+	bucket := time.Now().UTC().AddDate(0, 0, -60).Truncate(24 * time.Hour)
+	for _, cid := range []string{localCID, agentCID} {
+		require.NoError(t, rstore.InsertDailyRollup(ctx, &resource.RollupRow{
+			ContainerID: cid, Bucket: bucket, AvgCPUPercent: 50, AvgMemLimit: 100, SampleCount: 24,
+		}))
+	}
+
+	all, err := rstore.GetTopConsumersByPeriod(ctx, "cpu", "90d", 10, nil)
+	require.NoError(t, err)
+	assert.Len(t, all, 2)
+
+	onlyAgent, err := rstore.GetTopConsumersByPeriod(ctx, "cpu", "90d", 10, &agentID)
+	require.NoError(t, err)
+	require.Len(t, onlyAgent, 1)
+	assert.Equal(t, agentCID, onlyAgent[0].ContainerID)
+}

--- a/internal/store/resources_rollup_test.go
+++ b/internal/store/resources_rollup_test.go
@@ -148,3 +148,74 @@ func TestAggregateHourlyRollup_ValuesAboveInt32(t *testing.T) {
 	require.NotEmpty(t, aggregated)
 	assert.Equal(t, memLimit, aggregated[0].MemLimit)
 }
+
+// The 90-day chart reads resource_daily, kept a year, rather than
+// resource_hourly, kept exactly 90 days. Two consecutive reads must cover the
+// same period, which the hourly table cannot promise at its own boundary.
+func TestListDailyInRange(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	cid := seedHostContainer(t, NewContainerStore(db), "ext-daily", "")
+	store := NewResourceStore(db)
+
+	day := func(n int) time.Time {
+		return time.Now().UTC().AddDate(0, 0, -n).Truncate(24 * time.Hour)
+	}
+	for _, n := range []int{80, 40, 2} {
+		require.NoError(t, store.InsertDailyRollup(ctx, &resource.RollupRow{
+			ContainerID:   cid,
+			Bucket:        day(n),
+			AvgCPUPercent: float64(n),
+			AvgMemUsed:    int64(n) * 10,
+			AvgMemLimit:   1000,
+			AvgNetRx:      int64(n),
+			AvgNetTx:      int64(n) * 2,
+			SampleCount:   24,
+		}))
+	}
+
+	rows, err := store.ListDailyInRange(ctx, cid, day(90), time.Now())
+	require.NoError(t, err)
+	require.Len(t, rows, 3)
+
+	// Ordered by bucket, oldest first.
+	assert.True(t, rows[0].Timestamp.Before(rows[1].Timestamp))
+	assert.True(t, rows[1].Timestamp.Before(rows[2].Timestamp))
+	assert.EqualValues(t, 80, rows[0].CPUPercent)
+	assert.EqualValues(t, 2, rows[2].CPUPercent)
+
+	// The daily schema carries no block counters, so this window reports zero
+	// rather than a wrong number. Adding them would need a migration.
+	for _, row := range rows {
+		assert.Zero(t, row.BlockReadBytes)
+		assert.Zero(t, row.BlockWriteBytes)
+	}
+
+	// A narrower window excludes what falls outside it.
+	recent, err := store.ListDailyInRange(ctx, cid, day(30), time.Now())
+	require.NoError(t, err)
+	require.Len(t, recent, 1)
+	assert.EqualValues(t, 2, recent[0].CPUPercent)
+}
+
+// A container deleted while its history is still readable must not break the
+// window: the rollups outlive the container row.
+func TestListDailyInRange_SurvivesADeletedContainer(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	cstore := NewContainerStore(db)
+	cid := seedHostContainer(t, cstore, "ext-gone", "")
+	store := NewResourceStore(db)
+
+	bucket := time.Now().UTC().AddDate(0, 0, -5).Truncate(24 * time.Hour)
+	require.NoError(t, store.InsertDailyRollup(ctx, &resource.RollupRow{
+		ContainerID: cid, Bucket: bucket, AvgCPUPercent: 9, AvgMemLimit: 100, SampleCount: 24,
+	}))
+
+	require.NoError(t, cstore.DeleteContainerByID(ctx, cid))
+
+	rows, err := store.ListDailyInRange(ctx, cid, bucket.Add(-24*time.Hour), time.Now())
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.EqualValues(t, 9, rows[0].CPUPercent)
+}


### PR DESCRIPTION
The resource history was all-or-nothing: a Community instance saw no chart at all, not even the last hour, while Personal and Pro opened exactly the same windows. The pricing page announced a split the product did not make. And `/resources/top` served its 30d period to any edition by direct call, so the split was a decoration of the interface.

The cap is now a duration per edition (Community 6h, Personal 30d, Pro 90d), declared once in `internal/extension`. The catalogue is a list of durations, the minimum edition of each window is derived from the two: adding a window touches neither the edition table nor the capability list.

- `resource_history` becomes true everywhere: it is the right to see a history. The cap and the full catalogue travel beside the capabilities in `GET /api/v1/edition`, so the frontend holds no edition table of its own.
- Both endpoints and the `get_top_consumers` MCP tool resolve the window through the same registry. Above the cap: `403 EDITION_REQUIRED` carrying the required edition, the window and the current cap. Unknown window: `400`. Never truncated data.
- 30d reads the hourly rollup, 90d the daily one, kept a year. The hourly table is kept exactly 90 days, so serving 90d from it would drop its oldest buckets mid-read.
- `/resources/top` gains 6h and 90d so one catalogue covers both surfaces. Its realtime ranking moves to `resource.Service.TopConsumersNow`, shared with the MCP tool, which passed `"current"` straight to the store and failed on every call without a period.
- The Resources tab loses its gate; closed windows are shown with the edition that opens them and fire no request, and a refusal on a window that closes mid-session falls back to the largest one still open.

A conformance test holds the three editions to one invariant: the windows announced open are exactly those both endpoints serve. Verified on live instances, Community and Pro.

Two consequences worth stating: the daily schema has no block I/O columns, so **Disk I/O reads zero on the 90-day window only** (adding them would need a migration), and Community `/resources/top?period=30d` now answers 403 where it answered 200, which is the bypass being closed.

No migration, no retention change. `make test-pg` green.