### PR TITLE
fix(store): make the retention cleanup waitable so it stops writing before the database closes

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -111,6 +111,10 @@ type App struct {
 	shuttingDown    atomic.Bool
 	statusCompStore *store.StatusComponentStoreImpl
 
+	// Closed when the retention cleanup has stopped writing. Shutdown waits on
+	// it before closing the database.
+	retentionStopped <-chan struct{}
+
 	// Background services
 	checkEngine    *endpoint.CheckEngine
 	maintScheduler *status.MaintenanceScheduler
@@ -914,6 +918,19 @@ func (a *App) Shutdown() error {
 	}
 
 	_ = a.rt.Close()
+
+	// The cleanup deletes in batches and only notices the cancellation between
+	// them, so closing the database under it would abort a pass mid-write.
+	// Bounded by the same grace as the rest of the shutdown: a pass that is
+	// still running after that is left behind rather than holding the process.
+	if a.retentionStopped != nil {
+		select {
+		case <-a.retentionStopped:
+		case <-shutdownCtx.Done():
+			a.logger.Warn("retention cleanup still running at shutdown, closing the database anyway")
+		}
+	}
+
 	_ = a.db.Close()
 
 	a.logger.Info("maintenant stopped")

--- a/internal/app/lifecycle.go
+++ b/internal/app/lifecycle.go
@@ -328,7 +328,7 @@ func (a *App) startSwarmTopologyReconcile(ctx context.Context) {
 // startRetentionCleanup starts background retention cleanup goroutines.
 func (a *App) startRetentionCleanup(ctx context.Context) {
 	// Core store retention cleanup
-	store.StartRetentionCleanupWithOpts(ctx, a.containerStore, a.db, a.logger, store.RetentionOpts{
+	a.retentionStopped = store.StartRetentionCleanupWithOpts(ctx, a.containerStore, a.db, a.logger, store.RetentionOpts{
 		EndpointStore:    a.epStore,
 		HeartbeatStore:   a.hbStore,
 		CertificateStore: a.certStore,

--- a/internal/store/retention.go
+++ b/internal/store/retention.go
@@ -160,14 +160,22 @@ func (p *retentionPass) add(deleted int64, truncated bool) {
 // StartRetentionCleanupWithOpts starts retention cleanup with all store types.
 // The first pass runs immediately: an instance that restarts every few hours
 // would otherwise never reach its first cleanup.
-func StartRetentionCleanupWithOpts(ctx context.Context, store *ContainerStore, db *DB, logger *slog.Logger, opts RetentionOpts) {
+// The returned channel is closed once the cleanup has stopped writing, so a
+// caller that needs the database settled can wait for it: cancelling the context
+// only asks the goroutine to stop, it does not mean the pass in flight has
+// landed. Shutdown waits on it before closing the database, and a test waits on
+// it before its temporary directory is removed.
+func StartRetentionCleanupWithOpts(ctx context.Context, store *ContainerStore, db *DB, logger *slog.Logger, opts RetentionOpts) <-chan struct{} {
 	cfg := opts.Config.withDefaults(logger)
 	logger.Info("retention cleanup: starting",
 		"interval", cfg.Interval.String(),
 		"batch_size", cfg.BatchSize,
 		"snapshot_window", cfg.Snapshots.String())
 
+	stopped := make(chan struct{})
 	go func() {
+		defer close(stopped)
+
 		timer := time.NewTimer(0)
 		defer timer.Stop()
 
@@ -178,10 +186,19 @@ func StartRetentionCleanupWithOpts(ctx context.Context, store *ContainerStore, d
 			case <-timer.C:
 			}
 
+			// A cancellation racing the timer leaves both cases ready and the
+			// select picks at random, so re-check before starting a pass:
+			// without it the cleanup can write after its owner believes it has
+			// stopped.
+			if ctx.Err() != nil {
+				return
+			}
+
 			truncated := runRetentionPass(ctx, store, db, logger, opts, cfg)
 			timer.Reset(cfg.nextDelay(truncated))
 		}
 	}()
+	return stopped
 }
 
 // runRetentionPass runs every cleanup once and reports whether rows matching the

--- a/internal/store/retention_test.go
+++ b/internal/store/retention_test.go
@@ -227,10 +227,15 @@ func TestStartRetentionCleanup_RunsImmediately(t *testing.T) {
 
 	// An hour-long interval guarantees the timer never fires during the test:
 	// anything deleted came from the immediate first pass.
-	StartRetentionCleanupWithOpts(ctx, NewContainerStore(db), db, testLogger(), RetentionOpts{
+	// Registered after openTestDB, so cleanups run it first: the cleanup is
+	// stopped before the database is closed and the temporary directory
+	// removed. Without it a pass in flight can recreate the SQLite side files
+	// mid-RemoveAll and fail the cleanup.
+	stopped := StartRetentionCleanupWithOpts(ctx, NewContainerStore(db), db, testLogger(), RetentionOpts{
 		ResourceStore: NewResourceStore(db),
 		Config:        RetentionConfig{Interval: time.Hour},
 	})
+	t.Cleanup(func() { <-stopped })
 
 	require.Eventually(t, func() bool {
 		return countTableRows(t, db, "resource_snapshots") == 0


### PR DESCRIPTION
Cancelling the context only asks the cleanup goroutine to stop; it does not mean the pass in flight has landed. It deletes in batches and notices the cancellation between them, so Shutdown closing the database under it aborted a pass mid-write, and the test that starts it saw its temporary directory removed while SQLite still had the side files open.

StartRetentionCleanupWithOpts now returns a channel closed once the goroutine has stopped writing, the same shape as StartHealthReporter. Shutdown waits on it before closing the database, bounded by the existing ten-second grace, and the test waits on it in a cleanup registered after openTestDB so it runs first.

The pass also re-checks the context after the timer: a cancellation racing a tick leaves both select cases ready and the choice is random, which is how a pass could start after the owner believed the cleanup had stopped.