### PR TITLE
fix(quotas): count only standalone endpoints against the cap

### DIFF
--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -203,7 +203,7 @@ Maintenant comes in three editions, in order: **Community**, **Personal**, **Pro
 
 | Edition | Price | Unlocks |
 |---------|-------|---------|
-| Community | Free | Containers, endpoints, heartbeats, certificates, the public status page, and the full Swarm and Kubernetes views, with 7 days of resource history. Capped at 10 endpoints, 5 heartbeats, 5 certificate monitors and 3 status components, on a single host. |
+| Community | Free | Containers, endpoints, heartbeats, certificates, the public status page, and the full Swarm and Kubernetes views, with 7 days of resource history. Capped at 10 endpoints, 5 heartbeats, 5 certificate monitors and 3 status components created by hand (endpoints and certificate monitors discovered from container labels are unlimited), on a single host. |
 | Personal | €149 once, for life | Every cap lifted, up to 20 remote hosts, plus email and Telegram alerts, CVE enrichment, risk scoring, security posture, incidents, changelog, 30 days of resource history, advanced trigger filters and OCSP stapling. Covers one person on infrastructure they own or run for themselves, freelancers included. |
 | Pro | €29/month or €290/year | Everything above with unlimited hosts, plus Slack and Teams, escalation policies, per-entity routing, maintenance windows, status page subscribers and branding, 90 days of resource history, and the right to use Maintenant on behalf of others, with support. |
 

--- a/docs/guides/docker-labels.md
+++ b/docs/guides/docker-labels.md
@@ -91,6 +91,8 @@ labels:
 
 Global config labels (without an index) apply as defaults to all indexed endpoints. Indexed config overrides global config.
 
+The number of endpoints declared by labels is not capped in any edition: the Community cap of 10 endpoints only counts the ones you add by hand from the interface.
+
 ---
 
 ## Certificate Monitoring

--- a/internal/api/v1/router.go
+++ b/internal/api/v1/router.go
@@ -869,8 +869,9 @@ func (r *Router) computeQuotas(ctx context.Context, d HandlerDeps) map[string]in
 		}
 	}
 
+	// Endpoints: standalone only, like certificates.
 	if d.Endpoints != nil {
-		used, err := d.Endpoints.CountActiveEndpoints(ctx)
+		used, err := d.Endpoints.CountStandaloneEndpoints(ctx)
 		if err != nil {
 			r.logger.Error("failed to count endpoints for quota", "error", err)
 			used = 0

--- a/internal/endpoint/service.go
+++ b/internal/endpoint/service.go
@@ -553,9 +553,9 @@ func (s *Service) ListEndpoints(ctx context.Context, opts ListEndpointsOpts) ([]
 	return s.store.ListEndpoints(ctx, opts)
 }
 
-// CountActiveEndpoints returns the count of all active endpoints (both standalone and label-discovered).
-func (s *Service) CountActiveEndpoints(ctx context.Context) (int, error) {
-	return s.store.CountActiveEndpoints(ctx)
+// CountStandaloneEndpoints returns the number of active manually-created endpoints.
+func (s *Service) CountStandaloneEndpoints(ctx context.Context) (int, error) {
+	return s.store.CountStandaloneEndpoints(ctx)
 }
 
 // GetEndpoint retrieves an endpoint by ID.
@@ -593,7 +593,7 @@ func (s *Service) CalculateUptime(ctx context.Context, endpointID string) map[st
 
 // CreateStandalone creates a manually-defined endpoint and starts monitoring it.
 func (s *Service) CreateStandalone(ctx context.Context, name, target string, epType EndpointType, config EndpointConfig) (*Endpoint, error) {
-	count, err := s.store.CountActiveEndpoints(ctx)
+	count, err := s.store.CountStandaloneEndpoints(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("count endpoints: %w", err)
 	}

--- a/internal/endpoint/service_test.go
+++ b/internal/endpoint/service_test.go
@@ -72,6 +72,9 @@ func (m *memStore) UpsertEndpoint(_ context.Context, e *Endpoint) (string, error
 
 	ec := m.cloneEp(e)
 	ec.Active = true
+	if ec.Source == "" {
+		ec.Source = SourceLabel
+	}
 	m.endpoints[id] = ec
 	return id, nil
 }
@@ -140,12 +143,12 @@ func (m *memStore) ListEndpointsByExternalID(_ context.Context, externalID strin
 	return out, nil
 }
 
-func (m *memStore) CountActiveEndpoints(_ context.Context) (int, error) {
+func (m *memStore) CountStandaloneEndpoints(_ context.Context) (int, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	count := 0
 	for _, ep := range m.endpoints {
-		if ep.Active {
+		if ep.Active && ep.Source == SourceStandalone {
 			count++
 		}
 	}
@@ -730,9 +733,51 @@ func TestService_CreateStandalone_QuotaEnforced(t *testing.T) {
 	assert.Nil(t, ep3)
 
 	// Verify count
-	count, err := store.CountActiveEndpoints(ctx)
+	count, err := store.CountStandaloneEndpoints(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, 2, count)
+}
+
+// Label-declared endpoints are outside the standalone cap: an operator running
+// a dozen of them must still be able to add one by hand.
+func TestService_CreateStandalone_LabelEndpointsDoNotConsumeQuota(t *testing.T) {
+	store := newMemStore()
+	svc := NewService(Deps{
+		Store:          store,
+		Engine:         noopEngine(),
+		Logger:         noopLogger(),
+		LicenseChecker: &DefaultLicenseChecker{MaxEndpoints: 2},
+	})
+	ctx := context.Background()
+
+	labels := map[string]string{}
+	for i := 1; i <= 5; i++ {
+		labels[fmt.Sprintf("maintenant.endpoint.%d.http", i)] = fmt.Sprintf("http://svc:80%d/health", i)
+	}
+	svc.SyncEndpoints(ctx, "web", "container-1", labels, "", "")
+
+	all, err := store.ListEndpoints(ctx, ListEndpointsOpts{})
+	require.NoError(t, err)
+	require.Len(t, all, 5)
+
+	count, err := store.CountStandaloneEndpoints(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 0, count, "label endpoints must not count against the cap")
+
+	ep1, err := svc.CreateStandalone(ctx, "ep1", "http://example.com", TypeHTTP, DefaultConfig())
+	require.NoError(t, err)
+	require.NotNil(t, ep1)
+
+	ep2, err := svc.CreateStandalone(ctx, "ep2", "http://example.org", TypeHTTP, DefaultConfig())
+	require.NoError(t, err)
+	require.NotNil(t, ep2)
+
+	_, err = svc.CreateStandalone(ctx, "ep3", "http://example.net", TypeHTTP, DefaultConfig())
+	require.ErrorIs(t, err, ErrLimitReached)
+
+	count, err = store.CountStandaloneEndpoints(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 2, count, "the reported usage never exceeds the cap")
 }
 
 // TestDefaultLicenseChecker_Unlimited: extension.Limit reports -1 for an

--- a/internal/endpoint/store.go
+++ b/internal/endpoint/store.go
@@ -25,7 +25,7 @@ type EndpointStore interface {
 	GetEndpointByID(ctx context.Context, id string) (*Endpoint, error)
 	ListEndpoints(ctx context.Context, opts ListEndpointsOpts) ([]*Endpoint, error)
 	ListEndpointsByExternalID(ctx context.Context, externalID string) ([]*Endpoint, error)
-	CountActiveEndpoints(ctx context.Context) (int, error)
+	CountStandaloneEndpoints(ctx context.Context) (int, error)
 	DeactivateEndpoint(ctx context.Context, id string) error
 	DeleteEndpoint(ctx context.Context, id string) error
 

--- a/internal/extension/quota.go
+++ b/internal/extension/quota.go
@@ -29,6 +29,9 @@ const Unlimited = -1
 // declaration of the caps: the value that refuses a creation and the value the
 // interface displays both come from here, so they cannot drift apart.
 //
+// endpoints and certificates count only what an operator created by hand;
+// entries discovered from container labels are never capped nor counted.
+//
 // agent_hosts is 0 on Community by design — the multihost capability itself is
 // Personal, so the REST routes refuse before any count happens. The 0 still
 // matters: it is what the gRPC enrollment barrier reads, and it has no

--- a/internal/store/endpoints.go
+++ b/internal/store/endpoints.go
@@ -174,11 +174,12 @@ func (s *EndpointStore) ListEndpointsByExternalID(ctx context.Context, externalI
 	return endpoints, rows.Err()
 }
 
-func (s *EndpointStore) CountActiveEndpoints(ctx context.Context) (int, error) {
+func (s *EndpointStore) CountStandaloneEndpoints(ctx context.Context) (int, error) {
 	var count int
-	err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM endpoints WHERE active=1`).Scan(&count)
+	err := s.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM endpoints WHERE active=1 AND source='standalone'`).Scan(&count)
 	if err != nil {
-		return 0, fmt.Errorf("count active endpoints: %w", err)
+		return 0, fmt.Errorf("count standalone endpoints: %w", err)
 	}
 	return count, nil
 }

--- a/internal/store/endpoints_count_test.go
+++ b/internal/store/endpoints_count_test.go
@@ -1,0 +1,64 @@
+// Copyright 2026 Benjamin Touchard (Kolapsis)
+//
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+// or a commercial license. You may not use this file except in compliance
+// with one of these licenses.
+//
+// AGPL-3.0: https://www.gnu.org/licenses/agpl-3.0.html
+// Commercial: See COMMERCIAL-LICENSE.md
+//
+// Source: https://github.com/kolapsis/maintenant
+
+package store
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/kolapsis/maintenant/internal/endpoint"
+	"github.com/stretchr/testify/require"
+)
+
+// The Community cap applies to what an operator adds by hand, so the count
+// behind it ignores label-discovered endpoints, however many a host declares.
+func TestCountStandaloneEndpoints_IgnoresLabelEndpoints(t *testing.T) {
+	db := openTestDB(t)
+	s := NewEndpointStore(db)
+	ctx := context.Background()
+
+	for i := 1; i <= 12; i++ {
+		_, err := s.UpsertEndpoint(ctx, &endpoint.Endpoint{
+			ContainerName: "web",
+			LabelKey:      fmt.Sprintf("endpoint.%d.http", i),
+			ExternalID:    "container-1",
+			EndpointType:  endpoint.TypeHTTP,
+			Target:        fmt.Sprintf("http://svc:80%d/health", i),
+		})
+		require.NoError(t, err)
+	}
+
+	count, err := s.CountStandaloneEndpoints(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 0, count)
+
+	var standaloneIDs []string
+	for i := 1; i <= 3; i++ {
+		id, err := s.InsertStandaloneEndpoint(ctx, &endpoint.Endpoint{
+			Name:         fmt.Sprintf("manual %d", i),
+			EndpointType: endpoint.TypeHTTP,
+			Target:       fmt.Sprintf("https://example.com/%d", i),
+		})
+		require.NoError(t, err)
+		standaloneIDs = append(standaloneIDs, id)
+	}
+
+	count, err = s.CountStandaloneEndpoints(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 3, count)
+
+	require.NoError(t, s.DeactivateEndpoint(ctx, standaloneIDs[0]))
+	count, err = s.CountStandaloneEndpoints(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 2, count, "a deactivated endpoint frees its slot")
+}


### PR DESCRIPTION
Endpoints declared through container labels never went through `CanCreateEndpoint`, yet they were counted by the quota. A host declaring ten endpoints by labels exhausted the Community cap, the interface refused every manual creation, and `/quotas` reported a usage above the limit while labels kept creating more.

The cap now counts standalone endpoints only, the way certificate monitors already work: label-discovered entries are neither capped nor counted, in any edition. The count behind the refusal and the count exposed by the API are the same one, so the reported usage can no longer exceed the limit.

Indexed labels (`maintenant.endpoint.N.http|tcp`) stay unbounded: capping them would break existing installs.

Docs updated to state that the caps apply to what an operator adds by hand.