### PR TITLE
docs: add Scaleway, OVHcloud and Vultr deployment guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ curl -fsSL https://install.maintenant.dev | sudo bash
 
 Endpoints, certificates and heartbeats work without any container runtime. Container monitoring switches on by itself the moment a runtime shows up. [Install documentation](https://docs.maintenant.dev/install/) for pinned versions, air-gapped installs and supply-chain verification.
 
-**Cloud**: one `cloud-init` file boots a hardened host with maintenant running on [Hetzner Cloud](https://docs.maintenant.dev/guides/hetzner/) or [DigitalOcean](https://docs.maintenant.dev/guides/digitalocean/).
+**Cloud**: one `cloud-init` file boots a hardened host with maintenant running on [Hetzner Cloud](https://docs.maintenant.dev/guides/hetzner/), [DigitalOcean](https://docs.maintenant.dev/guides/digitalocean/), [Scaleway](https://docs.maintenant.dev/guides/scaleway/), [OVHcloud](https://docs.maintenant.dev/guides/ovhcloud/) or [Vultr](https://docs.maintenant.dev/guides/vultr/).
 
 ---
 

--- a/deploy/cloud-init/README.md
+++ b/deploy/cloud-init/README.md
@@ -21,6 +21,31 @@ doctl compute droplet create maintenant \
   --ssh-keys my-key \
   --user-data-file deploy/cloud-init/maintenant.yaml \
   --wait
+
+# Scaleway
+scw instance server create \
+  zone=fr-par-1 \
+  type=PLAY2-NANO \
+  image=ubuntu_noble \
+  name=maintenant \
+  ip=new \
+  cloud-init=@deploy/cloud-init/maintenant.yaml
+
+# OVHcloud Public Cloud (source your OpenStack RC file first)
+openstack server create \
+  --flavor d2-4 \
+  --image "Ubuntu 24.04" \
+  --key-name my-key \
+  --user-data deploy/cloud-init/maintenant.yaml \
+  maintenant
+
+# Vultr (the CLI base64-encodes the file for you, do not do it yourself)
+vultr-cli instance create \
+  --region="ewr" \
+  --plan="vc2-2c-4gb" \
+  --os=2284 \
+  --label="maintenant" \
+  --userdata-file=deploy/cloud-init/maintenant.yaml
 ```
 
 The dashboard is published on `127.0.0.1:8080` only. Reach it through an SSH tunnel, or front it
@@ -31,3 +56,6 @@ enrolment over a private network, load balancer checks and managed Kubernetes â€
 
 - [Hetzner Cloud](https://docs.maintenant.dev/guides/hetzner/)
 - [DigitalOcean](https://docs.maintenant.dev/guides/digitalocean/)
+- [Scaleway](https://docs.maintenant.dev/guides/scaleway/)
+- [OVHcloud](https://docs.maintenant.dev/guides/ovhcloud/)
+- [Vultr](https://docs.maintenant.dev/guides/vultr/)

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -89,6 +89,9 @@ Open **http://localhost:8080**. maintenant auto-discovers all your containers im
 
     - [Hetzner Cloud](../guides/hetzner.md)
     - [DigitalOcean](../guides/digitalocean.md)
+    - [Scaleway](../guides/scaleway.md)
+    - [OVHcloud](../guides/ovhcloud.md)
+    - [Vultr](../guides/vultr.md)
 
 !!! tip "Production deployment"
     For production, place maintenant behind a reverse proxy with authentication.

--- a/docs/guides/hetzner.md
+++ b/docs/guides/hetzner.md
@@ -246,6 +246,9 @@ docker compose -f /opt/maintenant/compose.yml start
 
 - [Installation](../getting-started/installation.md) — Docker, Kubernetes and source builds
 - [DigitalOcean Deployment](digitalocean.md) — The same ground on DigitalOcean
+- [Scaleway Deployment](scaleway.md) — The same ground on Scaleway
+- [OVHcloud Deployment](ovhcloud.md) — The same ground on OVHcloud
+- [Vultr Deployment](vultr.md) — The same ground on Vultr
 - [Agent Setup](agent-setup.md) — Enrolling additional hosts over gRPC
 - [Kubernetes Guide](kubernetes.md) — RBAC, Helm values, workload monitoring
 - [PostgreSQL Storage](postgresql.md) — Making the server replaceable

--- a/docs/guides/kubernetes.md
+++ b/docs/guides/kubernetes.md
@@ -21,6 +21,9 @@ On a managed cluster, name the storage class your provider's CSI driver installs
 |---------|-------|
 | Hetzner (`kube-hetzner`, `hetzner-k3s`, Talos) | `--set persistence.storageClass=hcloud-volumes`, see [Kubernetes on Hetzner](hetzner.md#kubernetes-on-hetzner) |
 | DigitalOcean (DOKS) | `--set persistence.storageClass=do-block-storage-retain`, see [Kubernetes on DOKS](digitalocean.md#kubernetes-on-doks) |
+| Scaleway (Kapsule) | `--set persistence.storageClass=sbs-default`, see [Kubernetes on Kapsule](scaleway.md#kubernetes-on-kapsule) |
+| OVHcloud (MKS) | `--set persistence.storageClass=csi-cinder-high-speed`, see [Kubernetes on Managed Kubernetes](ovhcloud.md#kubernetes-on-managed-kubernetes) |
+| Vultr (VKE) | `--set persistence.storageClass=vultr-block-storage-retain`, see [Kubernetes on VKE](vultr.md#kubernetes-on-vke) |
 
 ### Raw manifests
 
@@ -367,6 +370,9 @@ helm uninstall maintenant -n maintenant
 - [Installation](../getting-started/installation.md) — Docker and source builds
 - [Hetzner Cloud Deployment](hetzner.md) — Clusters built with kube-hetzner, hetzner-k3s or Talos
 - [DigitalOcean Deployment](digitalocean.md) — DOKS storage classes and Load Balancer checks
+- [Scaleway Deployment](scaleway.md) — Kapsule storage classes and Private Network DNS
+- [OVHcloud Deployment](ovhcloud.md) — MKS storage classes and zone-pinned volumes
+- [Vultr Deployment](vultr.md) — VKE storage classes and the 10Gi PVC floor
 - [Configuration](../getting-started/configuration.md) — Environment variables
 - [Container Monitoring](../features/containers.md) — How workloads are tracked
 - [Resource Metrics](../features/resources.md) — CPU/memory from metrics-server

--- a/docs/guides/ovhcloud.md
+++ b/docs/guides/ovhcloud.md
@@ -1,0 +1,330 @@
+# OVHcloud Deployment Guide
+
+How to run maintenant on OVHcloud Public Cloud: an instance provisioned with cloud-init, security groups, a Block Storage volume for the database, agents over a private network, and Managed Kubernetes.
+
+---
+
+## Public Cloud, not VPS
+
+OVHcloud sells two things that look interchangeable and are not. This guide targets **Public Cloud**, the OpenStack-based offer, for one blunt reason: **a VPS cannot run a cloud-init file**. The rebuild API accepts a `postInstallScript` (a bash script run once on first boot) and nothing else; there is no user-data field, and cloud-init support on VPS is still an open request on OVHcloud's roadmap.
+
+A VPS also has none of what the rest of this guide relies on:
+
+| | VPS | Public Cloud |
+|---|---|---|
+| cloud-init | no, bash post-install script only | yes |
+| Private network (vRack) | not supported | yes |
+| Block Storage volumes | a fixed "additional disk" option, not a Cinder volume | yes, attach and detach live |
+| Load balancer | no Octavia, only the separate IP Load Balancing product | yes |
+| Managed Kubernetes | no | yes |
+
+A VPS is still a fine home for a single maintenant server if you never plan to enrol remote agents: install Docker over SSH and follow the [installation guide](../getting-started/installation.md) directly. Everything below assumes Public Cloud.
+
+!!! warning "No ARM instances at OVHcloud"
+    maintenant publishes `linux/arm64` images, and the Hetzner and Scaleway guides use them to cut
+    costs. OVHcloud Public Cloud has no ARM instances: the request has been open on their roadmap
+    since January 2023. Every flavor below is x86.
+
+---
+
+## Why it fits a small instance
+
+maintenant is a single Go binary with the frontend embedded and SQLite as its default store. It idles around 17 MB of RAM and needs no database server, no Prometheus, no Redis.
+
+`d2-4` (Discovery) is the natural starting point for a monitoring server; `s1-4` is cheaper still if
+your project has access to it. Move up the `b3-` or `c3-` ranges only once you switch the store to
+PostgreSQL and monitor hundreds of containers.
+
+!!! note "Check flavors and images against your project"
+    Flavor names and their exact vCPU/RAM split are not published in a table you can rely on, and
+    the Ubuntu image name appears in two forms across OVHcloud's own documentation. List them:
+
+    ```bash
+    openstack flavor list
+    openstack image list | grep -i ubuntu
+    ```
+
+---
+
+## Step 1 — Create the instance
+
+Public Cloud is driven with the standard OpenStack client. Download the RC file from the OVHcloud
+Control Panel under **Users & Roles**, then source it. One RC file covers one user and one region.
+
+```bash
+source openrc.sh          # prompts for the Horizon password
+openstack server list     # confirms the session works
+```
+
+The repository ships a ready-to-use cloud-config at [`deploy/cloud-init/maintenant.yaml`](https://github.com/kolapsis/maintenant/blob/main/deploy/cloud-init/maintenant.yaml). It installs Docker from the official repository, writes `/opt/maintenant/compose.yml`, and starts the stack on first boot.
+
+```bash
+openstack server create \
+  --flavor d2-4 \
+  --image "<the Ubuntu 24.04 image name from openstack image list>" \
+  --key-name my-key \
+  --user-data deploy/cloud-init/maintenant.yaml \
+  maintenant
+```
+
+Then reach the dashboard, which the cloud-config binds to loopback:
+
+```bash
+ssh -L 8080:127.0.0.1:8080 ubuntu@<instance-public-ip>
+```
+
+Open **http://localhost:8080**. Every container on the host is already discovered.
+
+---
+
+## Step 2 — Security groups
+
+OpenStack blocks inbound traffic by default: the stock rules allow outgoing traffic only. Create a
+group, then apply it to the instance's port.
+
+```bash
+openstack security group create maintenant
+
+openstack security group rule create --protocol tcp --dst-port 22 \
+  --remote-ip "$(curl -s https://ipv4.icanhazip.com)/32" maintenant
+openstack security group rule create --protocol tcp --dst-port 80 maintenant
+openstack security group rule create --protocol tcp --dst-port 443 maintenant
+
+openstack port list --server <server-id>
+openstack port set --security-group maintenant <port-id>
+```
+
+Note what is **not** in that list: port `8080`. Publish the dashboard through a reverse proxy with authentication, never as a raw port on the public IP.
+
+!!! warning "maintenant will flag its own exposure"
+    If you change the Compose file to publish `"8080:8080"`, maintenant's own network security
+    scanner reports a critical **Port exposed on all interfaces** finding for its own container.
+    That is the intended behaviour, not a bug. See the note in
+    [Installation → Docker Compose](../getting-started/installation.md#docker-compose-recommended)
+    and [Configuration → Choosing a Bind Address](../getting-started/configuration.md#choosing-a-bind-address).
+
+!!! warning "Old private networks silently ignore security groups"
+    Private networks created before 6 September 2022 had port security turned off during an
+    OpenStack upgrade, so security groups are not enforced on them. A rule that appears to exist
+    and filters nothing is worse than no rule. Check and fix:
+
+    ```bash
+    openstack port show <port-id> -f value -c port_security_enabled
+    openstack network set --enable-port-security <network-id>
+    openstack port set --enable-port-security <port-id>
+    ```
+
+---
+
+## Step 3 — Put the database on a Block Storage volume
+
+The instance's disk goes away with the instance. A Cinder volume survives, resizes, and can be snapshotted on its own. Volumes run from 10 GB to 12 TB; `high-speed-gen2` is the current performance class, `classic` the cheaper one.
+
+```bash
+openstack volume create --type high-speed-gen2 --size 20 maintenant-data
+openstack server add volume <server-id> <volume-id>
+```
+
+**OVHcloud formats and mounts nothing.** The disk shows up as a virtio device, `/dev/vdb` (the root disk being `/dev/vda`):
+
+```bash
+lsblk                                    # the new volume shows up as /dev/vdb
+mkfs.ext4 /dev/vdb
+mkdir -p /mnt/maintenant-data
+blkid /dev/vdb                           # note the UUID
+echo "UUID=<uuid> /mnt/maintenant-data ext4 defaults,nofail 0 2" >> /etc/fstab
+mount -a
+```
+
+Then point the Compose volume at it:
+
+```yaml
+# /opt/maintenant/compose.yml
+    volumes:
+      - /mnt/maintenant-data/maintenant:/data
+    environment:
+      MAINTENANT_DB: "/data/maintenant.db"
+```
+
+!!! tip "Mount by UUID, not by device name"
+    `/dev/vdb` is the order the kernel happened to enumerate the disks in. Attach a second volume
+    and the names can swap, which is how a database ends up pointed at the wrong filesystem.
+
+!!! warning "Size the volume for migrations, not just for the data"
+    Schema migrations rebuild tables in place and transiently need several times the size of the
+    database. A volume sized to the current database will fail an upgrade. The 10 GB floor is also
+    the smallest volume OVHcloud sells, so this costs you nothing to respect.
+
+!!! note "Watching more than one host? Consider PostgreSQL"
+    The server holds the agents' identity and enrolment, the one thing they cannot rebuild on
+    their own. On the default SQLite file, losing that instance means re-enrolling every host by
+    hand. Pointing the server at a PostgreSQL you already run makes the instance replaceable. See
+    [PostgreSQL storage](postgresql.md).
+
+---
+
+## Monitoring several instances over a private network
+
+Public Cloud private networks are built on the vRack, which recent projects get automatically.
+Private traffic is free and unmetered.
+
+```bash
+openstack network create maintenant
+openstack subnet create maintenant-subnet \
+  --network maintenant --subnet-range 10.0.0.0/24
+```
+
+!!! important "Ask for DHCP explicitly"
+    A subnet can be created with `--no-dhcp`, and then instances get no address on it at all. If
+    you want addresses handed out, do not pass that flag. This is the first thing to check when an
+    attached instance has no private IP.
+
+**There is no internal DNS.** Unlike some providers, OVHcloud does not resolve instance names on a
+private network: the request was closed as not planned. Agents therefore dial a private IP, or a
+name you maintain yourself in `/etc/hosts` or your own DNS. Whichever you choose, the name has to
+match the certificate the server presents.
+
+Bind the gRPC listener to the private address on the server:
+
+```bash
+MAINTENANT_GRPC_LISTEN=10.0.0.2:8443
+MAINTENANT_GRPC_URL=grpcs://maintenant.internal.example.com:8443
+```
+
+Then enrol each other instance. Generate a token from **Agents → Add host**: the modal hands you a
+ready-made command. Run it on the host, pointing at the private address:
+
+```bash
+docker run -d \
+  --name maintenant-agent \
+  --restart unless-stopped \
+  -v /var/run/docker.sock:/var/run/docker.sock:ro \
+  -v /proc:/host/proc:ro \
+  -v maintenant-agent-data:/var/lib/maintenant \
+  ghcr.io/kolapsis/maintenant:latest \
+  --mode=agent \
+  --server=grpcs://maintenant.internal.example.com:8443 \
+  --enrollment-token=mnt_enr_XXXXXXXXXXXXXXXX
+```
+
+!!! important "Private does not mean plaintext"
+    Binding on the private address keeps the listener off the public internet, but the agent still
+    speaks TLS. Use a certificate that covers the name you gave the server; a DNS-01 ACME
+    certificate works for a name that only resolves privately. Do **not** reach for
+    `--grpc-insecure-skip-tls-verify` outside a lab. The full matrix of TLS modes is in
+    [Agent Setup → Step 1](agent-setup.md#step-1-make-the-grpc-endpoint-reachable).
+
+---
+
+## Load Balancer
+
+The Public Cloud Load Balancer is Octavia. A load balancer hides target failures by design: it
+marks a failing member `ERROR` and stops forwarding to it while the public endpoint keeps
+answering `200`. Checking only the load balancer tells you nothing until every member is down.
+
+Configure two layers of endpoint checks:
+
+| Check | Target | What it tells you |
+|-------|--------|-------------------|
+| Public | `https://app.example.com` | The service is reachable for users. |
+| Per-member | `http://10.0.0.3:8080/health` on each instance | Which backend is down behind a still-green load balancer. |
+
+The per-member checks run over the private network from the maintenant instance, so they need no
+public exposure. Add them from **Endpoints → New endpoint**; see [Endpoint Monitoring](../features/endpoints.md).
+
+Its public address is a floating IP bound to the load balancer's VIP port:
+
+```bash
+openstack loadbalancer show my-lb          # gives vip_port_id
+openstack floating ip create Ext-Net
+openstack floating ip set --port <vip-port-id> <floating-ip>
+```
+
+!!! warning "gRPC needs a TCP listener"
+    Octavia listeners here are `HTTP`, `HTTPS`, `TCP`, `UDP`, `SCTP`, `TERMINATED_HTTPS` and
+    `PROMETHEUS`. There is no gRPC protocol, and HTTP/2 support was closed as not planned. Put
+    maintenant's gRPC listener behind a `TCP` listener with a TCP health check.
+
+Health check thresholds are not published for a standalone load balancer, and the CLI requires you
+to set `--delay`, `--timeout` and `--max-retries` yourself. What OVHcloud does document is what its
+Kubernetes integration uses: a 5 second delay, a 3 second timeout, and 3 failures to take a member
+out. Those are reasonable values to start from when you compare its verdict to maintenant's.
+
+---
+
+## Kubernetes on Managed Kubernetes
+
+```bash
+helm install maintenant ./deploy/helm/maintenant \
+  -n maintenant --create-namespace \
+  --set persistence.storageClass=csi-cinder-high-speed \
+  --set persistence.size=10Gi
+```
+
+`csi-cinder-high-speed` is the cluster default. The other classes are `csi-cinder-classic`,
+`csi-cinder-high-speed-gen2`, their `-luks` encrypted variants, and `csi-cinder-classic-multiattach`.
+
+Three MKS specifics matter here:
+
+- **every provided class is `reclaimPolicy: Delete`.** There is no `-retain` variant, whatever
+  third-party posts claim. To keep the database after a `helm uninstall`, patch the PV once it
+  exists:
+
+  ```bash
+  kubectl patch pv <pv-name> -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'
+  ```
+
+- **`ReadWriteOnce` only.** The Cinder CSI driver never provisions `ReadWriteMany`, which suits
+  maintenant: SQLite takes a single writer and the deployment never scales past one replica. A
+  `ReadWriteMany` claim needs NFS-backed storage, which is not what you want under a database;
+- **a volume is pinned to its availability zone.** A PVC provisioned in one zone is only reachable
+  from nodes in that zone, so the pod follows the volume.
+
+Full RBAC, namespace filtering and Helm values are in the [Kubernetes Guide](kubernetes.md).
+
+---
+
+## Backups and snapshots
+
+A volume snapshot does not require detaching the volume, so it copies the database while it is
+being written to. For SQLite in WAL mode that is a torn copy, not a backup. Take an
+application-level copy first, then snapshot.
+
+```bash
+# On the instance: consistent copy while maintenant keeps running
+docker compose -f /opt/maintenant/compose.yml exec maintenant \
+  sqlite3 /data/maintenant.db ".backup '/data/maintenant.backup.db'"
+
+# Then snapshot the volume, or image the whole instance
+openstack volume snapshot create --volume <volume-id> --force \
+  "maintenant-data-$(date -u +%F)"
+openstack server image create --name "maintenant-$(date -u +%F)" <server-id>
+```
+
+If the image has no `sqlite3` binary, stop the stack for the few seconds the copy takes:
+
+```bash
+docker compose -f /opt/maintenant/compose.yml stop
+cp /mnt/maintenant-data/maintenant/maintenant.db /root/maintenant-$(date -u +%F).db
+docker compose -f /opt/maintenant/compose.yml start
+```
+
+!!! note "Snapshot and Backup are two different products"
+    A **snapshot** works on an attached volume. A **Volume Backup**, which ships the data to Object
+    Storage, requires detaching the volume first, so it means downtime for the monitoring server.
+    OVHcloud also suggests keeping I/O low during the operation and avoiding peak hours, since a
+    snapshot can take a long time.
+
+---
+
+## Related
+
+- [Installation](../getting-started/installation.md) — Docker, Kubernetes and source builds
+- [Hetzner Cloud Deployment](hetzner.md) — The same ground on Hetzner
+- [DigitalOcean Deployment](digitalocean.md) — The same ground on DigitalOcean
+- [Scaleway Deployment](scaleway.md) — The same ground on Scaleway
+- [Vultr Deployment](vultr.md) — The same ground on Vultr
+- [Agent Setup](agent-setup.md) — Enrolling additional hosts over gRPC
+- [Kubernetes Guide](kubernetes.md) — RBAC, Helm values, workload monitoring
+- [PostgreSQL Storage](postgresql.md) — Making the server replaceable
+- [Endpoint Monitoring](../features/endpoints.md) — HTTP/TCP checks behind a load balancer

--- a/docs/guides/scaleway.md
+++ b/docs/guides/scaleway.md
@@ -1,0 +1,329 @@
+# Scaleway Deployment Guide
+
+How to run maintenant on Scaleway: an Instance provisioned with cloud-init, a security group, a Block Storage volume for the database, agents over a Private Network with internal DNS, and Kapsule for the Kubernetes side.
+
+---
+
+## Why it fits a small Instance
+
+maintenant is a single Go binary with the frontend embedded and SQLite as its default store. It idles around 17 MB of RAM and needs no database server, no Prometheus, no Redis. An Instance already running your workload has room for it.
+
+| Type | vCPU / RAM | Arch | Typical fit |
+|------|-----------|------|-------------|
+| `DEV1-S` | 2 / 2 GiB | x86 | One host, a handful of containers and endpoint checks. |
+| `BASIC2-A2C-4G` | 2 / 4 GiB | arm64 | Same, on Ampere. Cheaper per hour than its x86 equivalent. |
+| `PLAY2-NANO` | 2 / 4 GiB | x86 | Central server for a fleet of agents, or a busy update/CVE scan schedule. |
+| `PRO2-XXS` and up | 2 / 8 GiB | x86 | Only once you move the store to PostgreSQL and monitor hundreds of containers. |
+
+The image is published for `linux/amd64` **and** `linux/arm64`, and the `ubuntu_noble` label resolves to the architecture of the Instance type you pick, so the ARM types need no change to any command below. Note that ARM types are Block-only and live in fewer zones than the x86 ones.
+
+!!! note "Check what your account can actually create"
+    Instance types come and go. List them rather than trusting a type name from a guide:
+
+    ```bash
+    scw instance server-type list zone=fr-par-1
+    ```
+
+---
+
+## Step 1 — Create the Instance
+
+The repository ships a ready-to-use cloud-config at [`deploy/cloud-init/maintenant.yaml`](https://github.com/kolapsis/maintenant/blob/main/deploy/cloud-init/maintenant.yaml). It installs Docker from the official repository, writes `/opt/maintenant/compose.yml`, and starts the stack on first boot.
+
+```bash
+# The SSH key belongs to the Project, it is not an argument of server create
+scw iam ssh-key create name=deploy public-key="$(cat ~/.ssh/id_ed25519.pub)"
+
+scw instance server create \
+  zone=fr-par-1 \
+  type=PLAY2-NANO \
+  image=ubuntu_noble \
+  name=maintenant \
+  ip=new \
+  cloud-init=@deploy/cloud-init/maintenant.yaml
+```
+
+Then reach the dashboard, which the cloud-config binds to loopback:
+
+```bash
+ssh -L 8080:127.0.0.1:8080 root@<instance-public-ip>
+```
+
+Open **http://localhost:8080**. Every container on the host is already discovered.
+
+!!! note "Changing the cloud-config later"
+    `cloud-init=@file` is a CLI convenience: it stores the file as a user-data key named
+    `cloud-init`. You can replace it afterwards and reboot:
+
+    ```bash
+    scw instance server update <server-id> cloud-init=@deploy/cloud-init/maintenant.yaml
+    ```
+
+    For a change that does not need a reboot, edit `/opt/maintenant/compose.yml` on the host.
+
+---
+
+## Step 2 — Security group
+
+```bash
+SG=$(scw instance security-group create \
+  name=maintenant \
+  inbound-default-policy=drop \
+  outbound-default-policy=accept \
+  zone=fr-par-1 -o json | jq -r '.id')
+
+# SSH from your address only
+scw instance security-group create-rule security-group-id=$SG \
+  protocol=TCP direction=inbound action=accept \
+  ip-range="$(curl -s https://ipv4.icanhazip.com)/32" dest-port-from=22
+
+# HTTP/HTTPS for the reverse proxy that fronts maintenant
+scw instance security-group create-rule security-group-id=$SG \
+  protocol=TCP direction=inbound action=accept ip-range=0.0.0.0/0 dest-port-from=80
+scw instance security-group create-rule security-group-id=$SG \
+  protocol=TCP direction=inbound action=accept ip-range=0.0.0.0/0 dest-port-from=443
+
+scw instance server update <server-id> security-group-id=$SG
+```
+
+Note what is **not** in that list: port `8080`. Publish the dashboard through a reverse proxy with authentication, never as a raw port on the public IP.
+
+!!! warning "maintenant will flag its own exposure"
+    If you change the Compose file to publish `"8080:8080"`, maintenant's own network security
+    scanner reports a critical **Port exposed on all interfaces** finding for its own container.
+    That is the intended behaviour, not a bug. See the note in
+    [Installation → Docker Compose](../getting-started/installation.md#docker-compose-recommended)
+    and [Configuration → Choosing a Bind Address](../getting-started/configuration.md#choosing-a-bind-address).
+
+!!! important "Security groups only filter public traffic"
+    A security group has no effect on Private Network traffic. What filters that is the VPC's
+    network ACLs, which is where the agent gRPC port belongs.
+
+---
+
+## Step 3 — Put the database on a Block Storage volume
+
+The Instance's local storage goes away with the Instance. A Block Storage volume survives, resizes, and can be snapshotted on its own. Volumes start at 5 GB and come in two flavours: `sbs_5k` (5 000 IOPS) and `sbs_15k`.
+
+```bash
+VOL=$(scw block volume create \
+  name=maintenant-data \
+  perf-iops=5000 \
+  from-empty.size=20GB \
+  zone=fr-par-1 -o json | jq -r '.id')
+
+scw instance server attach-volume \
+  server-id=<server-id> volume-id=$VOL volume-type=sbs_volume
+```
+
+!!! warning "The size unit is mandatory"
+    `from-empty.size=20` is rejected. Write `20GB` or `20G`. And note it is `from-empty.size`,
+    not `size`: volumes moved to the Block Storage API, and the Instances API no longer manages
+    them.
+
+**Scaleway does not format or mount the volume for you.** Do it once, then make it permanent:
+
+```bash
+lsblk                                    # the new volume shows up as /dev/sdb
+mkfs.ext4 /dev/sdb
+mkdir -p /mnt/maintenant-data
+blkid /dev/sdb                           # note the UUID
+echo "UUID=<uuid> /mnt/maintenant-data ext4 defaults,nofail 0 2" >> /etc/fstab
+mount -a
+```
+
+Then point the Compose volume at it:
+
+```yaml
+# /opt/maintenant/compose.yml
+    volumes:
+      - /mnt/maintenant-data/maintenant:/data
+    environment:
+      MAINTENANT_DB: "/data/maintenant.db"
+```
+
+!!! tip "Mount by UUID, not by device name"
+    `/dev/sdb` is the order the kernel happened to enumerate the disks in. Attach a second volume
+    and the names can swap, which is how a database ends up pointed at the wrong filesystem. The
+    `UUID=` line above is what the Scaleway documentation recommends. Scaleway's own CSI driver
+    uses a stable per-volume path, `/dev/disk/by-id/scsi-0SCW_sbs_volume-<volume-uuid>`, if you
+    prefer scripting the mount from the volume id.
+
+!!! warning "Size the volume for migrations, not just for the data"
+    Schema migrations rebuild tables in place and transiently need several times the size of the
+    database. A volume sized to the current database will fail an upgrade. 10 GB is a sane floor.
+
+!!! note "Watching more than one host? Consider PostgreSQL"
+    The server holds the agents' identity and enrolment, the one thing they cannot rebuild on
+    their own. On the default SQLite file, losing that Instance means re-enrolling every host by
+    hand. Pointing the server at a PostgreSQL you already run makes the instance replaceable. See
+    [PostgreSQL storage](postgresql.md).
+
+---
+
+## Monitoring several Instances over a Private Network
+
+A Private Network is where agent traffic belongs: it never leaves Scaleway's network, and Private Network traffic is free.
+
+```bash
+# The Private Network is regional, the NIC that attaches an Instance to it is zonal
+PN=$(scw vpc private-network create name=maintenant region=fr-par -o json | jq -r '.id')
+
+scw instance private-nic create server-id=<server-id> private-network-id=$PN zone=fr-par-1
+scw instance private-nic create server-id=<other-server-id> private-network-id=$PN zone=fr-par-1
+```
+
+Each attached Instance gets a private IP automatically from a `/22` range, and keeps it across reboots.
+
+**And this is where Scaleway saves you a certificate problem.** A Private Network comes with internal DNS: every attached resource resolves as `<hostname>.<private-network-name>.internal`. The Instance named `maintenant` on the network named `maintenant` is reachable at `maintenant.maintenant.internal` from any other Instance on that network, with no configuration.
+
+So the server binds gRPC to its private address and announces the internal name:
+
+```bash
+MAINTENANT_GRPC_LISTEN=<private-ip>:8443
+MAINTENANT_GRPC_URL=grpcs://maintenant.maintenant.internal:8443
+```
+
+Then enrol each other Instance. Generate a token from **Agents → Add host**: the modal hands you a ready-made command. Run it on the host, pointing at the internal name:
+
+```bash
+docker run -d \
+  --name maintenant-agent \
+  --restart unless-stopped \
+  -v /var/run/docker.sock:/var/run/docker.sock:ro \
+  -v /proc:/host/proc:ro \
+  -v maintenant-agent-data:/var/lib/maintenant \
+  ghcr.io/kolapsis/maintenant:latest \
+  --mode=agent \
+  --server=grpcs://maintenant.maintenant.internal:8443 \
+  --enrollment-token=mnt_enr_XXXXXXXXXXXXXXXX
+```
+
+!!! important "Private does not mean plaintext"
+    The internal name keeps the listener off the public internet, but the agent still speaks TLS,
+    and a certificate must cover `maintenant.maintenant.internal`. A DNS-01 ACME certificate
+    works for a name that only resolves privately. Do **not** reach for
+    `--grpc-insecure-skip-tls-verify` outside a lab. The full matrix of TLS modes is in
+    [Agent Setup → Step 1](agent-setup.md#step-1-make-the-grpc-endpoint-reachable).
+
+Three documented traps with internal DNS, all of which look like an agent bug:
+
+- renaming a resource does not update its DNS record until you detach and reattach its NIC;
+- a dot inside a resource name breaks resolution entirely;
+- resolution does not cross VPCs, so agents in another VPC need peering or the public address.
+
+---
+
+## Load Balancer
+
+A Load Balancer hides target failures by design: after 3 failed health checks it marks a backend `Down` and stops forwarding to it, while the public endpoint keeps answering `200`. Checking only the Load Balancer tells you nothing until every backend is down.
+
+Configure two layers of endpoint checks:
+
+| Check | Target | What it tells you |
+|-------|--------|-------------------|
+| Public | `https://app.example.com` | The service is reachable for users. |
+| Per-backend | `http://<private-ip>:8080/health` on each Instance | Which backend is down behind a still-green Load Balancer. |
+
+The per-backend checks run over the Private Network from the maintenant Instance, so they need no public exposure. Add them from **Endpoints → New endpoint**; see [Endpoint Monitoring](../features/endpoints.md).
+
+Its public address comes from:
+
+```bash
+scw lb lb get <lb-id> zone=fr-par-1 -o json | jq -r '.ip[0].ip_address'
+```
+
+Defaults worth knowing when you compare its verdict to maintenant's: a check every 3 seconds with a 1 second timeout, 3 consecutive failures to mark a backend down, and more than two consecutive successes to bring it back.
+
+!!! warning "gRPC needs a TCP frontend, not an HTTP one"
+    The Load Balancer speaks `tcp` and `http` only, and HTTP/2 is supported **only with TLS**, at
+    both ends. Cleartext gRPC (h2c) will not pass through an HTTP frontend. Put maintenant's gRPC
+    listener behind a `tcp` frontend, where the health check is TCP by default, or terminate TLS
+    end to end.
+
+---
+
+## Kubernetes on Kapsule
+
+```bash
+helm install maintenant ./deploy/helm/maintenant \
+  -n maintenant --create-namespace \
+  --set persistence.storageClass=sbs-default \
+  --set persistence.size=10Gi
+```
+
+`sbs-default` is the class the Scaleway CSI driver uses when a PVC names none; `sbs-5k` and `sbs-15k` pin the IOPS tier explicitly.
+
+!!! warning "`scw-bssd` is gone"
+    The old `scw-bssd` class belonged to CSI v0.2, whose support ended in February 2025. A chart
+    or a snippet still naming it will leave the PVC `Pending`.
+
+Two Kapsule specifics:
+
+- volumes are **`ReadWriteOnce` only** (the driver advertises no multi-node access mode), which
+  suits maintenant: SQLite takes a single writer and the deployment never scales past one replica.
+  A `ReadWriteMany` claim needs File Storage, which is not what you want under a database;
+- none of the provided classes uses `reclaimPolicy: Retain`, so deleting the PVC deletes the
+  volume. If you want the database to outlive a `helm uninstall`, declare your own class:
+
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: sbs-retain
+provisioner: csi.scaleway.com
+reclaimPolicy: Retain
+allowVolumeExpansion: true
+```
+
+Size the claim at 5 Gi or more: that is the floor the Block Storage API enforces for the `sbs_5k` and `sbs_15k` tiers.
+
+Full RBAC, namespace filtering and Helm values are in the [Kubernetes Guide](kubernetes.md).
+
+---
+
+## Backups and snapshots
+
+A snapshot copies the volume while the database is being written to. For SQLite in WAL mode that is a torn copy, not a backup. Take an application-level copy first, then snapshot.
+
+```bash
+# On the Instance: consistent copy while maintenant keeps running
+docker compose -f /opt/maintenant/compose.yml exec maintenant \
+  sqlite3 /data/maintenant.db ".backup '/data/maintenant.backup.db'"
+
+# Then snapshot the volume, or image the whole Instance
+scw block snapshot create volume-id=<volume-id> \
+  name="maintenant-data-$(date -u +%F)" zone=fr-par-1 -w
+scw instance server backup <server-id> name="maintenant-$(date -u +%F)" zone=fr-par-1
+```
+
+If the image has no `sqlite3` binary, stop the stack for the few seconds the copy takes:
+
+```bash
+docker compose -f /opt/maintenant/compose.yml stop
+cp /mnt/maintenant-data/maintenant/maintenant.db /root/maintenant-$(date -u +%F).db
+docker compose -f /opt/maintenant/compose.yml start
+```
+
+!!! note "`scw instance snapshot create` no longer works"
+    Snapshots moved to the Block Storage API. The old Instances command is deprecated and does
+    nothing, though it still appears in some CLI help output. Use `scw block snapshot create`.
+
+!!! tip "Where to put the copy"
+    Object Storage in the same region is the cheapest off-Instance destination. A volume snapshot
+    can also be exported there as QCOW2 with
+    `scw block snapshot export-to-object-storage`.
+
+---
+
+## Related
+
+- [Installation](../getting-started/installation.md) — Docker, Kubernetes and source builds
+- [Hetzner Cloud Deployment](hetzner.md) — The same ground on Hetzner
+- [DigitalOcean Deployment](digitalocean.md) — The same ground on DigitalOcean
+- [OVHcloud Deployment](ovhcloud.md) — The same ground on OVHcloud
+- [Vultr Deployment](vultr.md) — The same ground on Vultr
+- [Agent Setup](agent-setup.md) — Enrolling additional hosts over gRPC
+- [Kubernetes Guide](kubernetes.md) — RBAC, Helm values, workload monitoring
+- [PostgreSQL Storage](postgresql.md) — Making the server replaceable
+- [Endpoint Monitoring](../features/endpoints.md) — HTTP/TCP checks behind a Load Balancer

--- a/docs/guides/vultr.md
+++ b/docs/guides/vultr.md
@@ -1,0 +1,362 @@
+# Vultr Deployment Guide
+
+How to run maintenant on Vultr: an instance provisioned with cloud-init, a firewall group, a Block Storage volume for the database, agents over a VPC, and VKE for the Kubernetes side.
+
+---
+
+## Why it fits a small instance
+
+maintenant is a single Go binary with the frontend embedded and SQLite as its default store. It idles around 17 MB of RAM and needs no database server, no Prometheus, no Redis.
+
+| Plan | vCPU / RAM | $/month | Typical fit |
+|------|-----------|---------|-------------|
+| `vc2-1c-2gb` | 1 / 2 GB | 10 | One host, a handful of containers and endpoint checks. |
+| `vc2-2c-4gb` | 2 / 4 GB | 20 | Central server for a fleet of agents, or a busy update/CVE scan schedule. |
+| `vhf-2c-4gb` | 2 / 4 GB | 24 | Same, on high-frequency cores. |
+
+!!! warning "No ARM instances on Vultr"
+    maintenant publishes `linux/arm64` images, and the Hetzner and Scaleway guides use them to cut
+    costs. Vultr has nothing to run them on: every OS image in the catalogue is `x64`, and no
+    compute plan reports an Ampere CPU. Only the amd64 half of the image is usable here, on
+    instances and on VKE node pools alike.
+
+---
+
+## Step 1 — Create the instance
+
+The repository ships a ready-to-use cloud-config at [`deploy/cloud-init/maintenant.yaml`](https://github.com/kolapsis/maintenant/blob/main/deploy/cloud-init/maintenant.yaml). It installs Docker from the official repository, writes `/opt/maintenant/compose.yml`, and starts the stack on first boot.
+
+Find the OS id first. Vultr's own examples all use `1743`, which is Ubuntu **22.04**:
+
+```bash
+vultr-cli os list | grep -i "24.04"     # Ubuntu 24.04 LTS x64 is 2284
+```
+
+```bash
+vultr-cli instance create \
+  --region="ewr" \
+  --plan="vc2-2c-4gb" \
+  --os=2284 \
+  --label="maintenant" \
+  --host="maintenant" \
+  --ssh-keys="<sshkey-uuid>" \
+  --vpc-ids="<vpc-uuid>" \
+  --firewall-group="<firewall-group-uuid>" \
+  --userdata-file=deploy/cloud-init/maintenant.yaml
+```
+
+Then reach the dashboard, which the cloud-config binds to loopback:
+
+```bash
+ssh -L 8080:127.0.0.1:8080 root@<instance-ip>
+```
+
+Open **http://localhost:8080**. Every container on the host is already discovered.
+
+Three details that cost time if you get them wrong:
+
+!!! warning "Do not base64-encode the user data yourself"
+    The API expects base64, but `vultr-cli` encodes it for you. Encoding it yourself produces a
+    double-encoded blob, and cloud-init then does nothing at all, silently. Pass the plain file
+    with `--userdata-file`, or plain text with `-u`. The two flags are mutually exclusive.
+
+!!! warning "`-o` is not short for `--os`"
+    `--os` takes an integer and has no short form. `-o` is the global `--output` flag. The
+    abbreviated example shipped in the CLI's own help (`-o=1743`) is wrong and will not select an
+    operating system.
+
+!!! note "The flag is `--firewall-group` here"
+    At creation the flag is `--firewall-group`. `--firewall-group-id` exists only on
+    `vultr-cli instance update-firewall-group`, which is how you attach one afterwards.
+
+---
+
+## Step 2 — Firewall group
+
+```bash
+FW=$(vultr-cli firewall group create --description="maintenant" -o json | jq -r '.firewall_group.id')
+
+# SSH from your address only
+vultr-cli firewall rule create $FW \
+  --ip-type=v4 --protocol=tcp --subnet="$(curl -s https://ipv4.icanhazip.com)" --size=32 \
+  --port=22 --notes="ssh"
+
+# HTTP/HTTPS for the reverse proxy that fronts maintenant
+vultr-cli firewall rule create $FW \
+  --ip-type=v4 --protocol=tcp --subnet=0.0.0.0 --size=0 --port=80 --notes="http"
+vultr-cli firewall rule create $FW \
+  --ip-type=v4 --protocol=tcp --subnet=0.0.0.0 --size=0 --port=443 --notes="https"
+```
+
+The group id is a **positional argument**, not a flag: the `--id=` form in the CLI's shipped
+example does not exist. `--subnet` and `--size` are the network and its prefix length, split
+across two arguments rather than written as CIDR.
+
+Note what is **not** in that list: port `8080`. Publish the dashboard through a reverse proxy with authentication, never as a raw port on the public IP.
+
+!!! warning "maintenant will flag its own exposure"
+    If you change the Compose file to publish `"8080:8080"`, maintenant's own network security
+    scanner reports a critical **Port exposed on all interfaces** finding for its own container.
+    That is the intended behaviour, not a bug. See the note in
+    [Installation → Docker Compose](../getting-started/installation.md#docker-compose-recommended)
+    and [Configuration → Choosing a Bind Address](../getting-started/configuration.md#choosing-a-bind-address).
+
+To attach the group to an existing instance:
+
+```bash
+vultr-cli instance update-firewall-group <instance-id> -f $FW
+```
+
+---
+
+## Step 3 — Put the database on a Block Storage volume
+
+The instance's disk goes away with the instance. A Block Storage volume survives, resizes, and
+can be cloned from a snapshot.
+
+**Check the region first.** Block Storage is not available everywhere, and NVMe is available in
+far fewer regions than HDD:
+
+```bash
+curl -s "https://api.vultr.com/v2/regions?per_page=500" | \
+  jq -r '.regions[] | select(.options | index("block_storage_high_perf")) | .id'
+```
+
+Then create and attach:
+
+```bash
+vultr-cli block-storage create \
+  --region="ewr" --size=20 --label="maintenant-data" --block-type="high_perf"
+
+vultr-cli block-storage attach <block-id> --instance=<instance-id> --live
+```
+
+!!! warning "Without `--live`, the instance reboots"
+    Both `attach` and `detach` restart the instance unless you pass `--live`. On a monitoring
+    server that reboot is a gap in your own history.
+
+Minimum sizes are **10 GB for NVMe** (`high_perf`) and **40 GB for HDD** (`storage_opt`), at
+$0.10 and $0.025 per GB per month. Vultr's Block Storage FAQ still says 1 GB for NVMe; that figure
+is out of date and the API rejects it.
+
+**Vultr formats and mounts nothing.** The first volume appears as `/dev/vdb`:
+
+```bash
+lsblk
+mkfs.ext4 /dev/vdb
+mkdir -p /mnt/maintenant-data
+blkid /dev/vdb                           # note the UUID
+echo "UUID=<uuid> /mnt/maintenant-data ext4 defaults,nofail 0 2" >> /etc/fstab
+mount -a
+```
+
+Then point the Compose volume at it:
+
+```yaml
+# /opt/maintenant/compose.yml
+    volumes:
+      - /mnt/maintenant-data/maintenant:/data
+    environment:
+      MAINTENANT_DB: "/data/maintenant.db"
+```
+
+!!! tip "Mount by UUID, not by device name"
+    `/dev/vdb` is the order the kernel happened to enumerate the disks in. Attach a second volume
+    and the names can swap, which is how a database ends up pointed at the wrong filesystem.
+    Vultr's own CSI driver uses a stable per-volume path instead,
+    `/dev/disk/by-id/virtio-<mount-id>`, where the mount id is the `MOUNT ID` field of
+    `vultr-cli block-storage get`. Either is fine; the bare device name is not.
+
+!!! warning "Size the volume for migrations, not just for the data"
+    Schema migrations rebuild tables in place and transiently need several times the size of the
+    database. A volume sized to the current database will fail an upgrade. The 10 GB NVMe floor
+    already covers this.
+
+!!! note "Watching more than one host? Consider PostgreSQL"
+    The server holds the agents' identity and enrolment, the one thing they cannot rebuild on
+    their own. On the default SQLite file, losing that instance means re-enrolling every host by
+    hand. Pointing the server at a PostgreSQL you already run makes the instance replaceable. See
+    [PostgreSQL storage](postgresql.md).
+
+---
+
+## Monitoring several instances over a VPC
+
+```bash
+vultr-cli vpc create --region="ewr" --description="maintenant" \
+  --subnet="10.200.0.0" --size=24
+```
+
+VPC ranges are RFC1918 only, and you get five VPC networks per location.
+
+!!! warning "Attach the VPC at creation, or configure the interface by hand"
+    This is the one Vultr detail that will cost you an afternoon. On Linux, cloud-init configures
+    the private adapter **only if the VPC is attached while the instance is being deployed**. Pass
+    `--vpc-ids` to `instance create`. Attaching a VPC afterwards with `instance vpc attach` leaves
+    the interface unconfigured until you write the netplan yourself, and the instance simply has no
+    private address in the meantime.
+
+    On Windows and BSD the private adapter is manual even at deployment. On Fedora CoreOS the
+    network configuration comes from ignition and cannot be changed after deployment.
+
+Vultr documents no internal DNS for VPC networks, so address the server by its private IP (the
+`internal_ip` field of the instance) or by a name you maintain yourself. Whichever you choose, it
+has to match the certificate the server presents.
+
+Bind the gRPC listener to the private address:
+
+```bash
+MAINTENANT_GRPC_LISTEN=10.200.0.2:8443
+MAINTENANT_GRPC_URL=grpcs://maintenant.internal.example.com:8443
+```
+
+Open the port to the VPC range only:
+
+```bash
+vultr-cli firewall rule create $FW \
+  --ip-type=v4 --protocol=tcp --subnet=10.200.0.0 --size=24 --port=8443 \
+  --notes="agent gRPC"
+```
+
+Then enrol each other instance. Generate a token from **Agents → Add host**: the modal hands you a
+ready-made command. Run it on the host, pointing at the private address:
+
+```bash
+docker run -d \
+  --name maintenant-agent \
+  --restart unless-stopped \
+  -v /var/run/docker.sock:/var/run/docker.sock:ro \
+  -v /proc:/host/proc:ro \
+  -v maintenant-agent-data:/var/lib/maintenant \
+  ghcr.io/kolapsis/maintenant:latest \
+  --mode=agent \
+  --server=grpcs://maintenant.internal.example.com:8443 \
+  --enrollment-token=mnt_enr_XXXXXXXXXXXXXXXX
+```
+
+!!! important "Private does not mean plaintext"
+    Binding on the VPC address keeps the listener off the public internet, but the agent still
+    speaks TLS. Use a certificate that covers the name you gave the server; a DNS-01 ACME
+    certificate works for a name that only resolves privately. Do **not** reach for
+    `--grpc-insecure-skip-tls-verify` outside a lab. The full matrix of TLS modes is in
+    [Agent Setup → Step 1](agent-setup.md#step-1-make-the-grpc-endpoint-reachable).
+
+---
+
+## Load Balancer
+
+A load balancer hides target failures by design: it stops forwarding to a backend that fails its health checks while the public endpoint keeps answering `200`. Checking only the load balancer tells you nothing until every backend is down.
+
+Configure two layers of endpoint checks:
+
+| Check | Target | What it tells you |
+|-------|--------|-------------------|
+| Public | `https://app.example.com` | The service is reachable for users. |
+| Per-backend | `http://10.200.0.3:8080/health` on each instance | Which backend is down behind a still-green load balancer. |
+
+The per-backend checks run over the VPC from the maintenant instance, so they need no public
+exposure. Add them from **Endpoints → New endpoint**; see [Endpoint Monitoring](../features/endpoints.md).
+
+Its public address comes from:
+
+```bash
+vultr-cli load-balancer get <lb-id> -o json | jq -r '.load_balancer.ipv4'
+```
+
+!!! warning "The CLI's health check defaults are not the platform's"
+    Vultr's platform defaults are a 15 second interval, a 5 second response timeout, and 5
+    consecutive failures to take a backend out: roughly 75 seconds. `vultr-cli` sends **15** for
+    the timeout and both thresholds instead, which pushes the same removal to about **225
+    seconds**, with nothing in the output to say so. If you create the load balancer from the CLI,
+    set `--response-timeout`, `--unhealthy-threshold` and `--healthy-threshold` explicitly rather
+    than inheriting that.
+
+!!! warning "gRPC needs TCP forwarding"
+    Forwarding rules are HTTP, HTTPS and TCP, and nothing in Vultr's documentation mentions gRPC.
+    HTTP/2 and HTTP/3 exist but are client-side only and require an active HTTPS rule, so they
+    buy nothing for a gRPC backend. Use a TCP forwarding rule with a TCP health check and
+    terminate TLS on your own backend. Note also the cap of 15 forwarding rules per load balancer.
+
+---
+
+## Kubernetes on VKE
+
+```bash
+helm install maintenant ./deploy/helm/maintenant \
+  -n maintenant --create-namespace \
+  --set persistence.storageClass=vultr-block-storage-retain \
+  --set persistence.size=10Gi
+```
+
+The Vultr CSI driver ships six storage classes: `vultr-block-storage` and
+`vultr-block-storage-hdd`, their `-retain` variants, and two `vultr-vfs-storage` classes. Unlike
+most providers here, a `Retain` variant exists out of the box, which is what you want under a
+database you would rather not lose to a `helm uninstall`.
+
+!!! danger "Never put SQLite on `vultr-vfs-storage`"
+    The VFS classes are the only `ReadWriteMany` ones. SQLite on a shared filesystem corrupts:
+    its locking assumes a single writer on a local filesystem. Use a block class, which is
+    `ReadWriteOnce`, and matches maintenant's single-replica deployment anyway.
+
+!!! warning "Claim at least 10Gi, or the PVC hangs"
+    The block minimums are 10 GB for NVMe and 40 GB for HDD. The CSI driver passes a smaller
+    request straight through to the API without clamping it, so a `1Gi` claim is rejected and the
+    PVC sits in `Pending` with the reason visible only in `kubectl describe pvc`. A `500Mi` claim
+    becomes a size of zero.
+
+Always name `storageClassName` explicitly, as above: which class is the cluster default is not
+something Vultr documents in a form worth relying on, and none of the classes in the self-managed
+manifest carries the default annotation at all.
+
+!!! note "If you expose maintenant with a `LoadBalancer` Service"
+    VKE's cloud controller defaults to a TCP protocol and a TCP health check, which is right for
+    gRPC. Setting the `healthcheck-path` annotation silently switches the check to HTTP and breaks
+    a gRPC backend, so leave it unset. And do not edit a load balancer created by the controller
+    by hand; it will be reconciled away.
+
+Full RBAC, namespace filtering and Helm values are in the [Kubernetes Guide](kubernetes.md).
+
+---
+
+## Backups and snapshots
+
+Vultr snapshots a running instance without stopping it, and says plainly what that means: booting
+from one is like rebooting after a non-graceful restart. For SQLite in WAL mode that is a
+crash-consistent copy, not a backup. Take an application-level copy first.
+
+```bash
+# On the instance: consistent copy while maintenant keeps running
+docker compose -f /opt/maintenant/compose.yml exec maintenant \
+  sqlite3 /data/maintenant.db ".backup '/data/maintenant.backup.db'"
+
+# Then snapshot the instance
+vultr-cli snapshot create -i <instance-id> -d "maintenant $(date -u +%F)"
+```
+
+If the image has no `sqlite3` binary, stop the stack for the few seconds the copy takes:
+
+```bash
+docker compose -f /opt/maintenant/compose.yml stop
+cp /mnt/maintenant-data/maintenant/maintenant.db /root/maintenant-$(date -u +%F).db
+docker compose -f /opt/maintenant/compose.yml start
+```
+
+!!! note "Block Storage snapshots exist, but not in the CLI"
+    The API can snapshot a Block Storage volume and clone a volume from a snapshot, and the CLI
+    can consume one through `block-storage create --snapshot-id`. It cannot create one: there is
+    no `block-storage snapshot` subcommand. Use the API directly if you want volume-level
+    snapshots on a schedule.
+
+---
+
+## Related
+
+- [Installation](../getting-started/installation.md) — Docker, Kubernetes and source builds
+- [Hetzner Cloud Deployment](hetzner.md) — The same ground on Hetzner
+- [DigitalOcean Deployment](digitalocean.md) — The same ground on DigitalOcean
+- [Scaleway Deployment](scaleway.md) — The same ground on Scaleway
+- [OVHcloud Deployment](ovhcloud.md) — The same ground on OVHcloud
+- [Agent Setup](agent-setup.md) — Enrolling additional hosts over gRPC
+- [Kubernetes Guide](kubernetes.md) — RBAC, Helm values, workload monitoring
+- [PostgreSQL Storage](postgresql.md) — Making the server replaceable
+- [Endpoint Monitoring](../features/endpoints.md) — HTTP/TCP checks behind a load balancer

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -90,6 +90,9 @@ nav:
       - Kubernetes Guide: guides/kubernetes.md
       - Hetzner Cloud Deployment: guides/hetzner.md
       - DigitalOcean Deployment: guides/digitalocean.md
+      - Scaleway Deployment: guides/scaleway.md
+      - OVHcloud Deployment: guides/ovhcloud.md
+      - Vultr Deployment: guides/vultr.md
       - Docker Swarm Deployment: guides/swarm.md
       - PostgreSQL Storage: guides/postgresql.md
   - API:


### PR DESCRIPTION
Three more providers get the same treatment as Hetzner and DigitalOcean: instance creation from the shared cloud-init file, firewall rules, a block volume for the database, agent enrolment over a private network, load balancer health checks and managed Kubernetes.

Commands come from each provider CLI reference and CSI driver rather than the product pages, which are wrong in places.

The existing pages are wired up to match: the provider lists in the cloud-init README and the installation page, the storage-class table and Related sections in the Kubernetes guide, and the cloud sentence in the README.