### PR TITLE
fix(install): refuse a latest release that carries no binary

### DIFF
--- a/deploy/install/install.sh
+++ b/deploy/install/install.sh
@@ -155,14 +155,34 @@ check_prereqs() {
 
 # ── resolve_version ───────────────────────────────────────────────────────────
 
+# ── _release_has_binaries ─────────────────────────────────────────────────────
+# True when the release payload carries a linux binary for that tag. Both the
+# pinned and the latest paths need it: a release published without its assets —
+# a version older than the installer, or a build job that failed after the
+# release was created — must fail here with a message, not with a 404 halfway
+# through the download.
+
+_release_has_binaries() {
+    printf '%s' "$1" | grep -q "\"name\": *\"maintenant-${2}-linux-"
+}
+
 resolve_version() {
     VERSION="${MAINTENANT_VERSION:-latest}"
 
     if [ "$VERSION" = "latest" ]; then
         log_step "Resolving latest version..."
-        VERSION=$(fetch_url "$GITHUB_API/repos/$GITHUB_REPO/releases/latest" \
+        RELEASE_JSON=$(fetch_url "$GITHUB_API/repos/$GITHUB_REPO/releases/latest" 2>/dev/null) \
+            || abort "Failed to reach GitHub Releases" 20
+        VERSION=$(printf '%s' "$RELEASE_JSON" \
             | grep '"tag_name"' | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')
         [ -n "$VERSION" ] || abort "Failed to resolve latest version from GitHub API" 20
+
+        if ! _release_has_binaries "$RELEASE_JSON" "$VERSION"; then
+            log_error "The latest release ($VERSION) does not include standalone binaries."
+            _suggest_versions
+            abort "No standalone binaries in the latest release" 20
+        fi
+
         log_info "Latest version: $VERSION"
         return
     fi
@@ -174,9 +194,7 @@ resolve_version() {
         abort "Version $VERSION not found on GitHub Releases" 20
     }
 
-    # Check that standalone binaries exist in this release
-    ASSET_PATTERN="maintenant-${VERSION}-linux-"
-    if ! printf '%s' "$RELEASE_JSON" | grep -q "\"name\": *\"${ASSET_PATTERN}"; then
+    if ! _release_has_binaries "$RELEASE_JSON" "$VERSION"; then
         log_error "Version $VERSION exists but does not include standalone binaries."
         log_error "Standalone binaries were introduced starting from a later release."
         _suggest_versions
@@ -187,14 +205,25 @@ resolve_version() {
 }
 
 _suggest_versions() {
+    RECENT_JSON=$(fetch_url "$GITHUB_API/repos/$GITHUB_REPO/releases?per_page=10" 2>/dev/null) || return 0
+    RECENT=$(printf '%s' "$RECENT_JSON" \
+        | grep '"tag_name"' | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')
+    [ -n "$RECENT" ] || return 0
+
+    # The heading promises releases you can actually install, so the ones with no
+    # binary are filtered out instead of being offered and failing on the retry.
+    SUGGESTED=""
+    for v in $RECENT; do
+        if _release_has_binaries "$RECENT_JSON" "$v"; then
+            SUGGESTED="${SUGGESTED} $v"
+        fi
+    done
+    [ -n "$SUGGESTED" ] || return 0
+
     log_warn "Recent versions with standalone binaries:"
-    RECENT=$(fetch_url "$GITHUB_API/repos/$GITHUB_REPO/releases?per_page=5" 2>/dev/null \
-        | grep '"tag_name"' | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/') || true
-    if [ -n "$RECENT" ]; then
-        printf '%s\n' "$RECENT" | while IFS= read -r v; do
-            log_warn "  $v"
-        done
-    fi
+    for v in $SUGGESTED; do
+        log_warn "  $v"
+    done
 }
 
 # ── download_and_verify ───────────────────────────────────────────────────────

--- a/deploy/install/test/pinning.bats
+++ b/deploy/install/test/pinning.bats
@@ -42,7 +42,7 @@ MOCK_RELEASES_LIST='[
         log_info() { :; }; log_step() { :; }
         fetch_url() {
             case \"\$1\" in
-                *releases/latest) echo '{\"tag_name\": \"v1.5.0\"}' ;;
+                *releases/latest) printf '%s' '$MOCK_RELEASE_WITH_BINARIES' ;;
                 *) echo '[]' ;;
             esac
         }
@@ -105,4 +105,41 @@ MOCK_RELEASES_LIST='[
         resolve_version
     " 2>&1
     [ "$status" -eq 20 ]
+}
+
+@test "resolve_version: latest without standalone binaries exits 20" {
+    run bash -c "
+        MAINTENANT_VERSION=latest
+        NO_COLOR=1
+        export MAINTENANT_VERSION NO_COLOR
+        _INSTALL_SH_TESTING=1 . '$SCRIPT'
+        log_info() { :; }; log_step() { :; }
+        fetch_url() {
+            case \"\$1\" in
+                *releases/latest) printf '%s' '$MOCK_RELEASE_WITHOUT_BINARIES' ;;
+                *) printf '%s' '$MOCK_RELEASES_LIST' ;;
+            esac
+        }
+        resolve_version
+    "
+    [ "$status" -eq 20 ]
+    [[ "$output" == *"does not include standalone binaries"* ]]
+}
+
+@test "_suggest_versions: only lists releases that carry a binary" {
+    run bash -c "
+        NO_COLOR=1
+        export NO_COLOR
+        _INSTALL_SH_TESTING=1 . '$SCRIPT'
+        fetch_url() {
+            printf '%s' '[
+              {\"tag_name\": \"v1.5.0\", \"assets\": [{\"name\": \"maintenant-v1.5.0-linux-amd64\"}]},
+              {\"tag_name\": \"v1.0.0\", \"assets\": [{\"name\": \"Source code (zip)\"}]}
+            ]'
+        }
+        _suggest_versions
+    "
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"v1.5.0"* ]]
+    [[ "$output" != *"v1.0.0"* ]]
 }


### PR DESCRIPTION
`resolve_version` only checked for binaries when a version was pinned. On the `latest`
path it took the tag and moved on, so a release published without its assets — one older
than the installer, or a build job that failed after the release was created — got past
the check and died later on a 404 from the download, with nothing saying why.

The asset lookup is now one function used by both paths.

`_suggest_versions` filters on it too: its heading promises versions with standalone
binaries, and it was listing whatever came back, offering releases that fail the same
way on the retry.

Two new bats tests (42 total): `latest` without binaries exits 20, and the suggestion
list only names releases that carry one. The existing `latest` test mocked a release
with no assets, which matches no real release; it now uses the same payload as the
pinned-version test.