### PR TITLE
fix(agents): announce the standalone installer instead of a command that runs the website

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,13 @@ Monitor your entire fleet from a single pane of glass. One central **server** re
 
 ```bash
 # On each remote host — one command, generated for you in the UI
-curl -fsSL https://install.maintenant.dev | sudo bash -s -- \
+docker run -d \
+  --name maintenant-agent \
+  --restart unless-stopped \
+  -v /var/run/docker.sock:/var/run/docker.sock:ro \
+  -v /proc:/host/proc:ro \
+  -v maintenant-agent-data:/var/lib/maintenant \
+  ghcr.io/kolapsis/maintenant:latest \
   --mode=agent \
   --server=grpcs://monitoring.example.com \
   --enrollment-token=mnt_enr_XXXXXXXXXXXXXXXX \

--- a/docs/features/multihost.md
+++ b/docs/features/multihost.md
@@ -106,7 +106,7 @@ Content-Type: application/json
 The response contains:
 - `token` — the cleartext token, shown **once only**
 - `install_templates` — a map of ready-to-run install snippets, one per environment. Keys:
-  - `standalone` — `curl … | sudo bash` invocation of the install script (binary + systemd unit)
+  - `standalone` — a "coming soon" notice: the binary + systemd installer is not released yet
   - `docker_run` — single `docker run` command with the right socket/proc mounts
   - `docker_compose` — `compose.yml` snippet
   - `kubernetes` — Namespace + Secret + RBAC + DaemonSet manifest
@@ -121,16 +121,9 @@ The response contains:
 
 ### 2. Run the install command on the remote host
 
-Pick the snippet matching the host environment (the UI exposes these as tabs in the modal). For a bare-metal/VM host, the standalone snippet is:
+Pick the snippet matching the host environment (the UI exposes these as tabs in the modal). Docker is the way in today: the standalone installer is not released yet, and its tab says so.
 
-```bash
-curl -fsSL https://install.maintenant.dev | sudo bash -s -- \
-  --mode=agent \
-  --server=grpcs://monitoring.example.com \
-  --enrollment-token=mnt_enr_XXXXXXXXXXXXXXXX
-```
-
-For a host where the binary is already installed, the equivalent invocation is:
+For a host where the binary is already installed, the invocation is:
 
 ```bash
 maintenant \

--- a/docs/guides/agent-setup.md
+++ b/docs/guides/agent-setup.md
@@ -133,14 +133,12 @@ Pick the tab matching the host environment. Replace `grpcs://agents.example.com`
 
 === "Standalone (binary + systemd)"
 
-    ```bash
-    curl -fsSL https://install.maintenant.dev | sudo bash -s -- \
-      --mode=agent \
-      --server=grpcs://agents.example.com \
-      --enrollment-token=mnt_enr_XXXXXXXXXXXXXXXX
-    ```
+    !!! warning "Not released yet"
+        The one-line installer that drops the binary and a systemd unit is still being built,
+        and the modal's **Standalone** tab says so. Until it ships, run the agent with Docker
+        (next tabs) or drive an already-installed binary yourself.
 
-    The install script drops the binary and a systemd unit. If the binary is already installed, the equivalent invocation is:
+    With the binary in place, the agent is a plain invocation:
 
     ```bash
     maintenant \

--- a/docs/guides/hetzner.md
+++ b/docs/guides/hetzner.md
@@ -144,14 +144,22 @@ MAINTENANT_GRPC_LISTEN=10.0.0.2:8443
 MAINTENANT_GRPC_URL=grpcs://maintenant.internal.example.com:8443
 ```
 
-Then enrol each other server with the agent, dialling the private address:
+Then enrol each other server. Generate a token from **Agents → Add host**: the modal hands you a ready-made command, with the server address already filled in. Run it on the host, over the private address:
 
 ```bash
-curl -fsSL https://install.maintenant.dev | sudo bash -s -- \
+docker run -d \
+  --name maintenant-agent \
+  --restart unless-stopped \
+  -v /var/run/docker.sock:/var/run/docker.sock:ro \
+  -v /proc:/host/proc:ro \
+  -v maintenant-agent-data:/var/lib/maintenant \
+  ghcr.io/kolapsis/maintenant:latest \
   --mode=agent \
   --server=grpcs://maintenant.internal.example.com:8443 \
   --enrollment-token=mnt_enr_XXXXXXXXXXXXXXXX
 ```
+
+The token is consumed on first enrolment and cannot be retrieved again. The full walkthrough, including the Compose and Kubernetes variants, is in [Agent Setup](agent-setup.md).
 
 !!! important "Private does not mean plaintext"
     Binding on `10.0.0.2` keeps the listener off the public internet, but the agent still speaks

--- a/frontend/src/components/EnrollmentTokenModal.vue
+++ b/frontend/src/components/EnrollmentTokenModal.vue
@@ -25,17 +25,17 @@ const emit = defineEmits<{
 
 const STORAGE_KEY = 'mnt:enrollment-modal-mode'
 const MODES: Array<{ id: InstallMode; label: string }> = [
-  { id: 'standalone', label: 'Standalone' },
   { id: 'docker_run', label: 'Docker run' },
   { id: 'docker_compose', label: 'Compose' },
   { id: 'kubernetes', label: 'Kubernetes' },
+  { id: 'standalone', label: 'Standalone (soon)' },
 ]
 
 function isValidMode(value: unknown): value is InstallMode {
   return typeof value === 'string' && MODES.some((m) => m.id === value)
 }
 
-const selectedMode = ref<InstallMode>('standalone')
+const selectedMode = ref<InstallMode>('docker_run')
 
 onMounted(() => {
   try {
@@ -178,6 +178,7 @@ const hasLocalWarning = props.token.warnings?.includes('public_url_appears_local
             >{{ currentTemplate }}</pre>
 
             <button
+              v-if="selectedMode !== 'standalone'"
               type="button"
               class="mt-2 w-full rounded-lg border border-mnt-default bg-mnt-primary px-4 py-2 text-sm font-medium text-mnt-secondary hover:bg-mnt-elevated transition-colors"
               @click="copyText(currentTemplate, 'command')"

--- a/internal/api/v1/agents_handler.go
+++ b/internal/api/v1/agents_handler.go
@@ -131,18 +131,20 @@ func (h *AgentHandler) HandleCreateEnrollmentToken(w http.ResponseWriter, r *htt
 
 func buildInstallTemplates(serverURL, token string) map[string]string {
 	return map[string]string{
-		"standalone":     buildInstallStandalone(serverURL, token),
+		"standalone":     buildInstallStandalone(),
 		"docker_run":     buildInstallDockerRun(serverURL, token),
 		"docker_compose": buildInstallDockerCompose(serverURL, token),
 		"kubernetes":     buildInstallKubernetes(serverURL, token),
 	}
 }
 
-func buildInstallStandalone(serverURL, token string) string {
-	return "curl -fsSL https://install.maintenant.dev | sudo bash -s -- \\\n" +
-		"  --mode=agent \\\n" +
-		"  --server=" + serverURL + " \\\n" +
-		"  --enrollment-token=" + token
+// The standalone installer is not released yet. Until it is, the tab announces
+// itself rather than handing out an invocation that would fetch nothing.
+func buildInstallStandalone() string {
+	return "Coming soon.\n\n" +
+		"The standalone installer (binary + systemd unit) is not released yet.\n" +
+		"Run the agent with Docker in the meantime — see the Docker run,\n" +
+		"Compose and Kubernetes tabs."
 }
 
 func buildInstallDockerRun(serverURL, token string) string {

--- a/internal/api/v1/agents_token_handler_test.go
+++ b/internal/api/v1/agents_token_handler_test.go
@@ -72,11 +72,16 @@ func TestCreateEnrollmentToken_ReturnsCleartextOnce(t *testing.T) {
 	assert.Equal(t, agent.TokenIDFromHash(agent.HashToken(cleartext)), out["token_id"])
 
 	// The install snippets have to embed the real token or the operator cannot
-	// copy-paste them.
+	// copy-paste them. The standalone tab is the exception: it announces an
+	// unreleased installer instead of handing out a command.
 	templates, ok := out["install_templates"].(map[string]any)
 	require.True(t, ok)
 	require.NotEmpty(t, templates)
 	for name, tmpl := range templates {
+		if name == "standalone" {
+			assert.NotContains(t, tmpl, cleartext, "the coming-soon notice must not carry the token")
+			continue
+		}
 		assert.Contains(t, tmpl, cleartext, "install template %q must carry the token", name)
 	}
 

--- a/internal/api/v1/install_templates_test.go
+++ b/internal/api/v1/install_templates_test.go
@@ -34,6 +34,11 @@ func TestBuildInstallTemplates_ReturnsFourModes(t *testing.T) {
 		if v == "" {
 			t.Errorf("template %q is empty", k)
 		}
+		// The standalone installer is unreleased: its tab carries an
+		// announcement, not a command, so it holds neither URL nor token.
+		if k == "standalone" {
+			continue
+		}
 		if !strings.Contains(v, serverURL) {
 			t.Errorf("template %q does not contain server URL %q", k, serverURL)
 		}
@@ -47,13 +52,15 @@ func TestBuildInstallTemplates_ReturnsFourModes(t *testing.T) {
 	}
 }
 
-func TestBuildInstallStandalone_StartsWithCurl(t *testing.T) {
-	out := buildInstallStandalone("grpcs://h:8443", "mnt_enr_xyz")
-	if !strings.HasPrefix(out, "curl -fsSL https://install.maintenant.dev") {
-		t.Errorf("standalone template should start with curl install.sh invocation, got:\n%s", out)
+func TestBuildInstallStandalone_AnnouncesComingSoon(t *testing.T) {
+	out := buildInstallStandalone()
+	if !strings.HasPrefix(out, "Coming soon.") {
+		t.Errorf("standalone template should announce the unreleased installer, got:\n%s", out)
 	}
-	if !strings.Contains(out, "--mode=agent") {
-		t.Errorf("standalone template missing --mode=agent")
+	// install.maintenant.dev serves the marketing site, so an invocation
+	// piping it into a shell would run HTML as root.
+	if strings.Contains(out, "install.maintenant.dev") {
+		t.Errorf("standalone template still points at the unpublished installer:\n%s", out)
 	}
 }
 


### PR DESCRIPTION
`install.maintenant.dev` has no installer behind it. The wildcard record
points at the marketing site, so the command the enrollment modal handed out
piped a 200 `text/html` page straight into a root shell:

```
$ curl -s -o /dev/null -w "%{http_code} %{content_type}\n" https://install.maintenant.dev
200 text/html; charset=utf-8
```

The standalone installer (binary + systemd unit) is still being built, so the
tab now says so instead of generating that command.

- `buildInstallStandalone` returns a "Coming soon" notice and no longer takes
  the server URL or the token
- the enrollment modal opens on **Docker run**, and the standalone tab moves
  last, labelled `Standalone (soon)`
- the copy button is hidden on that tab, since there is nothing to copy
- the docs stop promising the one-liner: `agent-setup.md` keeps the plain
  binary invocation for a host that already has it, `multihost.md` describes
  the template key for what it is, and the README shows the Docker command

Also carries the fix to the Hetzner guide that landed after #82 was merged:
the same `curl | bash` had been copied into it.

Verified locally: `go test -race -cover ./...` (1941 tests), the PostgreSQL 14
pass (847 tests), `scripts/check-cgo.sh`, gosec via `act`, and the frontend
job's eslint + type-check + 132 vitest tests.
