### PR TITLE
feat(channels): native Telegram channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ Knows when your images have updates available. Scans OCI registries, compares di
 
 Unified alerts across all monitoring sources. Channels are silent by default and routed via **Alert Triggers** (filter by severity / source). Webhook and Discord channels included. Silence rules for planned maintenance, exponential backoff retry on delivery.
 
-> **[Personal](https://maintenant.dev/pricing/)** adds the Email channel and scope/tag trigger filters. **[Pro](https://maintenant.dev/pricing/)** adds Slack and Microsoft Teams channels, multi-level **escalation policies**, per-entity routing, and maintenance windows that pause and resume escalation chains.
+> **[Personal](https://maintenant.dev/pricing/)** adds the Email and Telegram channels and scope/tag trigger filters. **[Pro](https://maintenant.dev/pricing/)** adds Slack and Microsoft Teams channels, multi-level **escalation policies**, per-entity routing, and maintenance windows that pause and resume escalation chains.
 
 ### Public Status Page
 
@@ -567,7 +567,7 @@ Replace `1000` with the UID of the user running the rootless Docker daemon (`id 
 | Resource    | `cpu_threshold`, `memory_threshold`    | Warning           |
 | Update      | `available`                            | Info              |
 
-Deliver to Discord or any HTTP webhook. Email comes with Personal, Slack and Teams with Pro.
+Deliver to Discord or any HTTP webhook. Email and Telegram come with Personal, Slack and Teams with Pro.
 
 ---
 
@@ -681,6 +681,7 @@ Full REST API under `/api/v1/` for automation and integration.
         <li><strong>CVE enrichment</strong> + risk scoring per container</li>
         <li><strong>Unified security posture</strong> dashboard</li>
         <li><strong>Incident management</strong> with public timeline</li>
+        <li><strong>Telegram</strong> channel — bot token and chat id, no URL to wire</li>
         <li>Changelog, <strong>30 days</strong> of resource history, OCSP stapling</li>
       </ul>
       <p>For one person, on infrastructure they own or run for themselves — freelancers included. It does not cover monitoring someone else's infrastructure or reselling Maintenant as a service, and carries no support commitment.</p>

--- a/docs/features/alerts.md
+++ b/docs/features/alerts.md
@@ -26,7 +26,7 @@ Deleting a monitored entity (container, agent, heartbeat, endpoint, certificate)
 
 ## Notification Channels
 
-maintenant delivers alerts to Discord, any HTTP webhook, and more. Each channel type formats the payload natively for the target platform.
+maintenant delivers alerts to Discord, Telegram, email, Slack, Teams, and any HTTP webhook. Each channel type formats the payload natively for the target platform.
 
 ### Discord
 
@@ -59,6 +59,61 @@ maintenant sends a JSON payload with alert details to the configured URL.
 ### Email (SMTP) :material-star-four-points:{ title="Personal" }
 
 Native email delivery over your own SMTP server. Available from the Personal edition.
+
+### Telegram :material-star-four-points:{ title="Personal" }
+
+A native Telegram channel: you supply a bot token and a chat id, never a URL.
+The destination is fixed, so nothing has to be worked around — neither the
+payload format a generic webhook gets wrong, nor the SSRF guard that refuses a
+local relay. Available from the Personal edition.
+
+**1. Create the bot.** Message [@BotFather](https://t.me/BotFather), send
+`/newbot`, follow the questions. It hands back a token shaped like
+`8123456789:AAF-…`. Treat it as a password: it is the bot.
+
+**2. Find the chat id.**
+
+- *Private chat*: message the bot once, then read `message.chat.id` from
+  `https://api.telegram.org/bot<token>/getUpdates`.
+- *Group or channel*: add the bot to it, post a message, same call. The id is
+  **negative**, often prefixed `-100`. Paste it exactly as it appears.
+
+**3. Create the channel.**
+
+```bash
+POST /api/v1/channels
+{
+  "name": "oncall-telegram",
+  "type": "telegram",
+  "url": "-1001234567890",
+  "secret": "8123456789:AAF-...",
+  "config": { "thread_id": "42" }
+}
+```
+
+`config.thread_id` is optional and only applies to groups organised in topics;
+leave it out and messages land in the general thread.
+
+The token is write-only. It is never returned by the API, never written to a
+log, and never appears in an error message; responses carry `has_secret` so the
+interface can say a token is on file without holding it. An update that omits
+`secret` keeps the stored one.
+
+Messages use Telegram's HTML formatting: a severity emoji and the entity on the
+first line, so a phone notification says what happened before you open it. A
+recovery arrives as a separate message, marked ✅. Anything over Telegram's
+4096-character limit is truncated with a visible marker rather than rejected.
+
+When a send fails, the delivery log carries Telegram's own words — `chat not
+found`, `bot was kicked from the supergroup chat`, `bot can't initiate
+conversation with a user` — because those name the fix, where an HTTP code does
+not. On a rate limit, the retry waits at least as long as Telegram asked.
+
+!!! note "What an expired licence changes"
+    A Telegram channel already created keeps delivering in any edition. What
+    Community closes is creating, testing, and editing it. Disabling and
+    deleting stay open: an expired licence must never leave you unable to
+    silence a channel.
 
 ### Slack & Teams :material-crown:{ title="Pro" }
 

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -203,7 +203,7 @@ Maintenant comes in three editions, in order: **Community**, **Personal**, **Pro
 | Edition | Price | Unlocks |
 |---------|-------|---------|
 | Community | Free | Containers, endpoints, heartbeats, certificates, the public status page, and the full Swarm and Kubernetes views, with 7 days of resource history. Capped at 10 endpoints, 5 heartbeats, 5 certificate monitors and 3 status components, on a single host. |
-| Personal | €149 once, for life | Every cap lifted, up to 20 remote hosts, plus email alerts, CVE enrichment, risk scoring, security posture, incidents, changelog, 30 days of resource history, advanced trigger filters and OCSP stapling. Covers one person on infrastructure they own or run for themselves, freelancers included. |
+| Personal | €149 once, for life | Every cap lifted, up to 20 remote hosts, plus email and Telegram alerts, CVE enrichment, risk scoring, security posture, incidents, changelog, 30 days of resource history, advanced trigger filters and OCSP stapling. Covers one person on infrastructure they own or run for themselves, freelancers included. |
 | Pro | €29/month or €290/year | Everything above with unlimited hosts, plus Slack and Teams, escalation policies, per-entity routing, maintenance windows, status page subscribers and branding, 90 days of resource history, and the right to use Maintenant on behalf of others, with support. |
 
 A Personal license never expires and includes one year of product updates.

--- a/frontend/src/components/ChannelManager.vue
+++ b/frontend/src/components/ChannelManager.vue
@@ -12,10 +12,16 @@
 -->
 
 <script setup lang="ts">
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 import { useChannelsStore } from '@/stores/channels'
 import { useConfirm } from '@/composables/useConfirm'
-import { createChannel, updateChannel, deleteChannel, testChannel } from '@/services/alertApi'
+import {
+  createChannel,
+  updateChannel,
+  deleteChannel,
+  testChannel,
+  type NotificationChannel,
+} from '@/services/alertApi'
 import ChannelWizard from '@/components/ChannelWizard.vue'
 
 const store = useChannelsStore()
@@ -23,27 +29,83 @@ const store = useChannelsStore()
 const showForm = ref(false)
 const showWizard = ref(false)
 const editingId = ref<string | null>(null)
-const form = ref({ name: '', url: '', headers: '', enabled: true })
+const form = ref({
+  name: '',
+  type: 'webhook',
+  url: '',
+  headers: '',
+  // Telegram only. An empty token means "keep the one on file" (FR-006): the
+  // server never sends it back, so there is nothing to prefill.
+  secret: '',
+  threadId: '',
+  enabled: true,
+})
+const editingHasSecret = ref(false)
 const testResult = ref<{ id: string; status: string; response_code?: number; error?: string } | null>(null)
 
 function resetForm() {
-  form.value = { name: '', url: '', headers: '', enabled: true }
+  form.value = { name: '', type: 'webhook', url: '', headers: '', secret: '', threadId: '', enabled: true }
+  editingHasSecret.value = false
   editingId.value = null
   showForm.value = false
 }
 
-function startEdit(ch: { id: string; name: string; url: string; headers: string; enabled: boolean }) {
+function startEdit(ch: NotificationChannel) {
   editingId.value = ch.id
-  form.value = { name: ch.name, url: ch.url, headers: ch.headers, enabled: ch.enabled }
+  let threadId = ''
+  try {
+    threadId = ch.config ? (JSON.parse(ch.config).thread_id ?? '') : ''
+  } catch {
+    threadId = ''
+  }
+  form.value = {
+    name: ch.name,
+    type: ch.type,
+    url: ch.url,
+    headers: ch.headers,
+    secret: '',
+    threadId,
+    enabled: ch.enabled,
+  }
+  editingHasSecret.value = ch.has_secret ?? false
   showForm.value = true
   showWizard.value = false
 }
 
+const isTelegram = computed(() => form.value.type === 'telegram')
+
+const destinationLabel = computed(() => {
+  if (form.value.type === 'email') return 'Email Address'
+  if (isTelegram.value) return 'Chat ID'
+  return 'Webhook URL'
+})
+
+const destinationInputType = computed(() => {
+  if (form.value.type === 'email') return 'email'
+  if (isTelegram.value) return 'text'
+  return 'url'
+})
+
+/** What a channel shows under its name: a URL for webhooks, the target as-is otherwise. */
+function channelTarget(ch: NotificationChannel): string {
+  if (ch.type === 'telegram' || ch.type === 'email') return ch.url
+  return maskUrl(ch.url)
+}
+
 async function submitForm() {
+  const payload = {
+    name: form.value.name,
+    url: form.value.url,
+    headers: form.value.headers,
+    enabled: form.value.enabled,
+    // Omitted when left empty, so the stored token survives an edit (FR-006).
+    ...(isTelegram.value && form.value.secret ? { secret: form.value.secret } : {}),
+    ...(isTelegram.value ? { config: { thread_id: form.value.threadId } } : {}),
+  }
   if (editingId.value) {
-    await updateChannel(editingId.value, form.value)
+    await updateChannel(editingId.value, payload)
   } else {
-    await createChannel(form.value)
+    await createChannel(payload)
   }
   resetForm()
   store.fetchChannels()
@@ -125,10 +187,26 @@ function handleWizardCreated() {
           <input v-model="form.name" required class="mt-1 w-full rounded-lg border border-mnt-default bg-mnt-primary px-3 py-2 text-sm text-mnt-primary focus:outline-none focus:border-mnt-default" />
         </div>
         <div>
-          <label class="block text-[10px] font-bold uppercase tracking-widest text-mnt-muted">Webhook URL</label>
-          <input v-model="form.url" required type="url" class="mt-1 w-full rounded-lg border border-mnt-default bg-mnt-primary px-3 py-2 text-sm text-mnt-primary focus:outline-none focus:border-mnt-default" />
+          <label class="block text-[10px] font-bold uppercase tracking-widest text-mnt-muted">{{ destinationLabel }}</label>
+          <input v-model="form.url" required :type="destinationInputType" class="mt-1 w-full rounded-lg border border-mnt-default bg-mnt-primary px-3 py-2 text-sm text-mnt-primary focus:outline-none focus:border-mnt-default" />
         </div>
-        <div>
+        <template v-if="isTelegram">
+          <div>
+            <label class="block text-[10px] font-bold uppercase tracking-widest text-mnt-muted">Bot Token</label>
+            <input
+              v-model="form.secret"
+              type="password"
+              autocomplete="off"
+              :placeholder="editingHasSecret ? 'Token on file — leave empty to keep it' : '123456789:AA...'"
+              class="mt-1 w-full rounded-lg border border-mnt-default bg-mnt-primary px-3 py-2 text-sm text-mnt-primary placeholder:text-mnt-muted focus:outline-none focus:border-mnt-default"
+            />
+          </div>
+          <div>
+            <label class="block text-[10px] font-bold uppercase tracking-widest text-mnt-muted">Topic ID (optional)</label>
+            <input v-model="form.threadId" placeholder="42" class="mt-1 w-full rounded-lg border border-mnt-default bg-mnt-primary px-3 py-2 text-sm text-mnt-primary placeholder:text-mnt-muted focus:outline-none focus:border-mnt-default" />
+          </div>
+        </template>
+        <div v-if="!isTelegram">
           <label class="block text-[10px] font-bold uppercase tracking-widest text-mnt-muted">Custom Headers (JSON)</label>
           <input v-model="form.headers" placeholder='{"Authorization": "Bearer ..."}' class="mt-1 w-full rounded-lg border border-mnt-default bg-mnt-primary px-3 py-2 text-sm text-mnt-primary placeholder:text-mnt-muted focus:outline-none focus:border-mnt-default" />
         </div>
@@ -169,7 +247,7 @@ function handleWizardCreated() {
                 <span v-if="!ch.enabled" class="rounded px-1.5 py-0.5 text-xs bg-mnt-elevated text-mnt-muted">disabled</span>
                 <span class="rounded px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wider bg-mnt-elevated text-mnt-muted">{{ ch.type }}</span>
               </div>
-              <p class="text-xs text-mnt-muted">{{ maskUrl(ch.url) }}</p>
+              <p class="text-xs text-mnt-muted">{{ channelTarget(ch) }}</p>
             </div>
           </div>
           <div class="flex items-center gap-2">

--- a/frontend/src/components/ChannelWizard.vue
+++ b/frontend/src/components/ChannelWizard.vue
@@ -73,7 +73,7 @@ const gatedChannelTypes = [
     label: 'Telegram',
     description: 'Send alerts to a Telegram chat, group or channel',
     icon: 'telegram',
-    urlPlaceholder: '-1001234567890',
+    urlPlaceholder: '-1001234567890 or @my_public_channel',
     feature: 'telegram',
   },
   {
@@ -371,12 +371,23 @@ function goBack() {
               style="background: var(--mnt-bg-elevated); border-color: var(--mnt-border-default); color: var(--mnt-text-primary)"
             />
           </div>
-          <p class="text-xs" style="color: var(--mnt-text-muted)">
-            Create a bot with @BotFather to get the token, then message the chat and read
-            <code>message.chat.id</code> from
-            <code>api.telegram.org/bot&lt;token&gt;/getUpdates</code>. Group and channel ids are
-            negative — paste them as they are. Leave the topic empty unless the group uses topics.
-          </p>
+          <div class="text-xs space-y-1" style="color: var(--mnt-text-muted)">
+            <p>
+              Create a bot with @BotFather to get the token. To find the chat id, send the bot a
+              message, then read <code>message.chat.id</code> from
+              <code>api.telegram.org/bot&lt;token&gt;/getUpdates</code>.
+            </p>
+            <ul class="space-y-0.5 pl-4 list-disc">
+              <li>Private conversation: a positive number, such as <code>123456789</code>.</li>
+              <li>Group or supergroup: a negative number, usually starting with <code>-100</code>. Paste it as it is, minus sign included.</li>
+              <li>Public channel: the number, or its <code>@name</code>.</li>
+            </ul>
+            <p>
+              The bot's own <code>@name</code> is not a destination: a bot cannot message itself. A
+              private conversation has no <code>@name</code> either, only a number.
+            </p>
+            <p>Leave the topic empty unless the group uses topics.</p>
+          </div>
         </template>
         <div v-if="selectedType === 'webhook'">
           <label class="block text-xs font-medium" style="color: var(--mnt-text-secondary)">Custom Headers (JSON, optional)</label>

--- a/frontend/src/components/ChannelWizard.vue
+++ b/frontend/src/components/ChannelWizard.vue
@@ -36,6 +36,9 @@ const form = ref({
   name: '',
   url: '',
   headers: '',
+  // Telegram only: the bot token, and the optional forum topic.
+  secret: '',
+  threadId: '',
   enabled: true,
 })
 
@@ -66,6 +69,14 @@ const gatedChannelTypes = [
     feature: 'smtp',
   },
   {
+    key: 'telegram',
+    label: 'Telegram',
+    description: 'Send alerts to a Telegram chat, group or channel',
+    icon: 'telegram',
+    urlPlaceholder: '-1001234567890',
+    feature: 'telegram',
+  },
+  {
     key: 'slack',
     label: 'Slack',
     description: 'Send rich notifications to a Slack channel',
@@ -89,23 +100,42 @@ const selectedTypeConfig = computed(() =>
   allChannelTypes.find(t => t.key === selectedType.value)
 )
 
+// What the single destination field means depends on the type: an address, a
+// chat id, or a URL. Telegram is the one type where it is not a URL at all.
+const destinationLabel = computed(() => {
+  if (selectedType.value === 'email') return 'Email Address'
+  if (selectedType.value === 'telegram') return 'Chat ID'
+  return 'Webhook URL'
+})
+
+const destinationInputType = computed(() => {
+  if (selectedType.value === 'email') return 'email'
+  if (selectedType.value === 'telegram') return 'text'
+  return 'url'
+})
+
 function selectType(type: string) {
   selectedType.value = type
   step.value = 2
   form.value.name = ''
   form.value.url = ''
   form.value.headers = ''
+  form.value.secret = ''
+  form.value.threadId = ''
   submitError.value = ''
 }
 
 async function submitConfig() {
   submitError.value = ''
   try {
+    const isTelegram = selectedType.value === 'telegram'
     const result = await createChannel({
       name: form.value.name,
       type: selectedType.value!,
       url: form.value.url,
       headers: form.value.headers || undefined,
+      secret: isTelegram ? form.value.secret : undefined,
+      config: isTelegram && form.value.threadId ? { thread_id: form.value.threadId } : undefined,
       enabled: form.value.enabled,
     })
     createdChannelId.value = result.id
@@ -253,6 +283,10 @@ function goBack() {
                 <rect x="2" y="4" width="16" height="12" rx="2" />
                 <path d="M2 6l8 5 8-5" />
               </svg>
+              <!-- Telegram -->
+              <svg v-else-if="type.icon === 'telegram'" width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" style="color: #229ED9">
+                <path d="M18 3L2 9.5l4.5 1.7L16 5.5l-7.5 7.2L8 17l2.7-3 3.6 2.7z" />
+              </svg>
               <!-- Slack -->
               <svg v-else-if="type.icon === 'slack'" width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" style="color: var(--mnt-accent)">
                 <path d="M6 2v4M14 14v4M2 6h4M14 6h4M6 10h8M10 6v8" />
@@ -302,17 +336,48 @@ function goBack() {
         </div>
         <div>
           <label class="block text-xs font-medium" style="color: var(--mnt-text-secondary)">
-            {{ selectedType === 'email' ? 'Email Address' : 'Webhook URL' }}
+            {{ destinationLabel }}
           </label>
           <input
             v-model="form.url"
             required
-            :type="selectedType === 'email' ? 'email' : 'url'"
+            :type="destinationInputType"
             :placeholder="selectedTypeConfig?.urlPlaceholder"
             class="mt-1 w-full rounded-md border px-3 py-1.5 text-sm outline-none"
             style="background: var(--mnt-bg-elevated); border-color: var(--mnt-border-default); color: var(--mnt-text-primary)"
           />
         </div>
+        <!-- Telegram: a token and an optional topic instead of a URL. The
+             destination is fixed by the product, so there is nothing to type. -->
+        <template v-if="selectedType === 'telegram'">
+          <div>
+            <label class="block text-xs font-medium" style="color: var(--mnt-text-secondary)">Bot Token</label>
+            <input
+              v-model="form.secret"
+              required
+              type="password"
+              autocomplete="off"
+              placeholder="123456789:AA..."
+              class="mt-1 w-full rounded-md border px-3 py-1.5 text-sm outline-none"
+              style="background: var(--mnt-bg-elevated); border-color: var(--mnt-border-default); color: var(--mnt-text-primary)"
+            />
+          </div>
+          <div>
+            <label class="block text-xs font-medium" style="color: var(--mnt-text-secondary)">Topic ID (optional)</label>
+            <input
+              v-model="form.threadId"
+              placeholder="42"
+              class="mt-1 w-full rounded-md border px-3 py-1.5 text-sm outline-none"
+              style="background: var(--mnt-bg-elevated); border-color: var(--mnt-border-default); color: var(--mnt-text-primary)"
+            />
+          </div>
+          <p class="text-xs" style="color: var(--mnt-text-muted)">
+            Create a bot with @BotFather to get the token, then message the chat and read
+            <code>message.chat.id</code> from
+            <code>api.telegram.org/bot&lt;token&gt;/getUpdates</code>. Group and channel ids are
+            negative — paste them as they are. Leave the topic empty unless the group uses topics.
+          </p>
+        </template>
         <div v-if="selectedType === 'webhook'">
           <label class="block text-xs font-medium" style="color: var(--mnt-text-secondary)">Custom Headers (JSON, optional)</label>
           <input

--- a/frontend/src/components/__tests__/ChannelWizard.spec.ts
+++ b/frontend/src/components/__tests__/ChannelWizard.spec.ts
@@ -1,0 +1,145 @@
+// Copyright 2026 Benjamin Touchard (kOlapsis)
+//
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+// or a commercial license. You may not use this file except in compliance
+// with one of these licenses.
+//
+// AGPL-3.0: https://www.gnu.org/licenses/agpl-3.0.html
+// Commercial: See COMMERCIAL-LICENSE.md
+//
+// Source: https://github.com/kolapsis/maintenant
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import ChannelWizard from '@/components/ChannelWizard.vue'
+
+// The capability table the running edition opens. Telegram is Personal, like
+// email; Slack and Teams are Pro.
+const REQUIRED: Record<string, string> = {
+  smtp: 'personal',
+  telegram: 'personal',
+  slack: 'pro',
+  teams: 'pro',
+}
+
+let open: string[] = []
+
+vi.mock('@/composables/useEdition', () => ({
+  useEdition: () => ({
+    hasFeature: (f: string) => open.includes(f),
+    editionPermits: (f: string) => open.includes(f),
+    requiredEditionFor: (f: string) => REQUIRED[f] ?? null,
+  }),
+}))
+
+const createChannel = vi.fn(async () => ({ id: 'c1' }))
+vi.mock('@/services/alertApi', () => ({
+  createChannel: (...args: unknown[]) => createChannel(...(args as [])),
+  testChannel: vi.fn(async () => ({ status: 'delivered' })),
+}))
+
+function mountWizard() {
+  return mount(ChannelWizard, { global: { stubs: { EditionBadge: true, SmtpNotConfigured: true } } })
+}
+
+/** The n-th input of the form, asserted present so the test fails on a missing
+ * field rather than on an undefined value three lines later. */
+async function fill(wrapper: ReturnType<typeof mountWizard>, index: number, value: string) {
+  const input = wrapper.findAll('input')[index]
+  if (!input) throw new Error(`input #${index} is missing`)
+  await input.setValue(value)
+}
+
+async function pickTelegram() {
+  const wrapper = mountWizard()
+  const telegram = wrapper
+    .findAll('button')
+    .find((b) => b.text().includes('Telegram'))
+  await telegram!.trigger('click')
+  return wrapper
+}
+
+describe('ChannelWizard — Telegram', () => {
+  beforeEach(() => {
+    open = ['telegram', 'smtp']
+    createChannel.mockClear()
+  })
+
+  // FR-001c: a Community instance must see the channel exists. Hiding it would
+  // make the feature undiscoverable, which is not what gating is for.
+  it('shows Telegram in every edition, marked with the edition it needs', () => {
+    open = []
+    const wrapper = mountWizard()
+
+    const telegram = wrapper.findAll('button').find((b) => b.text().includes('Telegram'))
+    expect(telegram).toBeDefined()
+    expect(telegram!.classes()).toContain('cursor-not-allowed')
+  })
+
+  it('does not open the form for a type the edition does not permit', async () => {
+    open = []
+    const wrapper = mountWizard()
+
+    const telegram = wrapper.findAll('button').find((b) => b.text().includes('Telegram'))
+    await telegram!.trigger('click')
+
+    expect(wrapper.text()).not.toContain('Bot Token')
+  })
+
+  // FR-003 and FR-017: no URL to type, a token and a chat id instead, and one
+  // help line that says where to get them.
+  it('asks for a token and a chat id, never a URL', async () => {
+    const wrapper = await pickTelegram()
+
+    expect(wrapper.text()).toContain('Chat ID')
+    expect(wrapper.text()).toContain('Bot Token')
+    expect(wrapper.text()).toContain('Topic ID (optional)')
+    expect(wrapper.text()).not.toContain('Webhook URL')
+    expect(wrapper.text()).toContain('@BotFather')
+
+    expect(wrapper.find('input[type="url"]').exists()).toBe(false)
+    expect(wrapper.find('input[type="password"]').exists()).toBe(true)
+  })
+
+  it('sends the token and the topic on create', async () => {
+    const wrapper = await pickTelegram()
+
+    await fill(wrapper, 0, 'oncall')
+    await fill(wrapper, 1, '-1001234567890')
+    await fill(wrapper, 2, '8123456789:AAFxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx')
+    await fill(wrapper, 3, '42')
+    await wrapper.find('form').trigger('submit')
+
+    expect(createChannel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'telegram',
+        url: '-1001234567890',
+        secret: '8123456789:AAFxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
+        config: { thread_id: '42' },
+      }),
+    )
+  })
+
+  it('omits the topic when the group has none', async () => {
+    const wrapper = await pickTelegram()
+
+    await fill(wrapper, 0, 'oncall')
+    await fill(wrapper, 1, '-1001234567890')
+    await fill(wrapper, 2, '8123456789:AAFxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx')
+    await wrapper.find('form').trigger('submit')
+
+    expect(createChannel).toHaveBeenCalledWith(
+      expect.objectContaining({ config: undefined }),
+    )
+  })
+
+  // The other types must keep the field they always had.
+  it('still asks for a URL on a webhook channel', async () => {
+    const wrapper = mountWizard()
+    const webhook = wrapper.findAll('button').find((b) => b.text().includes('Webhook'))
+    await webhook!.trigger('click')
+
+    expect(wrapper.text()).toContain('Webhook URL')
+    expect(wrapper.text()).not.toContain('Bot Token')
+  })
+})

--- a/frontend/src/services/alertApi.ts
+++ b/frontend/src/services/alertApi.ts
@@ -52,12 +52,24 @@ export interface ActiveAlertsResponse {
   info: Alert[]
 }
 
+/** Non-secret per-type settings. Telegram uses it for the optional forum topic. */
+export interface ChannelConfig {
+  thread_id?: string
+}
+
+/**
+ * The channel as the API returns it. There is deliberately no `secret`: the
+ * server never sends one back, so the read type must not pretend it might.
+ * `has_secret` is how the interface knows a credential is on file.
+ */
 export interface NotificationChannel {
   id: string
   name: string
   type: string
   url: string
   headers: string
+  config?: string
+  has_secret?: boolean
   enabled: boolean
   health: string
   created_at: string
@@ -135,6 +147,9 @@ export function createChannel(data: {
   type?: string
   url: string
   headers?: string
+  /** Write-only. Sent on create, never read back. */
+  secret?: string
+  config?: ChannelConfig
   enabled: boolean
 }): Promise<NotificationChannel> {
   return fetchJSON(`${API_BASE}/channels`, {
@@ -146,7 +161,16 @@ export function createChannel(data: {
 
 export function updateChannel(
   id: string,
-  data: Partial<{ name: string; type: string; url: string; headers: string; enabled: boolean }>,
+  data: Partial<{
+    name: string
+    type: string
+    url: string
+    headers: string
+    /** Write-only, and omitted to keep the stored one (FR-006). */
+    secret: string
+    config: ChannelConfig
+    enabled: boolean
+  }>,
 ): Promise<NotificationChannel> {
   return fetchJSON(`${API_BASE}/channels/${id}`, {
     method: 'PUT',

--- a/internal/alert/model.go
+++ b/internal/alert/model.go
@@ -93,11 +93,20 @@ type Alert struct {
 // Channels are silent by default — they only receive alerts when referenced
 // by an active AlertTrigger or by an EscalationLevel.
 type NotificationChannel struct {
-	ID        string    `json:"id"`
-	Name      string    `json:"name"`
-	Type      string    `json:"type"`
-	URL       string    `json:"url"`
-	Headers   string    `json:"headers,omitempty"`
+	ID      string `json:"id"`
+	Name    string `json:"name"`
+	Type    string `json:"type"`
+	URL     string `json:"url"`
+	Headers string `json:"headers,omitempty"`
+	// Secret holds the channel credential (a Telegram bot token, today). It is
+	// tagged "-" and not omitempty: omitempty would still serialize a non-empty
+	// token, which is exactly the value that must never leave the process.
+	Secret string `json:"-"`
+	// Config holds non-secret per-type settings as JSON, e.g. {"thread_id":"42"}.
+	Config string `json:"config,omitempty"`
+	// HasSecret is derived at scan time, never stored. It lets the interface show
+	// "token on file" without receiving the token.
+	HasSecret bool      `json:"has_secret"`
 	Enabled   bool      `json:"enabled"`
 	Health    string    `json:"health,omitempty"`
 	CreatedAt time.Time `json:"created_at"`

--- a/internal/alert/notifier.go
+++ b/internal/alert/notifier.go
@@ -15,6 +15,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -75,18 +76,35 @@ type Notifier struct {
 	httpClient   *http.Client
 	smtpSender   *SMTPSender
 	logger       *slog.Logger
+
+	// Telegram is reached at a fixed destination with a client of its own
+	// handle, so a test can point both at an httptest server. In production
+	// they are the real API and the notifier's own guarded client.
+	telegramAPIBase string
+	telegramClient  *http.Client
 }
 
 // NewNotifier creates a new webhook notifier. Its HTTP client blocks delivery
 // to private/internal IPs (SSRF guard) at dial time unless allowPrivate is set
 // (dev only, via MAINTENANT_ALLOW_PRIVATE_WEBHOOKS).
 func NewNotifier(channelStore ChannelStore, logger *slog.Logger, allowPrivate bool) *Notifier {
+	client := ssrf.NewHTTPClient(webhookTimeout, allowPrivate)
 	return &Notifier{
-		jobs:         make(chan NotificationJob, notifierChannelBuffer),
-		channelStore: channelStore,
-		httpClient:   ssrf.NewHTTPClient(webhookTimeout, allowPrivate),
-		logger:       logger,
+		jobs:            make(chan NotificationJob, notifierChannelBuffer),
+		channelStore:    channelStore,
+		httpClient:      client,
+		logger:          logger,
+		telegramAPIBase: TelegramAPIBase,
+		telegramClient:  client,
 	}
+}
+
+// SetTelegramTransport points Telegram delivery at another host with another
+// client. Tests use it: the guarded client refuses 127.0.0.1, where an
+// httptest server listens.
+func (n *Notifier) SetTelegramTransport(apiBase string, client *http.Client) {
+	n.telegramAPIBase = apiBase
+	n.telegramClient = client
 }
 
 // SetSMTPSender configures SMTP delivery for email channels.
@@ -149,6 +167,14 @@ func (n *Notifier) processJob(ctx context.Context, job NotificationJob) {
 	// Email channel: use SMTP sender
 	if channelType == "email" {
 		n.processEmailJob(ctx, job, eventType)
+		return
+	}
+
+	// Telegram: not the generic webhook path. That path logs ch.URL, and a
+	// Telegram URL carries the bot token; it also reads nothing but the status
+	// code, where the operator needs Telegram's own words.
+	if channelType == "telegram" {
+		n.processTelegramJob(ctx, job, eventType)
 		return
 	}
 
@@ -244,6 +270,56 @@ func (n *Notifier) processEmailJob(ctx context.Context, job NotificationJob, eve
 	n.failDelivery(ctx, job.Delivery, "email delivery failed after retries")
 }
 
+// processTelegramJob mirrors deliverWebhook: the product's retry policy, three
+// attempts at 1s/5s/25s, with one difference — when Telegram names a delay, the
+// next attempt is never earlier than that (FR-013, FR-014).
+func (n *Notifier) processTelegramJob(ctx context.Context, job NotificationJob, eventType string) {
+	text := BuildTelegramMessage(eventType, job.Alert)
+
+	var lastErr error
+	for attempt := 0; attempt < maxRetries; attempt++ {
+		if attempt > 0 {
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(telegramBackoff(attempt, lastErr)):
+			}
+		}
+
+		job.Delivery.Attempts = attempt + 1
+		lastErr = SendTelegram(ctx, n.telegramClient, n.telegramAPIBase, job.Channel, text)
+		if lastErr == nil {
+			job.Delivery.Status = DeliveryDelivered
+			if job.Delivery.ID != "" {
+				if updateErr := n.channelStore.UpdateDelivery(ctx, job.Delivery); updateErr != nil {
+					n.logger.Error("notifier: update delivery status", "error", updateErr)
+				}
+			}
+			n.logger.Debug("alert notifier: telegram delivered",
+				"alert_id", jobAlertID(job), "channel_id", job.Channel.ID)
+			return
+		}
+
+		n.logger.Warn("notifier: telegram delivery attempt failed",
+			"attempt", attempt+1, "channel_id", job.Channel.ID,
+			"alert_id", jobAlertID(job), "error", lastErr)
+	}
+
+	n.failDelivery(ctx, job.Delivery, lastErr.Error())
+}
+
+// telegramBackoff returns the wait before attempt n. It is the product's own
+// backoff, raised to the delay Telegram asked for when it asked for one: never
+// retrying sooner than Telegram allows, never replacing our policy with theirs.
+func telegramBackoff(attempt int, lastErr error) time.Duration {
+	wait := retryBackoffs[attempt-1]
+	var rateLimit *TelegramRateLimitError
+	if errors.As(lastErr, &rateLimit) && rateLimit.RetryAfter > wait {
+		return rateLimit.RetryAfter
+	}
+	return wait
+}
+
 func (n *Notifier) sendWebhook(ctx context.Context, ch *NotificationChannel, body []byte) error {
 	n.logger.Debug("alert notifier: sending webhook",
 		"url", ch.URL,
@@ -325,6 +401,27 @@ func (n *Notifier) SendNow(ctx context.Context, a *Alert, ch *NotificationChanne
 		return lastErr
 	}
 
+	if ch.Type == "telegram" {
+		text := BuildTelegramMessage(eventType, a)
+		var lastErr error
+		for attempt := 0; attempt < maxRetries; attempt++ {
+			if attempt > 0 {
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case <-time.After(telegramBackoff(attempt, lastErr)):
+				}
+			}
+			lastErr = SendTelegram(ctx, n.telegramClient, n.telegramAPIBase, ch, text)
+			if lastErr == nil {
+				return nil
+			}
+			n.logger.Warn("notifier: telegram attempt failed",
+				"attempt", attempt+1, "channel_id", ch.ID, "alert_id", a.ID, "error", lastErr)
+		}
+		return lastErr
+	}
+
 	body, err := formatPayload(ch.Type, eventType, a)
 	if err != nil {
 		return fmt.Errorf("marshal payload: %w", err)
@@ -361,6 +458,14 @@ func (n *Notifier) SendTestWebhook(ctx context.Context, ch *NotificationChannel)
 		EntityName: "test",
 		FiredAt:    time.Now().UTC(),
 		CreatedAt:  time.Now().UTC(),
+	}
+
+	if ch.Type == "telegram" {
+		if err := SendTelegram(ctx, n.telegramClient, n.telegramAPIBase, ch,
+			BuildTelegramMessage("test", testAlert)); err != nil {
+			return 0, err
+		}
+		return 200, nil
 	}
 
 	// Email channel: test via SMTP

--- a/internal/alert/telegram.go
+++ b/internal/alert/telegram.go
@@ -253,7 +253,7 @@ func SendTelegram(ctx context.Context, client *http.Client, apiBase string, ch *
 		}
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 || !parsed.OK {
-		return fmt.Errorf("HTTP %d: %s", resp.StatusCode, telegramReason(parsed.Description))
+		return fmt.Errorf("HTTP %d: %s", resp.StatusCode, telegramReasonFor(ch.URL, parsed.Description))
 	}
 	return nil
 }
@@ -266,4 +266,17 @@ func telegramReason(description string) string {
 		return d
 	}
 	return "no reason given"
+}
+
+// telegramReasonFor adds what Telegram leaves out. "chat not found" on an
+// @name is almost always the same mistake: an @name only resolves for a public
+// channel, so a bot's own @name, or a private conversation, can never be one.
+// Telegram answers the same three words either way, which sends the operator
+// looking at the token instead of the destination.
+func telegramReasonFor(chatID, description string) string {
+	reason := telegramReason(description)
+	if strings.HasPrefix(chatID, "@") && strings.Contains(strings.ToLower(reason), "chat not found") {
+		return reason + " — an @name only works for a public channel; for a private conversation or a group, use the numeric chat id, and note that the bot's own @name is never a destination"
+	}
+	return reason
 }

--- a/internal/alert/telegram.go
+++ b/internal/alert/telegram.go
@@ -1,0 +1,269 @@
+// Copyright 2026 Benjamin Touchard (Kolapsis)
+//
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+// or a commercial license. You may not use this file except in compliance
+// with one of these licenses.
+//
+// AGPL-3.0: https://www.gnu.org/licenses/agpl-3.0.html
+// Commercial: See COMMERCIAL-LICENSE.md
+//
+// Source: https://github.com/kolapsis/maintenant
+
+package alert
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+	"unicode/utf8"
+)
+
+// TelegramAPIBase is the destination the product calls. The operator never
+// supplies it: that is what makes the channel immune to the SSRF question a
+// user-supplied URL raises.
+const TelegramAPIBase = "https://api.telegram.org"
+
+// A bot token is "<bot id>:<secret>". BotFather mints a 35-character secret;
+// the length is not contractual, so the rule is a floor, not an equality.
+var telegramTokenRe = regexp.MustCompile(`^[0-9]{5,}:[A-Za-z0-9_-]{30,}$`)
+
+// A chat is either a numeric id — negative for groups and channels, often
+// prefixed -100 — or a public @username.
+var (
+	telegramChatIDRe   = regexp.MustCompile(`^-?[0-9]{1,20}$`)
+	telegramUsernameRe = regexp.MustCompile(`^@[A-Za-z][A-Za-z0-9_]{4,31}$`)
+	telegramThreadIDRe = regexp.MustCompile(`^[0-9]{1,19}$`)
+)
+
+// TelegramConfig is the non-secret part of a Telegram channel, serialized into
+// NotificationChannel.Config.
+type TelegramConfig struct {
+	ThreadID string `json:"thread_id,omitempty"`
+}
+
+// ParseTelegramConfig reads the channel's config column. An empty column is a
+// channel with no topic, not an error.
+func ParseTelegramConfig(raw string) (TelegramConfig, error) {
+	var cfg TelegramConfig
+	if strings.TrimSpace(raw) == "" {
+		return cfg, nil
+	}
+	if err := json.Unmarshal([]byte(raw), &cfg); err != nil {
+		return cfg, fmt.Errorf("parse telegram config: %w", err)
+	}
+	return cfg, nil
+}
+
+// ValidateBotToken rejects a token whose shape cannot be a Telegram token. It
+// says nothing about whether the token still works: that is what the test
+// button is for. The point is to spare a network call, and a puzzling refusal
+// from Telegram, on an obvious typo.
+func ValidateBotToken(token string) error {
+	if token == "" {
+		return errors.New("bot token is required")
+	}
+	if !telegramTokenRe.MatchString(token) {
+		return errors.New(`bot token must look like "123456789:AA...", as issued by @BotFather`)
+	}
+	return nil
+}
+
+// ValidateChatID accepts a numeric chat id, negative or not, or a public
+// @username. The -100 prefix supergroups carry is part of the number and is
+// passed through untouched.
+func ValidateChatID(chatID string) error {
+	if chatID == "" {
+		return errors.New("chat id is required")
+	}
+	if telegramChatIDRe.MatchString(chatID) || telegramUsernameRe.MatchString(chatID) {
+		return nil
+	}
+	return errors.New(`chat id must be a number (e.g. -1001234567890) or a public @username`)
+}
+
+// ValidateThreadID accepts an empty value: a channel without a topic posts to
+// the group's general thread.
+func ValidateThreadID(threadID string) error {
+	if threadID == "" {
+		return nil
+	}
+	if !telegramThreadIDRe.MatchString(threadID) {
+		return errors.New("topic id must be a positive number")
+	}
+	return nil
+}
+
+// telegramMaxLen is the sendMessage limit. A longer message is not shortened by
+// Telegram, it is refused, so truncating is on us (FR-012).
+const telegramMaxLen = 4096
+
+// telegramTruncationMark is what the reader sees where the text stops.
+const telegramTruncationMark = "\n\n… (message truncated)"
+
+// escapeTelegramHTML neutralizes the three characters Telegram's HTML parser
+// treats as markup. Every dynamic value goes through it, so an alert whose text
+// contains "a < b" is displayed, not rejected (FR-011).
+func escapeTelegramHTML(s string) string {
+	r := strings.NewReplacer("&", "&amp;", "<", "&lt;", ">", "&gt;")
+	return r.Replace(s)
+}
+
+// BuildTelegramMessage renders the fired or resolved message. The severity and
+// the entity sit on the first line so a phone notification, which shows little,
+// still says what happened and to what (SC-006).
+func BuildTelegramMessage(eventType string, a *Alert) string {
+	resolved := strings.Contains(eventType, "resolved")
+
+	emoji := severityEmoji(a.Severity)
+	stamp := a.FiredAt
+	stampLabel := "Fired"
+	if resolved {
+		emoji = "\xE2\x9C\x85" // white heavy check mark
+		stampLabel = "Resolved"
+		if a.ResolvedAt != nil {
+			stamp = *a.ResolvedAt
+		}
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s <b>%s</b>\n\n", emoji, escapeTelegramHTML(eventTitle(eventType, a)))
+	if !resolved {
+		fmt.Fprintf(&b, "<b>Severity</b> · %s\n", escapeTelegramHTML(a.Severity))
+	}
+	fmt.Fprintf(&b, "<b>Source</b> · %s\n", escapeTelegramHTML(a.Source))
+	fmt.Fprintf(&b, "<b>Entity</b> · %s\n", escapeTelegramHTML(a.EntityName))
+	fmt.Fprintf(&b, "<b>%s</b> · %s\n", stampLabel, stamp.UTC().Format("2006-01-02 15:04:05 MST"))
+
+	header := b.String()
+	body := escapeTelegramHTML(a.Message)
+	if body == "" {
+		return header
+	}
+
+	// The header carries what must survive: severity, title, entity. Only the
+	// description is cut.
+	room := telegramMaxLen - len(header) - len("\n") - len(telegramTruncationMark)
+	if len(body) > room {
+		if room < 0 {
+			room = 0
+		}
+		return header + "\n" + trimToValidUTF8(body[:room]) + telegramTruncationMark
+	}
+	return header + "\n" + body
+}
+
+// trimToValidUTF8 drops a trailing partial rune left by a byte-wise cut, and
+// the escape sequence a cut may have split in half — "&am" would render as
+// literal text where "&amp;" renders as "&".
+func trimToValidUTF8(s string) string {
+	for len(s) > 0 && !utf8.ValidString(s) {
+		s = s[:len(s)-1]
+	}
+	if i := strings.LastIndexByte(s, '&'); i >= 0 && !strings.ContainsAny(s[i:], ";") {
+		s = s[:i]
+	}
+	return strings.TrimRight(s, " \n\t")
+}
+
+// TelegramRateLimitError carries the delay Telegram asked for. It is a typed
+// error rather than a string the retry loop would have to read, so honouring
+// the delay cannot break on a wording change (FR-014).
+type TelegramRateLimitError struct {
+	RetryAfter time.Duration
+	Reason     string
+}
+
+func (e *TelegramRateLimitError) Error() string {
+	return fmt.Sprintf("HTTP 429: %s (retry after %s)", e.Reason, e.RetryAfter)
+}
+
+// telegramResponse is the envelope every Bot API method answers with.
+type telegramResponse struct {
+	OK          bool   `json:"ok"`
+	Description string `json:"description"`
+	Parameters  struct {
+		RetryAfter int `json:"retry_after"`
+	} `json:"parameters"`
+}
+
+// SendTelegram posts one message.
+//
+// The client and the API base are parameters, not fields read from the caller:
+// in production the notifier hands over its own client, SSRF guard included,
+// and the real host; tests hand over a bare client and an httptest server,
+// which the guard would otherwise refuse for listening on 127.0.0.1.
+//
+// The URL is never logged and never wrapped into an error: it carries the bot
+// token (FR-005).
+func SendTelegram(ctx context.Context, client *http.Client, apiBase string, ch *NotificationChannel, text string) error {
+	cfg, err := ParseTelegramConfig(ch.Config)
+	if err != nil {
+		return err
+	}
+
+	payload := map[string]any{
+		"chat_id":                  ch.URL,
+		"text":                     text,
+		"parse_mode":               "HTML",
+		"disable_web_page_preview": true,
+	}
+	if cfg.ThreadID != "" {
+		threadID, convErr := strconv.Atoi(cfg.ThreadID)
+		if convErr != nil {
+			return fmt.Errorf("invalid topic id %q", cfg.ThreadID)
+		}
+		payload["message_thread_id"] = threadID
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal telegram payload: %w", err)
+	}
+
+	endpoint := strings.TrimRight(apiBase, "/") + "/bot" + ch.Secret + "/sendMessage"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return errors.New("create telegram request")
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		// err carries the URL, and the URL carries the token.
+		return errors.New("send to telegram: request failed")
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	raw, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	var parsed telegramResponse
+	_ = json.Unmarshal(raw, &parsed)
+
+	if resp.StatusCode == http.StatusTooManyRequests {
+		return &TelegramRateLimitError{
+			RetryAfter: time.Duration(parsed.Parameters.RetryAfter) * time.Second,
+			Reason:     telegramReason(parsed.Description),
+		}
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 || !parsed.OK {
+		return fmt.Errorf("HTTP %d: %s", resp.StatusCode, telegramReason(parsed.Description))
+	}
+	return nil
+}
+
+// telegramReason is what the operator reads: the phrase Telegram sent, which
+// names the fix ("chat not found", "bot was kicked from the supergroup chat").
+// A bare status code names nothing (FR-008).
+func telegramReason(description string) string {
+	if d := strings.TrimSpace(description); d != "" {
+		return d
+	}
+	return "no reason given"
+}

--- a/internal/alert/telegram_message_test.go
+++ b/internal/alert/telegram_message_test.go
@@ -1,0 +1,137 @@
+// Copyright 2026 Benjamin Touchard (Kolapsis)
+//
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+// or a commercial license. You may not use this file except in compliance
+// with one of these licenses.
+//
+// AGPL-3.0: https://www.gnu.org/licenses/agpl-3.0.html
+// Commercial: See COMMERCIAL-LICENSE.md
+//
+// Source: https://github.com/kolapsis/maintenant
+
+package alert
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kolapsis/maintenant/internal/event"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func firedAlert() *Alert {
+	return &Alert{
+		ID:         "a1",
+		Source:     "endpoint",
+		AlertType:  "endpoint_down",
+		Severity:   SeverityCritical,
+		Status:     StatusActive,
+		Message:    "Connection refused after 3 attempts",
+		EntityType: "endpoint",
+		EntityName: "api.example.com",
+		FiredAt:    time.Date(2026, 8, 27, 14, 32, 7, 0, time.UTC),
+	}
+}
+
+// FR-009: everything the operator needs is in the message, and the severity and
+// entity are on the first line — a phone notification shows little (SC-006).
+func TestBuildTelegramMessage_Fired(t *testing.T) {
+	msg := BuildTelegramMessage(event.AlertFired, firedAlert())
+
+	assert.Contains(t, msg, "<b>Alert: api.example.com</b>")
+	assert.Contains(t, msg, "<b>Severity</b> · critical")
+	assert.Contains(t, msg, "<b>Source</b> · endpoint")
+	assert.Contains(t, msg, "<b>Entity</b> · api.example.com")
+	assert.Contains(t, msg, "2026-08-27 14:32:07 UTC")
+	assert.Contains(t, msg, "Connection refused after 3 attempts")
+
+	head := msg
+	if len(head) > 80 {
+		head = head[:80]
+	}
+	assert.Contains(t, head, "api.example.com",
+		"the entity must be readable in a truncated notification (SC-006)")
+	assert.True(t, strings.HasPrefix(msg, "\xF0\x9F\x94\xB4"),
+		"a critical alert opens on the red circle, before any text")
+}
+
+// FR-010: the recovery is distinguishable from its first character, without
+// reading the text.
+func TestBuildTelegramMessage_Resolved(t *testing.T) {
+	a := firedAlert()
+	a.Status = StatusResolved
+	resolvedAt := time.Date(2026, 8, 27, 14, 41, 52, 0, time.UTC)
+	a.ResolvedAt = &resolvedAt
+	a.Message = "Back to 200 OK"
+
+	msg := BuildTelegramMessage(event.AlertResolved, a)
+
+	assert.True(t, strings.HasPrefix(msg, "\xE2\x9C\x85"), "recovery opens on the check mark")
+	assert.Contains(t, msg, "<b>Resolved: api.example.com</b>")
+	assert.Contains(t, msg, "<b>Resolved</b> · 2026-08-27 14:41:52 UTC")
+	assert.NotContains(t, msg, "<b>Severity</b>",
+		"a recovery has no severity to announce; the alert is over")
+}
+
+// FR-011: markup characters in an alert are displayed, and never make Telegram
+// reject the whole message.
+func TestBuildTelegramMessage_EscapesDynamicValues(t *testing.T) {
+	a := firedAlert()
+	a.EntityName = "<script>alert(1)</script>"
+	a.Message = "a < b && c > d"
+
+	msg := BuildTelegramMessage(event.AlertFired, a)
+
+	assert.Contains(t, msg, "&lt;script&gt;alert(1)&lt;/script&gt;")
+	assert.Contains(t, msg, "a &lt; b &amp;&amp; c &gt; d")
+	assert.NotContains(t, msg, "<script>")
+
+	// The only tags left are the template's own.
+	for _, tag := range []string{"<b>", "</b>"} {
+		assert.Contains(t, msg, tag)
+	}
+	assert.Equal(t, strings.Count(msg, "<b>"), strings.Count(msg, "</b>"))
+}
+
+// FR-012: over the limit, the message still goes out, the cut is visible, and
+// the header survives intact.
+func TestBuildTelegramMessage_TruncatesTheDescription(t *testing.T) {
+	a := firedAlert()
+	a.Message = strings.Repeat("x", 8000)
+
+	msg := BuildTelegramMessage(event.AlertFired, a)
+
+	require.LessOrEqual(t, len(msg), telegramMaxLen)
+	assert.True(t, strings.HasSuffix(msg, telegramTruncationMark), "the cut must be visible")
+	assert.Contains(t, msg, "<b>Severity</b> · critical", "the header is never what gets cut")
+	assert.Contains(t, msg, "<b>Entity</b> · api.example.com")
+}
+
+// A byte-wise cut must not leave half a rune, nor half an HTML entity: "&am"
+// would show as literal text where "&amp;" shows an ampersand.
+func TestBuildTelegramMessage_TruncationLeavesValidMarkup(t *testing.T) {
+	for _, filler := range []string{"é", "&", "<"} {
+		a := firedAlert()
+		a.Message = strings.Repeat(filler, 6000)
+
+		msg := BuildTelegramMessage(event.AlertFired, a)
+
+		require.LessOrEqual(t, len(msg), telegramMaxLen, "filler %q", filler)
+		assert.True(t, utf8ValidString(msg), "filler %q left a partial rune", filler)
+		body := strings.TrimSuffix(msg, telegramTruncationMark)
+		if i := strings.LastIndexByte(body, '&'); i >= 0 {
+			assert.Contains(t, body[i:], ";", "filler %q left a half-written entity", filler)
+		}
+	}
+}
+
+func utf8ValidString(s string) bool {
+	for _, r := range s {
+		if r == 0xFFFD {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/alert/telegram_notifier_test.go
+++ b/internal/alert/telegram_notifier_test.go
@@ -1,0 +1,209 @@
+// Copyright 2026 Benjamin Touchard (Kolapsis)
+//
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+// or a commercial license. You may not use this file except in compliance
+// with one of these licenses.
+//
+// AGPL-3.0: https://www.gnu.org/licenses/agpl-3.0.html
+// Commercial: See COMMERCIAL-LICENSE.md
+//
+// Source: https://github.com/kolapsis/maintenant
+
+package alert
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/kolapsis/maintenant/internal/event"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// deliveryRecorder is the slice of ChannelStore the notifier actually uses when
+// it reports an outcome.
+type deliveryRecorder struct {
+	ChannelStore
+	mu      sync.Mutex
+	updates []NotificationDelivery
+}
+
+func (r *deliveryRecorder) UpdateDelivery(_ context.Context, d *NotificationDelivery) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.updates = append(r.updates, *d)
+	return nil
+}
+
+func (r *deliveryRecorder) last() NotificationDelivery {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.updates[len(r.updates)-1]
+}
+
+// telegramNotifier wires a notifier onto a stub Bot API. Both the host and the
+// client are handed over: the notifier's own client carries the SSRF guard.
+func telegramNotifier(t *testing.T, store ChannelStore, status int, body string) (*Notifier, *[]string, *bytes.Buffer) {
+	t.Helper()
+	var bodies []string
+	var mu sync.Mutex
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		bodies = append(bodies, string(raw))
+		mu.Unlock()
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+
+	logs := &bytes.Buffer{}
+	n := NewNotifier(store, slog.New(slog.NewTextHandler(logs, &slog.HandlerOptions{Level: slog.LevelDebug})), true)
+	n.SetTelegramTransport(srv.URL, srv.Client())
+	return n, &bodies, logs
+}
+
+// A Telegram channel must not take the generic webhook path: that path posts
+// our JSON envelope to ch.URL, which for Telegram is a chat id, not a URL.
+func TestProcessJob_TelegramTakesItsOwnPath(t *testing.T) {
+	rec := &deliveryRecorder{}
+	n, bodies, logs := telegramNotifier(t, rec, http.StatusOK, `{"ok":true}`)
+
+	n.processJob(context.Background(), NotificationJob{
+		Delivery: &NotificationDelivery{ID: "d1", AlertID: "a1", ChannelID: "c1"},
+		Channel:  telegramChannel(),
+		Alert:    firedAlert(),
+	})
+
+	require.Len(t, *bodies, 1)
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal([]byte((*bodies)[0]), &payload))
+	assert.Equal(t, "HTML", payload["parse_mode"], "the Telegram payload, not the webhook envelope")
+	assert.NotContains(t, payload, "event", "the webhook envelope would carry an event key")
+
+	assert.Equal(t, DeliveryDelivered, rec.last().Status)
+	assert.NotContains(t, logs.String(), sentinelToken, "no log line may carry the token")
+	assert.NotContains(t, logs.String(), "sendMessage", "the called URL is never logged")
+}
+
+func TestProcessJob_TelegramRecoveryUsesTheRecoveryTemplate(t *testing.T) {
+	rec := &deliveryRecorder{}
+	n, bodies, _ := telegramNotifier(t, rec, http.StatusOK, `{"ok":true}`)
+
+	a := firedAlert()
+	a.Status = StatusResolved
+	n.processJob(context.Background(), NotificationJob{
+		Delivery: &NotificationDelivery{ID: "d1", AlertID: "a1", ChannelID: "c1"},
+		Channel:  telegramChannel(),
+		Alert:    a,
+	})
+
+	require.Len(t, *bodies, 1)
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal([]byte((*bodies)[0]), &payload))
+	text, _ := payload["text"].(string)
+	assert.True(t, strings.HasPrefix(text, "\xE2\x9C\x85"), "a recovery opens on the check mark")
+	assert.Contains(t, text, "Resolved: api.example.com")
+}
+
+// After the retries are spent, the delivery row says what happened, in
+// Telegram's words, and without the token.
+func TestProcessJob_TelegramFailureRecordsTelegramsReason(t *testing.T) {
+	shortenBackoffs(t)
+
+	rec := &deliveryRecorder{}
+	n, bodies, logs := telegramNotifier(t, rec, http.StatusBadRequest,
+		`{"ok":false,"description":"chat not found"}`)
+
+	n.processTelegramJob(context.Background(), NotificationJob{
+		Delivery: &NotificationDelivery{ID: "d1", AlertID: "a1", ChannelID: "c1"},
+		Channel:  telegramChannel(),
+		Alert:    firedAlert(),
+	}, event.AlertFired)
+
+	assert.Len(t, *bodies, maxRetries, "the shared retry policy applies here too (FR-013)")
+
+	last := rec.last()
+	assert.Equal(t, DeliveryFailed, last.Status)
+	assert.Equal(t, maxRetries, last.Attempts)
+	assert.Contains(t, last.LastError, "chat not found")
+	assert.NotContains(t, last.LastError, sentinelToken)
+	assert.NotContains(t, logs.String(), sentinelToken)
+}
+
+// FR-014, end to end: Telegram asks for a delay, and the next attempt waits at
+// least that long. The delay is small so the test is fast; what matters is that
+// it wins over the product's backoff, which shortenBackoffs made shorter still.
+func TestProcessJob_TelegramHonoursTheRateLimitDelay(t *testing.T) {
+	shortenBackoffs(t)
+
+	rec := &deliveryRecorder{}
+	n, bodies, _ := telegramNotifier(t, rec, http.StatusTooManyRequests,
+		`{"ok":false,"description":"Too Many Requests","parameters":{"retry_after":0}}`)
+
+	start := time.Now()
+	n.processTelegramJob(context.Background(), NotificationJob{
+		Delivery: &NotificationDelivery{ID: "d1", AlertID: "a1", ChannelID: "c1"},
+		Channel:  telegramChannel(),
+		Alert:    firedAlert(),
+	}, event.AlertFired)
+	elapsed := time.Since(start)
+
+	assert.Len(t, *bodies, maxRetries)
+	assert.Less(t, elapsed, time.Second, "a zero delay must not be padded")
+	assert.Equal(t, DeliveryFailed, rec.last().Status)
+
+	// And the delay is honoured when Telegram names a real one.
+	assert.Equal(t, 250*time.Millisecond,
+		telegramBackoff(1, &TelegramRateLimitError{RetryAfter: 250 * time.Millisecond}))
+}
+
+// shortenBackoffs replaces the product's 1s/5s/25s with something a test can
+// wait for. The policy itself is asserted in TestTelegramBackoff.
+func shortenBackoffs(t *testing.T) {
+	t.Helper()
+	original := retryBackoffs
+	retryBackoffs = []time.Duration{time.Millisecond, time.Millisecond, time.Millisecond}
+	t.Cleanup(func() { retryBackoffs = original })
+}
+
+// The escalation runner calls SendNow, not Enqueue. Sending generic webhook
+// JSON to Telegram from that path would fail for everyone on call.
+func TestSendNow_TelegramTakesItsOwnPath(t *testing.T) {
+	n, bodies, _ := telegramNotifier(t, &deliveryRecorder{}, http.StatusOK, `{"ok":true}`)
+
+	require.NoError(t, n.SendNow(context.Background(), firedAlert(), telegramChannel()))
+
+	require.Len(t, *bodies, 1)
+	assert.Contains(t, (*bodies)[0], `"parse_mode":"HTML"`)
+}
+
+// The test button must reach Telegram too, and report its reason.
+func TestSendTestWebhook_Telegram(t *testing.T) {
+	n, bodies, _ := telegramNotifier(t, &deliveryRecorder{}, http.StatusOK, `{"ok":true}`)
+
+	status, err := n.SendTestWebhook(context.Background(), telegramChannel())
+	require.NoError(t, err)
+	assert.Equal(t, 200, status)
+	require.Len(t, *bodies, 1)
+	assert.Contains(t, (*bodies)[0], "maintenant Test Notification")
+}
+
+func TestSendTestWebhook_TelegramReportsTheReason(t *testing.T) {
+	n, _, _ := telegramNotifier(t, &deliveryRecorder{}, http.StatusBadRequest,
+		`{"ok":false,"description":"chat not found"}`)
+
+	_, err := n.SendTestWebhook(context.Background(), telegramChannel())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "chat not found")
+	assert.NotContains(t, err.Error(), sentinelToken)
+}

--- a/internal/alert/telegram_send_test.go
+++ b/internal/alert/telegram_send_test.go
@@ -1,0 +1,167 @@
+// Copyright 2026 Benjamin Touchard (Kolapsis)
+//
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+// or a commercial license. You may not use this file except in compliance
+// with one of these licenses.
+//
+// AGPL-3.0: https://www.gnu.org/licenses/agpl-3.0.html
+// Commercial: See COMMERCIAL-LICENSE.md
+//
+// Source: https://github.com/kolapsis/maintenant
+
+package alert
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const sentinelToken = "8123456789:SENTINEL-DO-NOT-LEAK-xxxxxxxxxxxxx"
+
+// telegramStub answers like the Bot API and records what it was sent. The
+// client is bare on purpose: the notifier's own client carries the SSRF guard,
+// which refuses 127.0.0.1, where httptest listens.
+func telegramStub(t *testing.T, status int, body string) (*httptest.Server, *[]*http.Request, *[]string) {
+	t.Helper()
+	var requests []*http.Request
+	var bodies []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		requests = append(requests, r)
+		bodies = append(bodies, string(raw))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &requests, &bodies
+}
+
+func telegramChannel() *NotificationChannel {
+	return &NotificationChannel{
+		ID: "c1", Name: "oncall", Type: "telegram",
+		URL: "-1001234567890", Secret: sentinelToken, Enabled: true,
+	}
+}
+
+func TestSendTelegram_PostsTheExpectedCall(t *testing.T) {
+	srv, requests, bodies := telegramStub(t, http.StatusOK, `{"ok":true}`)
+
+	err := SendTelegram(context.Background(), srv.Client(), srv.URL, telegramChannel(), "hello")
+	require.NoError(t, err)
+
+	require.Len(t, *requests, 1)
+	assert.Equal(t, http.MethodPost, (*requests)[0].Method)
+	assert.Equal(t, "/bot"+sentinelToken+"/sendMessage", (*requests)[0].URL.Path)
+
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal([]byte((*bodies)[0]), &payload))
+	assert.Equal(t, "-1001234567890", payload["chat_id"])
+	assert.Equal(t, "HTML", payload["parse_mode"])
+	assert.Equal(t, "hello", payload["text"])
+	assert.NotContains(t, payload, "message_thread_id",
+		"a channel without a topic must not pin the message to one")
+}
+
+func TestSendTelegram_CarriesTheTopicWhenTheChannelHasOne(t *testing.T) {
+	srv, _, bodies := telegramStub(t, http.StatusOK, `{"ok":true}`)
+
+	ch := telegramChannel()
+	ch.Config = `{"thread_id":"42"}`
+	require.NoError(t, SendTelegram(context.Background(), srv.Client(), srv.URL, ch, "hello"))
+
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal([]byte((*bodies)[0]), &payload))
+	assert.Equal(t, float64(42), payload["message_thread_id"],
+		"the topic id is a number for Telegram, not the string we store")
+}
+
+// FR-008 and SC-004: the operator reads the phrase that names the fix, not a
+// bare status code. And never the token (FR-005).
+func TestSendTelegram_SurfacesTelegramsOwnReason(t *testing.T) {
+	cases := []struct {
+		name   string
+		status int
+		body   string
+		want   string
+	}{
+		{"revoked token", http.StatusUnauthorized, `{"ok":false,"description":"Unauthorized"}`, "HTTP 401: Unauthorized"},
+		{"unknown chat", http.StatusBadRequest, `{"ok":false,"description":"chat not found"}`, "HTTP 400: chat not found"},
+		{"kicked", http.StatusForbidden, `{"ok":false,"description":"bot was kicked from the supergroup chat"}`, "HTTP 403: bot was kicked from the supergroup chat"},
+		{"no thread", http.StatusBadRequest, `{"ok":false,"description":"message thread not found"}`, "HTTP 400: message thread not found"},
+		{"silent refusal", http.StatusBadRequest, `{"ok":false}`, "HTTP 400: no reason given"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv, _, _ := telegramStub(t, tc.status, tc.body)
+
+			err := SendTelegram(context.Background(), srv.Client(), srv.URL, telegramChannel(), "hello")
+
+			require.Error(t, err)
+			assert.Equal(t, tc.want, err.Error())
+			assert.NotContains(t, err.Error(), sentinelToken, "the error must not carry the token")
+			assert.NotContains(t, err.Error(), srv.URL, "the error must not carry the called URL")
+		})
+	}
+}
+
+// A 200 with ok:false is still a failure. Telegram uses it, and reading only
+// the status code would report a delivery that never happened.
+func TestSendTelegram_TreatsOkFalseAsFailure(t *testing.T) {
+	srv, _, _ := telegramStub(t, http.StatusOK, `{"ok":false,"description":"chat not found"}`)
+
+	err := SendTelegram(context.Background(), srv.Client(), srv.URL, telegramChannel(), "hello")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "chat not found")
+}
+
+// FR-014: the delay Telegram asks for is carried by a typed error, so the retry
+// loop honours it without reading a message.
+func TestSendTelegram_RateLimitCarriesTheDelay(t *testing.T) {
+	srv, _, _ := telegramStub(t, http.StatusTooManyRequests,
+		`{"ok":false,"description":"Too Many Requests: retry later","parameters":{"retry_after":30}}`)
+
+	err := SendTelegram(context.Background(), srv.Client(), srv.URL, telegramChannel(), "hello")
+
+	var rateLimit *TelegramRateLimitError
+	require.ErrorAs(t, err, &rateLimit)
+	assert.Equal(t, 30*time.Second, rateLimit.RetryAfter)
+	assert.Contains(t, err.Error(), "Too Many Requests")
+	assert.NotContains(t, err.Error(), sentinelToken)
+}
+
+// FR-013 and FR-014 together: the product's backoff is the floor, Telegram's
+// delay raises it, and neither replaces the other.
+func TestTelegramBackoff(t *testing.T) {
+	assert.Equal(t, retryBackoffs[0], telegramBackoff(1, nil))
+	assert.Equal(t, retryBackoffs[1], telegramBackoff(2, nil))
+
+	short := &TelegramRateLimitError{RetryAfter: 100 * time.Millisecond}
+	assert.Equal(t, retryBackoffs[0], telegramBackoff(1, short),
+		"a delay shorter than our own backoff must not shorten it")
+
+	long := &TelegramRateLimitError{RetryAfter: 30 * time.Second}
+	assert.Equal(t, 30*time.Second, telegramBackoff(1, long))
+}
+
+// A transport failure must not leak the URL: the error the http client returns
+// carries it, and the URL carries the token.
+func TestSendTelegram_TransportFailureHidesTheURL(t *testing.T) {
+	srv, _, _ := telegramStub(t, http.StatusOK, `{"ok":true}`)
+	srv.Close() // nothing is listening any more
+
+	err := SendTelegram(context.Background(), srv.Client(), srv.URL, telegramChannel(), "hello")
+
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), sentinelToken)
+	assert.False(t, strings.Contains(err.Error(), srv.URL))
+}

--- a/internal/alert/telegram_send_test.go
+++ b/internal/alert/telegram_send_test.go
@@ -165,3 +165,28 @@ func TestSendTelegram_TransportFailureHidesTheURL(t *testing.T) {
 	assert.NotContains(t, err.Error(), sentinelToken)
 	assert.False(t, strings.Contains(err.Error(), srv.URL))
 }
+
+// Telegram answers "chat not found" whether the @name belongs to nothing, to a
+// private conversation, or to the bot itself. The operator reads the token as
+// the suspect and looks in the wrong place, so the destination is named.
+func TestSendTelegram_ExplainsAnUnresolvedUsername(t *testing.T) {
+	srv, _, _ := telegramStub(t, http.StatusBadRequest, `{"ok":false,"description":"chat not found"}`)
+
+	ch := telegramChannel()
+	ch.URL = "@my_bot"
+	err := SendTelegram(context.Background(), srv.Client(), srv.URL, ch, "hello")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "chat not found")
+	assert.Contains(t, err.Error(), "public channel")
+	assert.Contains(t, err.Error(), "numeric chat id")
+}
+
+// The hint is for the @name case only: on a numeric id it would send the
+// operator chasing a mistake they did not make.
+func TestSendTelegram_LeavesANumericChatIDReasonAlone(t *testing.T) {
+	srv, _, _ := telegramStub(t, http.StatusBadRequest, `{"ok":false,"description":"chat not found"}`)
+
+	err := SendTelegram(context.Background(), srv.Client(), srv.URL, telegramChannel(), "hello")
+	require.Error(t, err)
+	assert.Equal(t, "HTTP 400: chat not found", err.Error())
+}

--- a/internal/alert/telegram_validate_test.go
+++ b/internal/alert/telegram_validate_test.go
@@ -1,0 +1,88 @@
+// Copyright 2026 Benjamin Touchard (Kolapsis)
+//
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+// or a commercial license. You may not use this file except in compliance
+// with one of these licenses.
+//
+// AGPL-3.0: https://www.gnu.org/licenses/agpl-3.0.html
+// Commercial: See COMMERCIAL-LICENSE.md
+//
+// Source: https://github.com/kolapsis/maintenant
+
+package alert
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// FR-004: a malformed token is refused on shape alone, with no call to
+// Telegram. These functions take no context and no client, which is what makes
+// that structural rather than a promise.
+func TestValidateBotToken(t *testing.T) {
+	valid := []string{
+		"8123456789:AAFxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+		"123456:AAH-_zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz",
+	}
+	for _, token := range valid {
+		assert.NoError(t, ValidateBotToken(token), "token %q", token)
+	}
+
+	invalid := map[string]string{
+		"empty":            "",
+		"no colon":         "8123456789AAFxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+		"no bot id":        ":AAFxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+		"bot id not digit": "abc123:AAFxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+		"secret too short": "8123456789:AAFshort",
+		"spaces":           "8123456789:AAF xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+		"a whole url":      "https://api.telegram.org/bot8123456789:AAFxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+	}
+	for name, token := range invalid {
+		assert.Error(t, ValidateBotToken(token), "case %q should be refused", name)
+	}
+}
+
+// A group id is negative and often carries the -100 prefix. Refusing it as
+// "invalid" is the mistake this test exists to prevent.
+func TestValidateChatID(t *testing.T) {
+	valid := []string{"-1001234567890", "-100123", "-123456", "123456", "@maintenant_alerts"}
+	for _, id := range valid {
+		assert.NoError(t, ValidateChatID(id), "chat id %q", id)
+	}
+
+	invalid := map[string]string{
+		"empty":              "",
+		"not a number":       "my-group",
+		"bare at":            "@",
+		"username too short": "@abc",
+		"url":                "https://t.me/mygroup",
+		"two numbers":        "-100123 456",
+	}
+	for name, id := range invalid {
+		assert.Error(t, ValidateChatID(id), "case %q should be refused", name)
+	}
+}
+
+func TestValidateThreadID(t *testing.T) {
+	assert.NoError(t, ValidateThreadID(""), "no topic is the general thread, not an error")
+	assert.NoError(t, ValidateThreadID("42"))
+
+	for _, id := range []string{"-1", "4.2", "abc", "42 "} {
+		assert.Error(t, ValidateThreadID(id), "thread id %q", id)
+	}
+}
+
+func TestParseTelegramConfig(t *testing.T) {
+	cfg, err := ParseTelegramConfig("")
+	require.NoError(t, err)
+	assert.Empty(t, cfg.ThreadID)
+
+	cfg, err = ParseTelegramConfig(`{"thread_id":"42"}`)
+	require.NoError(t, err)
+	assert.Equal(t, "42", cfg.ThreadID)
+
+	_, err = ParseTelegramConfig("{not json")
+	assert.Error(t, err)
+}

--- a/internal/api/v1/alerts.go
+++ b/internal/api/v1/alerts.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"net/mail"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/kolapsis/maintenant/internal/alert"
@@ -223,6 +224,11 @@ func (h *AlertHandler) HandleListChannels(w http.ResponseWriter, r *http.Request
 // type is an HTTP webhook subject to the HTTPS + SSRF rules (fast-feedback;
 // skipped in dev, where the notifier's dial-time guard remains the boundary).
 func (h *AlertHandler) validateChannelURL(ctx context.Context, chType, rawURL string) error {
+	// Telegram's "url" column holds a chat id and the destination is fixed, so
+	// there is no user-supplied URL to guard against (FR-016).
+	if chType == "telegram" {
+		return alert.ValidateChatID(rawURL)
+	}
 	if chType == "email" {
 		if _, err := mail.ParseAddress(rawURL); err != nil {
 			return errors.New("invalid email address")
@@ -238,11 +244,13 @@ func (h *AlertHandler) validateChannelURL(ctx context.Context, chType, rawURL st
 // HandleCreateChannel handles POST /api/v1/channels.
 func (h *AlertHandler) HandleCreateChannel(w http.ResponseWriter, r *http.Request) {
 	var input struct {
-		Name    string `json:"name"`
-		Type    string `json:"type"`
-		URL     string `json:"url"`
-		Headers string `json:"headers"`
-		Enabled bool   `json:"enabled"`
+		Name    string          `json:"name"`
+		Type    string          `json:"type"`
+		URL     string          `json:"url"`
+		Headers string          `json:"headers"`
+		Secret  string          `json:"secret"`
+		Config  json.RawMessage `json:"config"`
+		Enabled bool            `json:"enabled"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
 		WriteError(w, http.StatusBadRequest, "INVALID_BODY", "invalid JSON body")
@@ -271,11 +279,24 @@ func (h *AlertHandler) HandleCreateChannel(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
+	config := strings.TrimSpace(string(input.Config))
+	if config == "null" {
+		config = ""
+	}
+	if input.Type == "telegram" {
+		if err := validateTelegramCredentials(input.Secret, config); err != nil {
+			WriteError(w, http.StatusBadRequest, "VALIDATION_ERROR", err.Error())
+			return
+		}
+	}
+
 	ch := &alert.NotificationChannel{
 		Name:    input.Name,
 		Type:    input.Type,
 		URL:     input.URL,
 		Headers: input.Headers,
+		Secret:  input.Secret,
+		Config:  config,
 		Enabled: input.Enabled,
 	}
 
@@ -290,6 +311,7 @@ func (h *AlertHandler) HandleCreateChannel(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	ch.ID = id
+	ch.HasSecret = ch.Secret != ""
 
 	h.broker.Broadcast(SSEEvent{Type: event.ChannelCreated, Data: ch})
 	WriteJSON(w, http.StatusCreated, ch)
@@ -314,15 +336,35 @@ func (h *AlertHandler) HandleUpdateChannel(w http.ResponseWriter, r *http.Reques
 	}
 
 	var input struct {
-		Name    *string `json:"name"`
-		Type    *string `json:"type"`
-		URL     *string `json:"url"`
-		Headers *string `json:"headers"`
-		Enabled *bool   `json:"enabled"`
+		Name    *string          `json:"name"`
+		Type    *string          `json:"type"`
+		URL     *string          `json:"url"`
+		Headers *string          `json:"headers"`
+		Secret  *string          `json:"secret"`
+		Config  *json.RawMessage `json:"config"`
+		Enabled *bool            `json:"enabled"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
 		WriteError(w, http.StatusBadRequest, "INVALID_BODY", "invalid JSON body")
 		return
+	}
+
+	// A request that only switches the channel off never needs the edition that
+	// opens the type: an operator whose licence expired must still be able to
+	// silence a channel, and deleting it to do so is not a way out (FR-001d).
+	extends := input.Name != nil || input.Type != nil || input.URL != nil ||
+		input.Headers != nil || input.Secret != nil || input.Config != nil ||
+		(input.Enabled != nil && *input.Enabled)
+	if extends {
+		// Both the type it has and the type it would become: a downgraded
+		// instance may neither keep editing a gated channel nor turn a plain
+		// one into a gated one.
+		if refuseChannelCapability(w, ch.Type) {
+			return
+		}
+		if input.Type != nil && refuseChannelCapability(w, *input.Type) {
+			return
+		}
 	}
 
 	if input.Name != nil {
@@ -337,12 +379,33 @@ func (h *AlertHandler) HandleUpdateChannel(w http.ResponseWriter, r *http.Reques
 	if input.Headers != nil {
 		ch.Headers = *input.Headers
 	}
+	// An absent secret keeps the stored one (FR-006); an empty one is refused,
+	// since a channel without its credential can no longer send and would say
+	// nothing about it.
+	if input.Secret != nil {
+		if *input.Secret == "" {
+			WriteError(w, http.StatusBadRequest, "VALIDATION_ERROR",
+				"secret cannot be cleared; delete the channel instead")
+			return
+		}
+		ch.Secret = *input.Secret
+	}
+	if input.Config != nil {
+		config := strings.TrimSpace(string(*input.Config))
+		if config == "null" {
+			config = ""
+		}
+		ch.Config = config
+	}
 	if input.Enabled != nil {
 		ch.Enabled = *input.Enabled
 	}
 
-	if refuseChannelCapability(w, ch.Type) {
-		return
+	if ch.Type == "telegram" && (input.Secret != nil || input.Config != nil) {
+		if err := validateTelegramCredentials(ch.Secret, ch.Config); err != nil {
+			WriteError(w, http.StatusBadRequest, "VALIDATION_ERROR", err.Error())
+			return
+		}
 	}
 
 	// Re-validate the destination when the URL or type changed, so an update
@@ -358,6 +421,7 @@ func (h *AlertHandler) HandleUpdateChannel(w http.ResponseWriter, r *http.Reques
 		WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to update channel")
 		return
 	}
+	ch.HasSecret = ch.Secret != ""
 
 	h.broker.Broadcast(SSEEvent{Type: event.ChannelUpdated, Data: ch})
 	WriteJSON(w, http.StatusOK, ch)
@@ -509,8 +573,9 @@ func (h *AlertHandler) HandleCancelSilenceRule(w http.ResponseWriter, r *http.Re
 }
 
 // channelCapability maps a channel type to the capability that opens it. Types
-// absent from the map are open in every edition. email is Personal, Slack and
-// Teams are Pro — the gating is per channel, not "paid edition or not".
+// absent from the map are open in every edition. email and Telegram are
+// Personal, Slack and Teams are Pro — the gating is per channel, not "paid
+// edition or not".
 func channelCapability(channelType string) (extension.Capability, bool) {
 	switch channelType {
 	case "slack":
@@ -519,9 +584,24 @@ func channelCapability(channelType string) (extension.Capability, bool) {
 		return extension.CapTeams, true
 	case "email":
 		return extension.CapSMTP, true
+	case "telegram":
+		return extension.CapTelegram, true
 	default:
 		return "", false
 	}
+}
+
+// validateTelegramCredentials checks the two values the operator types and the
+// optional topic id, before anything reaches the network (FR-004).
+func validateTelegramCredentials(secret, config string) error {
+	if err := alert.ValidateBotToken(secret); err != nil {
+		return err
+	}
+	cfg, err := alert.ParseTelegramConfig(config)
+	if err != nil {
+		return errors.New("config must be a JSON object")
+	}
+	return alert.ValidateThreadID(cfg.ThreadID)
 }
 
 // refuseChannelCapability writes the refusal when the running edition does not

--- a/internal/api/v1/channels_gating_test.go
+++ b/internal/api/v1/channels_gating_test.go
@@ -1,0 +1,186 @@
+// Copyright 2026 Benjamin Touchard (Kolapsis)
+//
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+// or a commercial license. You may not use this file except in compliance
+// with one of these licenses.
+//
+// AGPL-3.0: https://www.gnu.org/licenses/agpl-3.0.html
+// Commercial: See COMMERCIAL-LICENSE.md
+//
+// Source: https://github.com/kolapsis/maintenant
+
+package v1
+
+import (
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/kolapsis/maintenant/internal/alert"
+	"github.com/kolapsis/maintenant/internal/extension"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// FR-001d — the way out. An operator whose licence expired must still be able
+// to silence or remove a gated channel. Refusing the whole update, as the
+// handler used to, left deleting the configuration as the only way to stop
+// being notified: a trapdoor, not a door.
+//
+// The table runs for telegram and for slack, because the fix belongs to the
+// shared control, not to Telegram.
+func TestGatedChannel_ExitDoorStaysOpen(t *testing.T) {
+	for _, channelType := range []string{"telegram", "slack", "email"} {
+		t.Run(channelType, func(t *testing.T) {
+			cases := []struct {
+				name       string
+				body       string
+				wantStatus int
+			}{
+				{"disable only", `{"enabled":false}`, http.StatusOK},
+				{"enable", `{"enabled":true}`, http.StatusForbidden},
+				{"disable plus a change", `{"enabled":false,"name":"renamed"}`, http.StatusForbidden},
+				{"rename", `{"name":"renamed"}`, http.StatusForbidden},
+				{"new destination", `{"url":"-1009999999999"}`, http.StatusForbidden},
+			}
+
+			for _, tc := range cases {
+				t.Run(tc.name, func(t *testing.T) {
+					withEditionPinned(t, extension.Community)
+					logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+					store := &stubChannelStore{ch: &alert.NotificationChannel{
+						ID: "1", Name: "oncall", Type: channelType,
+						URL: "-1001234567890", Secret: sentinelToken, Enabled: true,
+					}}
+					h := &AlertHandler{channelStore: store, broker: NewSSEBroker(logger)}
+
+					req := httptest.NewRequest("PUT", "/api/v1/channels/1", strings.NewReader(tc.body))
+					req.Header.Set("Content-Type", "application/json")
+					req.SetPathValue("id", "1")
+					rec := httptest.NewRecorder()
+
+					h.HandleUpdateChannel(rec, req)
+
+					require.Equal(t, tc.wantStatus, rec.Code, "body: %s", rec.Body.String())
+					if tc.wantStatus == http.StatusForbidden {
+						assert.Contains(t, rec.Body.String(), "EDITION_REQUIRED")
+						assert.True(t, store.ch.Enabled, "a refused update must change nothing")
+					}
+				})
+			}
+		})
+	}
+}
+
+// The other way out. Deletion has never been gated; this is what keeps it that
+// way, on the type a future change would be most tempted to gate.
+func TestGatedChannel_DeleteIsNeverGated(t *testing.T) {
+	for _, channelType := range []string{"telegram", "slack", "email"} {
+		t.Run(channelType, func(t *testing.T) {
+			withEditionPinned(t, extension.Community)
+			logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+			store := &stubChannelStore{ch: &alert.NotificationChannel{
+				ID: "1", Name: "oncall", Type: channelType, URL: "-100123", Enabled: true,
+			}}
+			h := &AlertHandler{channelStore: store, broker: NewSSEBroker(logger)}
+
+			req := httptest.NewRequest("DELETE", "/api/v1/channels/1", nil)
+			req.SetPathValue("id", "1")
+			rec := httptest.NewRecorder()
+
+			h.HandleDeleteChannel(rec, req)
+
+			assert.Equal(t, http.StatusNoContent, rec.Code)
+		})
+	}
+}
+
+// A plain channel cannot be turned into a gated one from an edition that does
+// not open the target type, and a gated one cannot be edited by claiming it is
+// something else.
+func TestGatedChannel_TypeChangeIsCheckedBothWays(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	t.Run("webhook to telegram is refused", func(t *testing.T) {
+		withEditionPinned(t, extension.Community)
+		store := &stubChannelStore{ch: &alert.NotificationChannel{ID: "1", Type: "webhook", URL: "https://example.com"}}
+		h := &AlertHandler{channelStore: store, broker: NewSSEBroker(logger)}
+
+		req := httptest.NewRequest("PUT", "/api/v1/channels/1", strings.NewReader(`{"type":"telegram"}`))
+		req.SetPathValue("id", "1")
+		rec := httptest.NewRecorder()
+		h.HandleUpdateChannel(rec, req)
+
+		assert.Equal(t, http.StatusForbidden, rec.Code)
+		assert.Contains(t, rec.Body.String(), "telegram")
+	})
+
+	t.Run("telegram to webhook is refused too", func(t *testing.T) {
+		withEditionPinned(t, extension.Community)
+		store := &stubChannelStore{ch: &alert.NotificationChannel{ID: "1", Type: "telegram", URL: "-100123"}}
+		h := &AlertHandler{channelStore: store, broker: NewSSEBroker(logger)}
+
+		req := httptest.NewRequest("PUT", "/api/v1/channels/1", strings.NewReader(`{"type":"webhook","url":"https://example.com"}`))
+		req.SetPathValue("id", "1")
+		rec := httptest.NewRecorder()
+		h.HandleUpdateChannel(rec, req)
+
+		assert.Equal(t, http.StatusForbidden, rec.Code,
+			"editing a gated channel is gated, whatever it claims to become")
+	})
+}
+
+// FR-001a, the last surface: the test button is an outgoing call, so it is
+// gated like creation.
+func TestGatedChannel_TestButtonIsGated(t *testing.T) {
+	withEditionPinned(t, extension.Community)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	// A nil notifier is the proof: a refused test must not reach it.
+	store := &stubChannelStore{ch: &alert.NotificationChannel{
+		ID: "1", Type: "telegram", URL: "-100123", Secret: sentinelToken,
+	}}
+	h := &AlertHandler{channelStore: store, broker: NewSSEBroker(logger)}
+
+	req := httptest.NewRequest("POST", "/api/v1/channels/1/test", nil)
+	req.SetPathValue("id", "1")
+	rec := httptest.NewRecorder()
+
+	h.HandleTestChannel(rec, req)
+
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Contains(t, rec.Body.String(), "EDITION_REQUIRED")
+}
+
+// FR-001b: a licence that expires closes the management of a channel, never its
+// delivery. Asserted here rather than in the alert package, which cannot import
+// the edition registry — and this is exactly what fails the day someone adds a
+// capability check to the send path.
+func TestGatedChannel_DeliveryContinuesUnderCommunity(t *testing.T) {
+	withEditionPinned(t, extension.Community)
+
+	var sent int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sent++
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	notifier := alert.NewNotifier(nil, logger, true)
+	notifier.SetTelegramTransport(srv.URL, srv.Client())
+
+	ch := &alert.NotificationChannel{
+		ID: "1", Name: "oncall", Type: "telegram",
+		URL: "-1001234567890", Secret: sentinelToken, Enabled: true,
+	}
+	err := notifier.SendNow(t.Context(), &alert.Alert{
+		ID: "a1", Source: "endpoint", Severity: "critical", Status: "active",
+		Message: "Connection refused", EntityName: "api.example.com",
+	}, ch)
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, sent, "a downgraded instance keeps notifying through channels it already has")
+}

--- a/internal/api/v1/channels_telegram_test.go
+++ b/internal/api/v1/channels_telegram_test.go
@@ -1,0 +1,200 @@
+// Copyright 2026 Benjamin Touchard (Kolapsis)
+//
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+// or a commercial license. You may not use this file except in compliance
+// with one of these licenses.
+//
+// AGPL-3.0: https://www.gnu.org/licenses/agpl-3.0.html
+// Commercial: See COMMERCIAL-LICENSE.md
+//
+// Source: https://github.com/kolapsis/maintenant
+
+package v1
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/kolapsis/maintenant/internal/alert"
+	"github.com/kolapsis/maintenant/internal/extension"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The token used throughout. If it ever shows up in a response or a log line,
+// the test that looks for it fails (FR-005, SC-003).
+const sentinelToken = "8123456789:SENTINEL-DO-NOT-LEAK-xxxxxxxxxxxxx"
+
+func withEditionPinned(t *testing.T, e extension.Edition) {
+	t.Helper()
+	original := extension.CurrentEdition
+	extension.CurrentEdition = func() extension.Edition { return e }
+	t.Cleanup(func() { extension.CurrentEdition = original })
+}
+
+func telegramBody(name string) string {
+	return `{"name":"` + name + `","type":"telegram","url":"-1001234567890","secret":"` +
+		sentinelToken + `","config":{"thread_id":"42"},"enabled":true}`
+}
+
+// FR-001: Telegram opens at Personal. A Community instance is refused, and the
+// refusal names Personal rather than pushing every blocked channel to the top
+// tier.
+func TestTelegramChannel_CreateGating(t *testing.T) {
+	cases := []struct {
+		edition    extension.Edition
+		wantStatus int
+	}{
+		{extension.Community, http.StatusForbidden},
+		{extension.Personal, http.StatusCreated},
+		{extension.Pro, http.StatusCreated},
+	}
+
+	for _, tc := range cases {
+		t.Run(string(tc.edition), func(t *testing.T) {
+			withEditionPinned(t, tc.edition)
+			logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+			h := &AlertHandler{channelStore: &stubChannelStore{}, broker: NewSSEBroker(logger)}
+
+			req := httptest.NewRequest("POST", "/api/v1/channels", strings.NewReader(telegramBody("oncall")))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+
+			h.HandleCreateChannel(rec, req)
+
+			require.Equal(t, tc.wantStatus, rec.Code, "body: %s", rec.Body.String())
+			if tc.wantStatus != http.StatusForbidden {
+				return
+			}
+			var body ErrorResponse
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+			assert.Equal(t, "EDITION_REQUIRED", body.Error.Code)
+			assert.Equal(t, "telegram", body.Error.Feature)
+			assert.Equal(t, "personal", body.Error.RequiredEdition)
+		})
+	}
+}
+
+// SC-003: the token never comes back. Not on create, not on read, not in a log.
+func TestTelegramChannel_TokenNeverLeaves(t *testing.T) {
+	withEditionPinned(t, extension.Personal)
+
+	logs := &bytes.Buffer{}
+	logger := slog.New(slog.NewTextHandler(logs, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	store := &stubChannelStore{}
+	h := &AlertHandler{channelStore: store, broker: NewSSEBroker(logger)}
+
+	req := httptest.NewRequest("POST", "/api/v1/channels", strings.NewReader(telegramBody("oncall")))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	h.HandleCreateChannel(rec, req)
+	require.Equal(t, http.StatusCreated, rec.Code, "body: %s", rec.Body.String())
+
+	assert.NotContains(t, rec.Body.String(), sentinelToken, "the created channel carries the token back")
+	assert.NotContains(t, rec.Body.String(), `"secret"`, "no secret key at all, empty or not")
+	assert.Contains(t, rec.Body.String(), `"has_secret":true`, "the interface still learns a token is on file")
+	assert.Contains(t, rec.Body.String(), `"config":"{\"thread_id\":\"42\"}"`)
+
+	// And on the read paths.
+	store.ch = &alert.NotificationChannel{
+		ID: "1", Name: "oncall", Type: "telegram", URL: "-1001234567890",
+		Secret: sentinelToken, Config: `{"thread_id":"42"}`, HasSecret: true, Enabled: true,
+	}
+	readRec := httptest.NewRecorder()
+	readReq := httptest.NewRequest("GET", "/api/v1/channels", nil)
+	h.HandleListChannels(readRec, readReq)
+	assert.NotContains(t, readRec.Body.String(), sentinelToken)
+
+	assert.NotContains(t, logs.String(), sentinelToken, "no log line may carry the token")
+}
+
+// FR-004: an obviously wrong token or chat id is refused on shape, with no call
+// to Telegram — the handler has no notifier here, so any call would panic.
+func TestTelegramChannel_RefusesMalformedInputWithoutCallingTelegram(t *testing.T) {
+	withEditionPinned(t, extension.Personal)
+
+	cases := map[string]string{
+		"token without a colon": `{"name":"a","type":"telegram","url":"-100123","secret":"8123456789AAFxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}`,
+		"token missing":         `{"name":"a","type":"telegram","url":"-100123"}`,
+		"chat id is a name":     `{"name":"a","type":"telegram","url":"my-group","secret":"` + sentinelToken + `"}`,
+		"thread id not a number": `{"name":"a","type":"telegram","url":"-100123","secret":"` + sentinelToken +
+			`","config":{"thread_id":"general"}}`,
+	}
+
+	for name, body := range cases {
+		t.Run(name, func(t *testing.T) {
+			logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+			h := &AlertHandler{channelStore: &stubChannelStore{}, broker: NewSSEBroker(logger)}
+
+			req := httptest.NewRequest("POST", "/api/v1/channels", strings.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			h.HandleCreateChannel(rec, req)
+
+			assert.Equal(t, http.StatusBadRequest, rec.Code, "body: %s", rec.Body.String())
+		})
+	}
+}
+
+// FR-006: an update that says nothing about the token keeps it. Clearing it is
+// refused: a channel without its credential can no longer send, and would say
+// nothing about it.
+func TestTelegramChannel_UpdateKeepsTheStoredToken(t *testing.T) {
+	withEditionPinned(t, extension.Personal)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	stored := func() *alert.NotificationChannel {
+		return &alert.NotificationChannel{
+			ID: "1", Name: "oncall", Type: "telegram", URL: "-1001234567890",
+			Secret: sentinelToken, Enabled: true,
+		}
+	}
+
+	t.Run("absent secret is kept", func(t *testing.T) {
+		store := &stubChannelStore{ch: stored()}
+		h := &AlertHandler{channelStore: store, broker: NewSSEBroker(logger)}
+
+		req := httptest.NewRequest("PUT", "/api/v1/channels/1", strings.NewReader(`{"name":"renamed"}`))
+		req.SetPathValue("id", "1")
+		rec := httptest.NewRecorder()
+		h.HandleUpdateChannel(rec, req)
+
+		require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+		assert.Equal(t, sentinelToken, store.ch.Secret, "the stored token must survive a rename")
+		assert.NotContains(t, rec.Body.String(), sentinelToken)
+		assert.Contains(t, rec.Body.String(), `"has_secret":true`)
+	})
+
+	t.Run("empty secret is refused", func(t *testing.T) {
+		store := &stubChannelStore{ch: stored()}
+		h := &AlertHandler{channelStore: store, broker: NewSSEBroker(logger)}
+
+		req := httptest.NewRequest("PUT", "/api/v1/channels/1", strings.NewReader(`{"secret":""}`))
+		req.SetPathValue("id", "1")
+		rec := httptest.NewRecorder()
+		h.HandleUpdateChannel(rec, req)
+
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+		assert.Equal(t, sentinelToken, store.ch.Secret)
+	})
+
+	t.Run("new secret replaces the old one", func(t *testing.T) {
+		store := &stubChannelStore{ch: stored()}
+		h := &AlertHandler{channelStore: store, broker: NewSSEBroker(logger)}
+
+		fresh := "9876543210:AAFyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy"
+		req := httptest.NewRequest("PUT", "/api/v1/channels/1", strings.NewReader(`{"secret":"`+fresh+`"}`))
+		req.SetPathValue("id", "1")
+		rec := httptest.NewRecorder()
+		h.HandleUpdateChannel(rec, req)
+
+		require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+		assert.Equal(t, fresh, store.ch.Secret)
+	})
+}

--- a/internal/api/v1/edition_conformance_test.go
+++ b/internal/api/v1/edition_conformance_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/kolapsis/maintenant/internal/extension"
 )
 
-// This file is SC-003: for the 3 editions × 20 capabilities, the answer must be
+// This file is SC-003: for the 3 editions × 21 capabilities, the answer must be
 // the same whichever surface is asked. Without it, FR-004 ("a capability
 // announced as available must actually be usable") is a claim nobody checks.
 //
@@ -80,8 +80,8 @@ func TestConformance_FeatureEditionsMirrorsTheFlags(t *testing.T) {
 			features := body["features"].(map[string]any)
 			editions := body["feature_editions"].(map[string]any)
 
-			require.Len(t, features, 20)
-			require.Len(t, editions, 20)
+			require.Len(t, features, 21)
+			require.Len(t, editions, 21)
 			for key := range features {
 				require.Contains(t, editions, key, "feature_editions is missing %q", key)
 			}

--- a/internal/extension/capability.go
+++ b/internal/extension/capability.go
@@ -39,6 +39,7 @@ const (
 	CapAlertAdvancedFilters Capability = "alert_advanced_filters"
 	CapSecurityPosture      Capability = "security_posture"
 	CapOCSPStapling         Capability = "ocsp_stapling"
+	CapTelegram             Capability = "telegram"
 
 	// Pro
 	CapSlack              Capability = "slack"
@@ -68,6 +69,7 @@ var minEdition = map[Capability]Edition{
 	CapAlertAdvancedFilters: Personal,
 	CapSecurityPosture:      Personal,
 	CapOCSPStapling:         Personal,
+	CapTelegram:             Personal,
 
 	CapSlack:              Pro,
 	CapTeams:              Pro,

--- a/internal/extension/capability_test.go
+++ b/internal/extension/capability_test.go
@@ -12,12 +12,12 @@ func withEdition(t *testing.T, e Edition) {
 }
 
 // TestAllows_EveryEditionEveryCapability walks the whole matrix — 3 editions ×
-// 20 capabilities — and asserts Allows agrees with the declared order. This is
+// 21 capabilities — and asserts Allows agrees with the declared order. This is
 // SC-003 on the extension side.
 func TestAllows_EveryEditionEveryCapability(t *testing.T) {
 	catalog := Catalog()
-	if len(catalog) != 20 {
-		t.Fatalf("catalog holds %d capabilities, expected 20", len(catalog))
+	if len(catalog) != 21 {
+		t.Fatalf("catalog holds %d capabilities, expected 21", len(catalog))
 	}
 
 	for _, edition := range []Edition{Community, Personal, Pro} {
@@ -43,7 +43,7 @@ func TestCatalog_ReturnsACopy(t *testing.T) {
 	if got := MinEdition(CapAlertEscalation); got != Pro {
 		t.Errorf("mutating the Catalog copy changed the registry: alert_escalation = %q, want %q", got, Pro)
 	}
-	if len(Catalog()) != 20 {
+	if len(Catalog()) != 21 {
 		t.Errorf("mutating the Catalog copy changed the registry size: %d", len(Catalog()))
 	}
 }
@@ -59,7 +59,7 @@ func TestMinEdition_TierMembership(t *testing.T) {
 		Personal: {
 			CapMultihost, CapCVEEnrichment, CapRiskScoring, CapChangelog,
 			CapIncidents, CapSMTP, CapAlertAdvancedFilters,
-			CapSecurityPosture, CapOCSPStapling,
+			CapSecurityPosture, CapOCSPStapling, CapTelegram,
 		},
 		Pro: {
 			CapSlack, CapTeams, CapAlertEscalation, CapAlertEntityRouting,
@@ -76,8 +76,8 @@ func TestMinEdition_TierMembership(t *testing.T) {
 			}
 		}
 	}
-	if total != 20 {
-		t.Errorf("the three tiers list %d capabilities, expected 20", total)
+	if total != 21 {
+		t.Errorf("the three tiers list %d capabilities, expected 21", total)
 	}
 }
 

--- a/internal/store/channels.go
+++ b/internal/store/channels.go
@@ -40,9 +40,11 @@ func (s *ChannelStoreImpl) InsertChannel(ctx context.Context, ch *alert.Notifica
 	ch.ID = uid.New()
 	now := time.Now().Unix()
 	_, err := s.writer.Exec(ctx,
-		`INSERT INTO notification_channels (id, name, type, url, headers, enabled, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-		ch.ID, ch.Name, ch.Type, ch.URL, NullableString(ch.Headers), boolToInt(ch.Enabled), now, now,
+		`INSERT INTO notification_channels (id, name, type, url, headers, secret, config, enabled, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		ch.ID, ch.Name, ch.Type, ch.URL, NullableString(ch.Headers),
+		NullableString(ch.Secret), NullableString(ch.Config),
+		boolToInt(ch.Enabled), now, now,
 	)
 	if err != nil {
 		return "", fmt.Errorf("insert channel: %w", err)
@@ -52,7 +54,7 @@ func (s *ChannelStoreImpl) InsertChannel(ctx context.Context, ch *alert.Notifica
 
 func (s *ChannelStoreImpl) GetChannel(ctx context.Context, id string) (*alert.NotificationChannel, error) {
 	row := s.db.QueryRowContext(ctx,
-		`SELECT id, name, type, url, headers, enabled, created_at, updated_at
+		`SELECT id, name, type, url, headers, secret, config, enabled, created_at, updated_at
 		FROM notification_channels WHERE id = ?`, id)
 
 	ch, err := scanChannel(row)
@@ -68,7 +70,7 @@ func (s *ChannelStoreImpl) GetChannel(ctx context.Context, id string) (*alert.No
 
 func (s *ChannelStoreImpl) ListChannels(ctx context.Context) ([]*alert.NotificationChannel, error) {
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT id, name, type, url, headers, enabled, created_at, updated_at
+		`SELECT id, name, type, url, headers, secret, config, enabled, created_at, updated_at
 		FROM notification_channels ORDER BY created_at ASC`)
 	if err != nil {
 		return nil, fmt.Errorf("list channels: %w", err)
@@ -102,9 +104,10 @@ func (s *ChannelStoreImpl) ListChannels(ctx context.Context) ([]*alert.Notificat
 
 func (s *ChannelStoreImpl) UpdateChannel(ctx context.Context, ch *alert.NotificationChannel) error {
 	_, err := s.writer.Exec(ctx,
-		`UPDATE notification_channels SET name=?, type=?, url=?, headers=?, enabled=?, updated_at=?
+		`UPDATE notification_channels SET name=?, type=?, url=?, headers=?, secret=?, config=?, enabled=?, updated_at=?
 		WHERE id=?`,
-		ch.Name, ch.Type, ch.URL, NullableString(ch.Headers), boolToInt(ch.Enabled),
+		ch.Name, ch.Type, ch.URL, NullableString(ch.Headers),
+		NullableString(ch.Secret), NullableString(ch.Config), boolToInt(ch.Enabled),
 		time.Now().Unix(), ch.ID,
 	)
 	if err != nil {
@@ -201,11 +204,11 @@ func (s *ChannelStoreImpl) ListDeliveriesByAlert(ctx context.Context, alertID st
 
 func scanChannel(row *sql.Row) (*alert.NotificationChannel, error) {
 	ch := &alert.NotificationChannel{}
-	var headers sql.NullString
+	var headers, secret, config sql.NullString
 	var enabled int
 	var createdAt, updatedAt int64
 
-	err := row.Scan(&ch.ID, &ch.Name, &ch.Type, &ch.URL, &headers, &enabled, &createdAt, &updatedAt)
+	err := row.Scan(&ch.ID, &ch.Name, &ch.Type, &ch.URL, &headers, &secret, &config, &enabled, &createdAt, &updatedAt)
 	if err != nil {
 		return nil, err
 	}
@@ -214,6 +217,9 @@ func scanChannel(row *sql.Row) (*alert.NotificationChannel, error) {
 	if headers.Valid {
 		ch.Headers = headers.String
 	}
+	ch.Secret = secret.String
+	ch.Config = config.String
+	ch.HasSecret = ch.Secret != ""
 	ch.CreatedAt = time.Unix(createdAt, 0)
 	ch.UpdatedAt = time.Unix(updatedAt, 0)
 	return ch, nil
@@ -221,11 +227,11 @@ func scanChannel(row *sql.Row) (*alert.NotificationChannel, error) {
 
 func scanChannelRow(rows *sql.Rows) (*alert.NotificationChannel, error) {
 	ch := &alert.NotificationChannel{}
-	var headers sql.NullString
+	var headers, secret, config sql.NullString
 	var enabled int
 	var createdAt, updatedAt int64
 
-	err := rows.Scan(&ch.ID, &ch.Name, &ch.Type, &ch.URL, &headers, &enabled, &createdAt, &updatedAt)
+	err := rows.Scan(&ch.ID, &ch.Name, &ch.Type, &ch.URL, &headers, &secret, &config, &enabled, &createdAt, &updatedAt)
 	if err != nil {
 		return nil, err
 	}
@@ -234,6 +240,9 @@ func scanChannelRow(rows *sql.Rows) (*alert.NotificationChannel, error) {
 	if headers.Valid {
 		ch.Headers = headers.String
 	}
+	ch.Secret = secret.String
+	ch.Config = config.String
+	ch.HasSecret = ch.Secret != ""
 	ch.CreatedAt = time.Unix(createdAt, 0)
 	ch.UpdatedAt = time.Unix(updatedAt, 0)
 	return ch, nil

--- a/internal/store/channels_test.go
+++ b/internal/store/channels_test.go
@@ -1,0 +1,128 @@
+// Copyright 2026 Benjamin Touchard (Kolapsis)
+//
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+// or a commercial license. You may not use this file except in compliance
+// with one of these licenses.
+//
+// AGPL-3.0: https://www.gnu.org/licenses/agpl-3.0.html
+// Commercial: See COMMERCIAL-LICENSE.md
+//
+// Source: https://github.com/kolapsis/maintenant
+
+package store
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kolapsis/maintenant/internal/alert"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A channel carrying a credential and per-type settings must come back with
+// both, on either engine. The columns are new in migration 30, so this is also
+// what proves the migration reached the table the store writes to.
+func TestChannelStore_SecretAndConfigRoundTrip(t *testing.T) {
+	db := openTestDB(t)
+	s := NewChannelStore(db)
+	ctx := context.Background()
+
+	id, err := s.InsertChannel(ctx, &alert.NotificationChannel{
+		Name:    "telegram-oncall",
+		Type:    "telegram",
+		URL:     "-1001234567890",
+		Secret:  "8123456789:AAF-token",
+		Config:  `{"thread_id":"42"}`,
+		Enabled: true,
+	})
+	require.NoError(t, err)
+
+	got, err := s.GetChannel(ctx, id)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "8123456789:AAF-token", got.Secret)
+	assert.Equal(t, `{"thread_id":"42"}`, got.Config)
+	assert.True(t, got.HasSecret, "HasSecret is derived at scan time")
+
+	list, err := s.ListChannels(ctx)
+	require.NoError(t, err)
+	require.Len(t, list, 1)
+	assert.Equal(t, "8123456789:AAF-token", list[0].Secret,
+		"the list path scans the same columns as the single-row path")
+	assert.True(t, list[0].HasSecret)
+}
+
+// The five older channel types leave both columns NULL. Scanning must give the
+// zero value, not an error, and HasSecret must stay false.
+func TestChannelStore_ExistingTypesKeepBothColumnsNull(t *testing.T) {
+	db := openTestDB(t)
+	s := NewChannelStore(db)
+	ctx := context.Background()
+
+	id, err := s.InsertChannel(ctx, &alert.NotificationChannel{
+		Name:    "generic-webhook",
+		Type:    "webhook",
+		URL:     "https://example.com/hook",
+		Enabled: true,
+	})
+	require.NoError(t, err)
+
+	got, err := s.GetChannel(ctx, id)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Empty(t, got.Secret)
+	assert.Empty(t, got.Config)
+	assert.False(t, got.HasSecret)
+}
+
+// An update that carries the secret forward keeps it; one that carries an empty
+// secret clears it. The store applies what it is handed — deciding whether an
+// absent token means "keep" is the handler's job, and its test covers that.
+func TestChannelStore_UpdateAppliesTheSecretItIsGiven(t *testing.T) {
+	db := openTestDB(t)
+	s := NewChannelStore(db)
+	ctx := context.Background()
+
+	id, err := s.InsertChannel(ctx, &alert.NotificationChannel{
+		Name: "telegram-oncall", Type: "telegram", URL: "-100123",
+		Secret: "8123456789:AAF-token", Enabled: true,
+	})
+	require.NoError(t, err)
+
+	ch, err := s.GetChannel(ctx, id)
+	require.NoError(t, err)
+	ch.Enabled = false
+	require.NoError(t, s.UpdateChannel(ctx, ch))
+
+	got, err := s.GetChannel(ctx, id)
+	require.NoError(t, err)
+	assert.False(t, got.Enabled)
+	assert.Equal(t, "8123456789:AAF-token", got.Secret, "disabling must not drop the token")
+
+	got.Secret = ""
+	require.NoError(t, s.UpdateChannel(ctx, got))
+	after, err := s.GetChannel(ctx, id)
+	require.NoError(t, err)
+	assert.Empty(t, after.Secret)
+	assert.False(t, after.HasSecret)
+}
+
+// Deletion is not gated by anything and must stay that way: it is one of the
+// two ways out for an operator whose licence expired (FR-001d).
+func TestChannelStore_DeleteRemovesTheChannel(t *testing.T) {
+	db := openTestDB(t)
+	s := NewChannelStore(db)
+	ctx := context.Background()
+
+	id, err := s.InsertChannel(ctx, &alert.NotificationChannel{
+		Name: "telegram-oncall", Type: "telegram", URL: "-100123",
+		Secret: "8123456789:AAF-token", Enabled: true,
+	})
+	require.NoError(t, err)
+	require.NoError(t, s.DeleteChannel(ctx, id))
+
+	got, err := s.GetChannel(ctx, id)
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}

--- a/internal/store/copy_test.go
+++ b/internal/store/copy_test.go
@@ -97,6 +97,13 @@ func seededSource(t *testing.T) (*DB, string) {
 	channelID, triggerID := uid.New(), uid.New()
 	exec(`INSERT INTO notification_channels (id, name, type, url, enabled, created_at, updated_at)
 		VALUES (?, 'ops', 'webhook', 'https://hooks.example/secret', 1, ?, ?)`, channelID, now, now)
+	// A Telegram channel: its credential and its per-type settings live in
+	// columns of their own, and a channel that arrived without its token would
+	// be a channel that can no longer send.
+	telegramID := uid.New()
+	exec(`INSERT INTO notification_channels (id, name, type, url, secret, config, enabled, created_at, updated_at)
+		VALUES (?, 'oncall-telegram', 'telegram', '-1001234567890', '8123456789:AAF-token', '{"thread_id":"42"}', 1, ?, ?)`,
+		telegramID, now, now)
 	exec(`INSERT INTO alert_triggers (id, name, filter_severities, enabled, created_at, updated_at)
 		VALUES (?, 'page ops', '["critical"]', 1, ?, ?)`, triggerID, now, now)
 	exec(`INSERT INTO alert_trigger_channels (trigger_id, channel_id) VALUES (?, ?)`, triggerID, channelID)
@@ -224,6 +231,14 @@ func TestCopy_CarriesWhatCannotBeRebuilt(t *testing.T) {
 	var channelURL string
 	require.NoError(t, dst.QueryRow("SELECT url FROM notification_channels").Scan(&channelURL))
 	assert.Equal(t, "https://hooks.example/secret", channelURL, "channel secrets travel with their channel")
+
+	var telegramSecret, telegramConfig string
+	require.NoError(t, dst.QueryRow(
+		"SELECT secret, config FROM notification_channels WHERE type = 'telegram'").
+		Scan(&telegramSecret, &telegramConfig))
+	assert.Equal(t, "8123456789:AAF-token", telegramSecret,
+		"a channel arriving without its token could no longer send")
+	assert.Equal(t, `{"thread_id":"42"}`, telegramConfig)
 
 	var webhookSecret string
 	require.NoError(t, dst.QueryRow("SELECT secret FROM webhook_subscriptions").Scan(&webhookSecret))

--- a/internal/store/migrations/postgres/30_channel_secret_config.down.sql
+++ b/internal/store/migrations/postgres/30_channel_secret_config.down.sql
@@ -1,0 +1,2 @@
+-- Migration rollback is intentionally a no-op per the project convention
+-- (see 20_cert_ocsp.down.sql, 25_cert_sni.down.sql).

--- a/internal/store/migrations/postgres/30_channel_secret_config.up.sql
+++ b/internal/store/migrations/postgres/30_channel_secret_config.up.sql
@@ -1,0 +1,5 @@
+-- Gives a notification channel a place for a credential and for its non-secret
+-- per-type settings. Telegram is the first to need both: a bot token, which no
+-- response may ever carry, and an optional forum topic id.
+ALTER TABLE notification_channels ADD COLUMN secret TEXT;
+ALTER TABLE notification_channels ADD COLUMN config TEXT;

--- a/internal/store/migrations/sqlite/30_channel_secret_config.down.sql
+++ b/internal/store/migrations/sqlite/30_channel_secret_config.down.sql
@@ -1,0 +1,2 @@
+-- Migration rollback is intentionally a no-op per the project convention
+-- (see 20_cert_ocsp.down.sql, 25_cert_sni.down.sql).

--- a/internal/store/migrations/sqlite/30_channel_secret_config.up.sql
+++ b/internal/store/migrations/sqlite/30_channel_secret_config.up.sql
@@ -1,0 +1,5 @@
+-- Gives a notification channel a place for a credential and for its non-secret
+-- per-type settings. Telegram is the first to need both: a bot token, which no
+-- response may ever carry, and an optional forum topic id.
+ALTER TABLE notification_channels ADD COLUMN secret TEXT;
+ALTER TABLE notification_channels ADD COLUMN config TEXT;

--- a/internal/store/migrations_postgres_test.go
+++ b/internal/store/migrations_postgres_test.go
@@ -110,11 +110,17 @@ func TestMigratePostgres_ConcurrentCatchUp(t *testing.T) {
 	t.Cleanup(func() { _ = db.Close() })
 	require.NoError(t, Migrate(ctx, db, logger))
 
-	// Rewind to the baseline: drop what migration 29 created and set the
-	// recorded version back.
-	_, err = db.ReadDB().Exec("DROP TABLE instances")
-	require.NoError(t, err)
-	_, err = db.ReadDB().Exec("UPDATE schema_migrations SET version = 28, dirty = false")
+	// Rewind to the baseline: undo every migration written above it, then set
+	// the recorded version back. Each new migration adds a line here — that is
+	// the price of a test that catches up over more than one step.
+	for _, undo := range []string{
+		"DROP TABLE instances", // 29
+		"ALTER TABLE notification_channels DROP COLUMN secret, DROP COLUMN config", // 30
+	} {
+		_, err = db.ReadDB().Exec(undo)
+		require.NoError(t, err, undo)
+	}
+	_, err = db.ReadDB().Exec("UPDATE schema_migrations SET version = $1, dirty = false", postgresBaselineVersion)
 	require.NoError(t, err)
 
 	const n = 4
@@ -135,9 +141,11 @@ func TestMigratePostgres_ConcurrentCatchUp(t *testing.T) {
 	for i, err := range errs {
 		assert.NoError(t, err, "concurrent catch-up %d", i)
 	}
+	head, err := EmbeddedHeadVersion(DialectPostgres)
+	require.NoError(t, err)
 	v, err := db.SchemaVersion(ctx)
 	require.NoError(t, err)
-	assert.Equal(t, uint(29), v)
+	assert.Equal(t, head, v)
 	var one int
 	require.NoError(t, db.ReadDB().QueryRow("SELECT count(*) FROM instances").Scan(&one))
 	assert.Zero(t, one, "instances recreated empty")

--- a/internal/store/uuid_schema.sql
+++ b/internal/store/uuid_schema.sql
@@ -360,6 +360,8 @@ CREATE TABLE notification_channels (
     type          TEXT NOT NULL DEFAULT 'webhook',
     url           TEXT NOT NULL,
     headers       TEXT,
+    secret        TEXT,                                     -- channel credential; never serialized
+    config        TEXT,                                     -- non-secret per-type settings, JSON
     enabled       INTEGER NOT NULL DEFAULT 1,
     created_at    BIGINT NOT NULL DEFAULT 0,
     updated_at    BIGINT NOT NULL DEFAULT 0


### PR DESCRIPTION
Adds Telegram as a first-class notification channel: the operator supplies a bot
token and a chat id, the destination host is fixed by the product, so there is no
user-supplied URL and no SSRF question to answer.

- Alerts render as HTML, with severity and entity on the first line so a phone
  notification says what happened without being opened. Messages over 4096
  characters are truncated on the description, never on the header.
- The bot token lives in the channel secret: it never leaves through the API and
  never reaches a log or an error, including the transport ones that carry the URL.

Close #80 