### PR TITLE
fix(release): sign with a bundle, which is all cosign 3 produces

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -221,16 +221,15 @@ jobs:
       - name: Install Cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
-      # .sig + .pem are what install.sh fetches; the bundle is the modern format
-      # for anyone verifying by hand.
+      # The bundle is the only output cosign 3 produces: sign-blob dropped
+      # --output-signature and --output-certificate, and still accepts them
+      # while ignoring them, so asking for a .sig and a .pem here succeeds and
+      # writes nothing. Everything that verifies a release reads the bundle.
       - name: Sign SHA256SUMS (keyless Sigstore)
         working-directory: release-assets
         run: |
-          cosign sign-blob --yes \
-            --output-signature SHA256SUMS.sig \
-            --output-certificate SHA256SUMS.pem \
-            --bundle SHA256SUMS.bundle \
-            SHA256SUMS
+          cosign sign-blob --yes --bundle SHA256SUMS.bundle SHA256SUMS
+          test -s SHA256SUMS.bundle
 
       - name: Upload the assets to the release
         env:
@@ -241,7 +240,7 @@ jobs:
         run: |
           gh release upload "$TAG" \
             maintenant-*-linux-* install.sh \
-            SHA256SUMS SHA256SUMS.sig SHA256SUMS.pem SHA256SUMS.bundle \
+            SHA256SUMS SHA256SUMS.bundle \
             --clobber
 
   # Installs from the release that was just published, through the documented

--- a/deploy/install/install.sh
+++ b/deploy/install/install.sh
@@ -228,6 +228,18 @@ _suggest_versions() {
 
 # ── download_and_verify ───────────────────────────────────────────────────────
 
+# ── _cosign_major ─────────────────────────────────────────────────────────────
+# Major version of the cosign on PATH, empty when it cannot be read. cosign 3
+# dropped --output-signature and --output-certificate from sign-blob, so a
+# release carries a bundle and nothing else; reading that bundle needs a 3.x
+# binary too.
+
+_cosign_major() {
+    cosign version 2>/dev/null \
+        | sed -n 's/^[[:space:]]*GitVersion:[[:space:]]*v\{0,1\}\([0-9]\{1,\}\).*/\1/p' \
+        | head -n 1
+}
+
 download_and_verify() {
     TMPDIR_INSTALL=$(mktemp -d)
     ASSET_NAME="maintenant-${VERSION}-linux-${ARCH}"
@@ -241,23 +253,26 @@ download_and_verify() {
     (cd "$TMPDIR_INSTALL" && sha256sum -c SHA256SUMS --ignore-missing) \
         || abort "SHA256 checksum mismatch — download may be corrupted" 21
 
-    if [ -z "${SKIP_COSIGN:-}" ] && command -v cosign >/dev/null 2>&1; then
-        fetch_url_to "$BASE_URL/SHA256SUMS.sig" "$TMPDIR_INSTALL/SHA256SUMS.sig"
-        fetch_url_to "$BASE_URL/SHA256SUMS.pem" "$TMPDIR_INSTALL/SHA256SUMS.pem"
+    if [ -n "${SKIP_COSIGN:-}" ]; then
+        log_warn "cosign verification skipped (--skip-cosign)"
+    elif ! command -v cosign >/dev/null 2>&1; then
+        log_warn "cosign not found — skipping signature verification (install cosign 3 for supply-chain protection)"
+    elif COSIGN_MAJOR=$(_cosign_major); [ -z "$COSIGN_MAJOR" ] || [ "$COSIGN_MAJOR" -lt 3 ]; then
+        # Not treated as a verification failure: a 2.x binary cannot read the
+        # bundle at all, and an unreadable version string says nothing about
+        # the signature either.
+        log_warn "cosign 3 or later is required to read the release bundle — skipping signature verification"
+    else
+        fetch_url_to "$BASE_URL/SHA256SUMS.bundle" "$TMPDIR_INSTALL/SHA256SUMS.bundle"
         log_step "Verifying cosign signature..."
         if ! cosign verify-blob \
-            --certificate "$TMPDIR_INSTALL/SHA256SUMS.pem" \
-            --signature "$TMPDIR_INSTALL/SHA256SUMS.sig" \
+            --bundle "$TMPDIR_INSTALL/SHA256SUMS.bundle" \
             --certificate-identity-regexp "^https://github\\.com/$GITHUB_REPO/\\.github/workflows/release\\.yml@refs/tags/v[0-9]+\\.[0-9]+\\.[0-9]+\$" \
             --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
             "$TMPDIR_INSTALL/SHA256SUMS"; then
             abort "cosign signature verification failed" 22
         fi
         log_info "cosign signature verified"
-    elif [ -z "${SKIP_COSIGN:-}" ]; then
-        log_warn "cosign not found — skipping signature verification (install cosign for supply-chain protection)"
-    else
-        log_warn "cosign verification skipped (--skip-cosign)"
     fi
 }
 

--- a/deploy/install/test/install_basic.bats
+++ b/deploy/install/test/install_basic.bats
@@ -166,3 +166,46 @@ run_script() {
     [ "$status" -eq 0 ]
     rm -rf "$FAKE_TMPDIR" "$FAKE_INSTALL_DIR" "$FAKE_DATA_DIR" "$FAKE_CONFIG_DIR"
 }
+
+# ── cosign version gate ───────────────────────────────────────────────────────
+
+@test "_cosign_major: reads the major from cosign version output" {
+    result=$(bash -c "
+        cosign() { echo '  GitVersion:    v3.1.2'; }
+        export -f cosign
+        _INSTALL_SH_TESTING=1 . '$SCRIPT'
+        _cosign_major
+    ")
+    [ "$result" = "3" ]
+}
+
+@test "_cosign_major: empty when the version cannot be read" {
+    result=$(bash -c "
+        cosign() { echo 'not a version'; }
+        export -f cosign
+        _INSTALL_SH_TESTING=1 . '$SCRIPT'
+        _cosign_major
+    ")
+    [ -z "$result" ]
+}
+
+@test "download_and_verify: cosign 2 skips verification instead of failing" {
+    FAKE_TMPDIR=$(mktemp -d)
+    printf 'fakebinary' > "$FAKE_TMPDIR/maintenant-v1.0.0-linux-amd64"
+    (cd "$FAKE_TMPDIR" && sha256sum maintenant-v1.0.0-linux-amd64 > SHA256SUMS)
+
+    run bash -c "
+        NO_COLOR=1; export NO_COLOR
+        cosign() { echo '  GitVersion:    v2.4.1'; }
+        export -f cosign
+        _INSTALL_SH_TESTING=1 . '$SCRIPT'
+        VERSION=v1.0.0
+        ARCH=amd64
+        GITHUB_REPO=kOlapsis/maintenant
+        fetch_url_to() { cp '$FAKE_TMPDIR/'\"\$(basename \"\$2\")\" \"\$2\" 2>/dev/null || true; }
+        download_and_verify
+    "
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"cosign 3 or later is required"* ]]
+    rm -rf "$FAKE_TMPDIR"
+}

--- a/docs/install.md
+++ b/docs/install.md
@@ -199,9 +199,7 @@ Every release includes:
 | `maintenant-vX.Y.Z-linux-amd64` / `-arm64` | Binary for each architecture |
 | `install.sh` | The install script itself, stamped with the release tag |
 | `SHA256SUMS` | Checksums for the binaries and the script |
-| `SHA256SUMS.sig` | cosign signature of `SHA256SUMS` |
-| `SHA256SUMS.pem` | Sigstore ephemeral certificate |
-| `SHA256SUMS.bundle` | Sigstore bundle, for verifying by hand |
+| `SHA256SUMS.bundle` | Sigstore bundle: the cosign signature and its certificate |
 | `provenance.intoto.jsonl` | SLSA Build L3 attestation |
 
 The script published with a release carries that release's tag in its header, and
@@ -212,7 +210,9 @@ disk always names the script that produced it.
 
 1. Downloads the binary and `SHA256SUMS` into a temp directory.
 2. Verifies the binary against its SHA256 checksum — **mandatory**, exits code 21 on mismatch.
-3. If `cosign` is in `$PATH` and `--skip-cosign` is not set, verifies the `SHA256SUMS` signature against the Sigstore transparency log, asserting that the signature was produced by the official `release.yml` workflow on the correct tag.
+3. If `cosign` 3 or later is in `$PATH` and `--skip-cosign` is not set, verifies the `SHA256SUMS` signature from the bundle against the Sigstore transparency log, asserting that the signature was produced by the official `release.yml` workflow on the correct tag.
+
+**cosign 3 is required.** `sign-blob` dropped `--output-signature` and `--output-certificate`, so a release carries a bundle and nothing else, and reading that bundle needs a 3.x binary. An older cosign is treated like an absent one: the script says so and continues, rather than reporting a signature failure that would say nothing about the signature.
 
 The cosign check is **best-effort**: if `cosign` is absent, the script warns and continues. Install it for full supply-chain protection:
 
@@ -231,16 +231,14 @@ BASE=https://github.com/kolapsis/maintenant/releases/download/${VERSION}
 
 curl -LO ${BASE}/maintenant-${VERSION}-linux-${ARCH}
 curl -LO ${BASE}/SHA256SUMS
-curl -LO ${BASE}/SHA256SUMS.sig
-curl -LO ${BASE}/SHA256SUMS.pem
+curl -LO ${BASE}/SHA256SUMS.bundle
 
 # SHA256
 sha256sum -c SHA256SUMS --ignore-missing
 
-# cosign
+# cosign (3.x)
 cosign verify-blob \
-  --certificate SHA256SUMS.pem \
-  --signature SHA256SUMS.sig \
+  --bundle SHA256SUMS.bundle \
   --certificate-identity-regexp \
     "^https://github\.com/kolapsis/maintenant/\.github/workflows/release\.yml@refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$" \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \


### PR DESCRIPTION
The release job asked cosign for a .sig and a .pem, uploaded them, and failed: "no matches found for SHA256SUMS.sig". cosign 3 dropped --output-signature and --output-certificate from sign-blob, and still accepts them while ignoring them, so signing reported success and wrote only the bundle. The step was green, the upload was not, and no release has ever carried a binary because of it.

Signing now produces SHA256SUMS.bundle and asserts it is non-empty. install.sh verifies from the bundle, and gates on the cosign major version: a 2.x binary cannot read the new bundle format, so it is treated like an absent cosign — warned about and skipped — rather than reported as a failed signature, which it is not. Three bats tests cover the version parsing and that gate.

Docs follow: the asset table, what the script verifies, and the manual verification commands.