### PR TITLE
feat(mcp): expose notification channels and the running edition

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,11 @@ MAINTENANT_DB=./maintenant.db
 # Update intelligence scan interval (Go duration, default: 24h)
 # MAINTENANT_UPDATE_INTERVAL=24h
 
+# Raise an alert when a container has been stopped for this long (Go duration,
+# e.g. 5m). Unset or 0 disables the check; a container that exited with code 0
+# counts as finished, not down. The alert resolves on its own once it runs again.
+# MAINTENANT_CONTAINER_DOWN_AFTER=5m
+
 # How long raw resource samples are kept (Go duration, default: 48h).
 # The 24h chart is the longest range reading them — 7d is served from the hourly
 # rollup — so 24h is the floor. Raw samples dominate database size.

--- a/cmd/maintenant/main.go
+++ b/cmd/maintenant/main.go
@@ -116,6 +116,13 @@ func main() {
 		os.Exit(1)
 	}
 
+	// A threshold that does not parse must stop startup: falling back to "off"
+	// would leave the operator believing the check runs.
+	if err := cfg.ValidateAlerting(); err != nil {
+		logger.Error("invalid alerting configuration", "error", err)
+		os.Exit(1)
+	}
+
 	// --copy-store-to runs the copy and exits, like --mcp-stdio: the binary has
 	// no subcommands and this feature does not introduce any.
 	if target := visited["copy-store-to"]; target != "" {

--- a/docs/features/alerts.md
+++ b/docs/features/alerts.md
@@ -10,13 +10,19 @@ maintenant generates alerts from every monitoring subsystem:
 
 | Source | Events | Default Severity |
 |--------|--------|------------------|
-| **Container** | `restart_loop`, `health_unhealthy` | Warning |
+| **Container** | `restart_loop`, `health_unhealthy`, `container_down` | Warning |
 | **Endpoint** | `consecutive_failure` | Critical |
 | **Heartbeat** | `deadline_missed`, `exit_code_failure` | Critical |
 | **Certificate** | `expiring`, `expired`, `chain_invalid` | Critical |
 | **Resource** | `cpu_threshold`, `memory_threshold` | Warning |
 | **Update** | `available` | Info |
 | **Agent** | `disconnected` | Warning |
+
+### Container down
+
+A container that stops and stays stopped raises no alert on its own: `restart_loop` needs it to come back, and `health_unhealthy` needs a `HEALTHCHECK`. Set `MAINTENANT_CONTAINER_DOWN_AFTER` to a Go duration (`5m`, `30s`, `1h`) and `container_down` fires once a container has been in `exited` or `dead` for that long, at the severity configured on the container. It resolves on its own when the container runs again.
+
+The threshold is unset by default, because switching it on alerts retroactively on every container already stopped. A container that exited with code 0 is recorded as `completed` and never counts as down, so a finished job stays quiet. The sweep runs every 30 seconds, which is the alert's resolution, not its threshold.
 
 An agent alert fires when a remote agent stops reporting, whether its stream dropped or it never came back after a restart, and resolves on reconnection. Revoking or deleting an agent clears it instead of raising one.
 
@@ -180,7 +186,7 @@ Trigger CRUD endpoints :
 | `PUT` | `/api/v1/alert-triggers/{id}` |
 | `DELETE` | `/api/v1/alert-triggers/{id}` |
 
-Triggers can also be managed via MCP tools: `list_triggers`, `get_trigger`, `create_trigger`, `update_trigger`, `delete_trigger`.
+Triggers can also be managed via MCP tools: `list_triggers`, `get_trigger`, `create_trigger`, `update_trigger`, `delete_trigger`. Channels have the matching set: `list_channels`, `get_channel`, `create_channel`, `update_channel`, `delete_channel`, `test_channel`.
 
 > **Migration note**: previous versions used `routing_rules` attached to channels. On upgrade, those rules are auto-converted to AlertTriggers (one trigger per rule). Channels without any rule receive a generated `Default — all alerts → {channel name}` trigger to preserve the legacy broadcast behavior. The legacy `/api/v1/channels/{id}/rules*` endpoints have been removed.
 

--- a/docs/features/mcp.md
+++ b/docs/features/mcp.md
@@ -167,6 +167,7 @@ only in the web UI.
 | `get_updates` | Available image updates for monitored containers | Community |
 | `get_health` | maintenant version, runtime, and status | Community |
 | `list_agents` | Registered remote agents with connection state and runtime | Personal |
+| `get_edition` | Running edition, which capability each edition opens, quota usage and history windows | Community |
 
 ### Security & supply chain (read)
 
@@ -199,6 +200,9 @@ only in the web UI.
 
 | Tool | Description | Edition |
 |------|-------------|---------|
+| `list_channels` / `get_channel` | List or fetch notification channels; secrets are never returned | Community |
+| `create_channel` / `update_channel` / `delete_channel` | Manage notification channels (webhook is Community; email and Telegram need Personal, Slack and Teams need Pro) | Community |
+| `test_channel` | Send a test notification through a channel | Community |
 | `list_triggers` / `get_trigger` | List or fetch alert triggers (entity → channel routing) | Community |
 | `create_trigger` / `update_trigger` / `delete_trigger` | Manage alert triggers (scope/tag filters require Personal) | Community |
 | `list_escalation_policies` / `get_escalation_policy` | List or fetch escalation policies | Pro |
@@ -228,6 +232,7 @@ Once connected, you can ask your AI assistant questions like:
 - "What's consuming the most CPU?"
 - "Are there any active alerts? Acknowledge the one for the API."
 - "Which certificates expire within 30 days?"
+- "Create a Slack channel for the ops webhook and route critical container alerts to it."
 - "Are there image updates available for my containers?"
 - "Pause the backup-check heartbeat monitor."
 - "Any critical CVEs in my images? What's my security posture?"

--- a/internal/alert/down.go
+++ b/internal/alert/down.go
@@ -1,0 +1,148 @@
+package alert
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/kolapsis/maintenant/internal/container"
+)
+
+// AlertTypeContainerDown is raised for a container that has been stopped for
+// longer than the configured threshold.
+const AlertTypeContainerDown = "container_down"
+
+// DownDetector raises an alert for every container stopped for longer than the
+// threshold, and resolves it once the container runs again. It reads the state
+// from the store on each pass instead of tracking it in memory, so a container
+// that went down while the server was off is still caught, and it asks the
+// alert store what is already firing instead of re-emitting every pass.
+type DownDetector struct {
+	containers container.ContainerStore
+	alerts     AlertStore
+	after      time.Duration
+	logger     *slog.Logger
+	emit       func(Event)
+}
+
+// NewDownDetector returns a detector for containers stopped longer than after.
+func NewDownDetector(containers container.ContainerStore, alerts AlertStore, after time.Duration, logger *slog.Logger) *DownDetector {
+	return &DownDetector{
+		containers: containers,
+		alerts:     alerts,
+		after:      after,
+		logger:     logger,
+	}
+}
+
+// SetEmitter sets the sink receiving the fire and recovery events.
+func (d *DownDetector) SetEmitter(emit func(Event)) {
+	d.emit = emit
+}
+
+// isDown reports whether a state means the container stopped running on its
+// own. "completed" is a job that ended as intended, "paused" and "created" were
+// never running to begin with.
+func isDown(state container.ContainerState) bool {
+	return state == container.StateExited || state == container.StateDead
+}
+
+// Check runs one pass: fire for what crossed the threshold, resolve for what
+// came back.
+func (d *DownDetector) Check(ctx context.Context) error {
+	containers, err := d.containers.ListContainers(ctx, container.ListContainersOpts{})
+	if err != nil {
+		return fmt.Errorf("container down check: list containers: %w", err)
+	}
+	active, err := d.alerts.ListActiveAlerts(ctx)
+	if err != nil {
+		return fmt.Errorf("container down check: list active alerts: %w", err)
+	}
+
+	now := time.Now()
+	down := make(map[string]*container.Container, len(containers))
+	known := make(map[string]*container.Container, len(containers))
+	for _, c := range containers {
+		known[c.ID] = c
+		if isDown(c.State) && now.Sub(c.LastStateChangeAt) >= d.after {
+			down[c.ID] = c
+		}
+	}
+
+	firing := make(map[string]*Alert, len(active))
+	for _, a := range active {
+		if a.AlertType == AlertTypeContainerDown && a.EntityType == "container" {
+			firing[a.EntityID] = a
+		}
+	}
+
+	for id, c := range down {
+		if _, already := firing[id]; already {
+			continue
+		}
+		stoppedFor := now.Sub(c.LastStateChangeAt).Round(time.Second)
+		d.logger.Warn("container down past threshold",
+			"container_id", c.ID, "name", c.Name, "state", string(c.State),
+			"stopped_for", stoppedFor, "threshold", d.after,
+		)
+		d.send(Event{
+			Source:     SourceContainer,
+			AlertType:  AlertTypeContainerDown,
+			Severity:   downSeverity(c),
+			Message:    fmt.Sprintf("Container %s has been %s for %s", c.Name, c.State, stoppedFor),
+			EntityType: "container",
+			EntityID:   c.ID,
+			EntityName: c.Name,
+			Details: map[string]any{
+				"state":             string(c.State),
+				"stopped_for":       int64(stoppedFor / time.Second),
+				"threshold_seconds": int64(d.after / time.Second),
+				"agent_id":          c.AgentID,
+			},
+			Timestamp: now,
+		})
+	}
+
+	for id, a := range firing {
+		if _, still := down[id]; still {
+			continue
+		}
+		name := a.EntityName
+		if c, ok := known[id]; ok {
+			name = c.Name
+		}
+		d.logger.Info("container back up", "container_id", id, "name", name)
+		d.send(Event{
+			Source:     SourceContainer,
+			AlertType:  AlertTypeContainerDown,
+			Severity:   SeverityInfo,
+			IsRecover:  true,
+			Message:    fmt.Sprintf("Container %s is running again", name),
+			EntityType: "container",
+			EntityID:   id,
+			EntityName: name,
+			Timestamp:  now,
+		})
+	}
+
+	return nil
+}
+
+// downSeverity honours the per-container alert severity the operator set.
+func downSeverity(c *container.Container) string {
+	switch c.AlertSeverity {
+	case container.SeverityInfo:
+		return SeverityInfo
+	case container.SeverityWarning:
+		return SeverityWarning
+	default:
+		return SeverityCritical
+	}
+}
+
+func (d *DownDetector) send(evt Event) {
+	if d.emit != nil {
+		d.emit(evt)
+	}
+}

--- a/internal/alert/down_test.go
+++ b/internal/alert/down_test.go
@@ -1,0 +1,227 @@
+// Copyright 2026 Benjamin Touchard (Kolapsis)
+//
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+// or a commercial license. You may not use this file except in compliance
+// with one of these licenses.
+//
+// AGPL-3.0: https://www.gnu.org/licenses/agpl-3.0.html
+// Commercial: See COMMERCIAL-LICENSE.md
+//
+// Source: https://github.com/kolapsis/maintenant
+
+package alert_test
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kolapsis/maintenant/internal/alert"
+	"github.com/kolapsis/maintenant/internal/container"
+	"github.com/kolapsis/maintenant/internal/store"
+	"github.com/kolapsis/maintenant/internal/store/storetest"
+)
+
+const downThreshold = 5 * time.Minute
+
+type downFixture struct {
+	containers *store.ContainerStore
+	alerts     *store.AlertStoreImpl
+	detector   *alert.DownDetector
+	events     []alert.Event
+}
+
+func newDownFixture(t *testing.T) *downFixture {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	db := storetest.Open(t, logger)
+
+	f := &downFixture{
+		containers: store.NewContainerStore(db),
+		alerts:     store.NewAlertStore(db),
+	}
+	f.detector = alert.NewDownDetector(f.containers, f.alerts, downThreshold, logger)
+	f.detector.SetEmitter(func(evt alert.Event) { f.events = append(f.events, evt) })
+	return f
+}
+
+// add stores a container in the given state, changed stoppedFor ago.
+func (f *downFixture) add(t *testing.T, name string, state container.ContainerState, stoppedFor time.Duration) string {
+	t.Helper()
+	c := &container.Container{
+		ExternalID:        name + "-external",
+		Name:              name,
+		Image:             "busybox:latest",
+		State:             state,
+		AlertSeverity:     container.SeverityCritical,
+		RuntimeType:       "docker",
+		FirstSeenAt:       time.Now().Add(-24 * time.Hour),
+		LastStateChangeAt: time.Now().Add(-stoppedFor),
+	}
+	id, err := f.containers.InsertContainer(context.Background(), c)
+	require.NoError(t, err)
+	return id
+}
+
+// fire replays an event through the alert store the way the engine would, so
+// the next pass sees it as already firing.
+func (f *downFixture) fire(t *testing.T, evt alert.Event) {
+	t.Helper()
+	_, err := f.alerts.InsertAlert(context.Background(), &alert.Alert{
+		Source:     evt.Source,
+		AlertType:  evt.AlertType,
+		Severity:   evt.Severity,
+		Status:     alert.StatusActive,
+		Message:    evt.Message,
+		EntityType: evt.EntityType,
+		EntityID:   evt.EntityID,
+		EntityName: evt.EntityName,
+		Details:    "{}",
+		FiredAt:    evt.Timestamp,
+	})
+	require.NoError(t, err)
+}
+
+func (f *downFixture) check(t *testing.T) []alert.Event {
+	t.Helper()
+	f.events = nil
+	require.NoError(t, f.detector.Check(context.Background()))
+	return f.events
+}
+
+func TestDownDetector_FiresPastTheThreshold(t *testing.T) {
+	f := newDownFixture(t)
+	id := f.add(t, "api", container.StateExited, 10*time.Minute)
+
+	events := f.check(t)
+	require.Len(t, events, 1)
+	evt := events[0]
+	assert.Equal(t, alert.SourceContainer, evt.Source)
+	assert.Equal(t, alert.AlertTypeContainerDown, evt.AlertType)
+	assert.Equal(t, alert.SeverityCritical, evt.Severity)
+	assert.False(t, evt.IsRecover)
+	assert.Equal(t, "container", evt.EntityType)
+	assert.Equal(t, id, evt.EntityID)
+	assert.Equal(t, "api", evt.EntityName)
+	assert.Equal(t, int64(downThreshold/time.Second), evt.Details["threshold_seconds"])
+}
+
+func TestDownDetector_StaysQuietBeforeTheThreshold(t *testing.T) {
+	f := newDownFixture(t)
+	f.add(t, "api", container.StateExited, time.Minute)
+
+	assert.Empty(t, f.check(t))
+}
+
+// A container that exited with code 0 is recorded as completed: a job that
+// finished as intended is not an outage.
+func TestDownDetector_IgnoresStatesThatAreNotAnOutage(t *testing.T) {
+	for _, state := range []container.ContainerState{
+		container.StateRunning,
+		container.StateCompleted,
+		container.StatePaused,
+		container.StateCreated,
+		container.StateRestarting,
+	} {
+		t.Run(string(state), func(t *testing.T) {
+			f := newDownFixture(t)
+			f.add(t, "job", state, time.Hour)
+			assert.Empty(t, f.check(t))
+		})
+	}
+}
+
+func TestDownDetector_DeadCountsAsDown(t *testing.T) {
+	f := newDownFixture(t)
+	f.add(t, "api", container.StateDead, time.Hour)
+
+	require.Len(t, f.check(t), 1)
+}
+
+// The detector asks the alert store what is already firing, so a second pass
+// over the same stopped container emits nothing.
+func TestDownDetector_DoesNotReFireWhileTheAlertIsActive(t *testing.T) {
+	f := newDownFixture(t)
+	f.add(t, "api", container.StateExited, 10*time.Minute)
+
+	events := f.check(t)
+	require.Len(t, events, 1)
+	f.fire(t, events[0])
+
+	assert.Empty(t, f.check(t))
+}
+
+func TestDownDetector_ResolvesWhenTheContainerRunsAgain(t *testing.T) {
+	f := newDownFixture(t)
+	f.add(t, "api", container.StateExited, 10*time.Minute)
+
+	events := f.check(t)
+	require.Len(t, events, 1)
+	f.fire(t, events[0])
+
+	f.add(t, "api", container.StateRunning, time.Second)
+
+	events = f.check(t)
+	require.Len(t, events, 1)
+	assert.True(t, events[0].IsRecover)
+	assert.Equal(t, alert.SeverityInfo, events[0].Severity)
+	assert.Equal(t, alert.AlertTypeContainerDown, events[0].AlertType)
+	assert.Equal(t, "api", events[0].EntityName)
+}
+
+// Nothing is emitted for a container that never crossed the threshold, so a
+// recovery cannot appear out of nowhere.
+func TestDownDetector_NoRecoveryWithoutAFiringAlert(t *testing.T) {
+	f := newDownFixture(t)
+	f.add(t, "api", container.StateRunning, time.Hour)
+
+	assert.Empty(t, f.check(t))
+}
+
+// The severity is the one configured on the container, not a constant.
+func TestDownDetector_HonoursThePerContainerSeverity(t *testing.T) {
+	f := newDownFixture(t)
+	c := &container.Container{
+		ExternalID:        "warn-external",
+		Name:              "warn",
+		State:             container.StateExited,
+		AlertSeverity:     container.SeverityWarning,
+		RuntimeType:       "docker",
+		FirstSeenAt:       time.Now().Add(-time.Hour),
+		LastStateChangeAt: time.Now().Add(-time.Hour),
+	}
+	_, err := f.containers.InsertContainer(context.Background(), c)
+	require.NoError(t, err)
+
+	events := f.check(t)
+	require.Len(t, events, 1)
+	assert.Equal(t, alert.SeverityWarning, events[0].Severity)
+}
+
+// An unrelated active alert on the same container must not be mistaken for the
+// down alert, or the detector would never fire.
+func TestDownDetector_IgnoresOtherAlertTypesOnTheSameContainer(t *testing.T) {
+	f := newDownFixture(t)
+	id := f.add(t, "api", container.StateExited, 10*time.Minute)
+
+	_, err := f.alerts.InsertAlert(context.Background(), &alert.Alert{
+		Source:     alert.SourceContainer,
+		AlertType:  "restart_loop",
+		Severity:   alert.SeverityWarning,
+		Status:     alert.StatusActive,
+		Message:    "restarting",
+		EntityType: "container",
+		EntityID:   id,
+		EntityName: "api",
+		Details:    "{}",
+		FiredAt:    time.Now(),
+	})
+	require.NoError(t, err)
+
+	require.Len(t, f.check(t), 1)
+}

--- a/internal/api/v1/alerts.go
+++ b/internal/api/v1/alerts.go
@@ -572,25 +572,6 @@ func (h *AlertHandler) HandleCancelSilenceRule(w http.ResponseWriter, r *http.Re
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// channelCapability maps a channel type to the capability that opens it. Types
-// absent from the map are open in every edition. email and Telegram are
-// Personal, Slack and Teams are Pro — the gating is per channel, not "paid
-// edition or not".
-func channelCapability(channelType string) (extension.Capability, bool) {
-	switch channelType {
-	case "slack":
-		return extension.CapSlack, true
-	case "teams":
-		return extension.CapTeams, true
-	case "email":
-		return extension.CapSMTP, true
-	case "telegram":
-		return extension.CapTelegram, true
-	default:
-		return "", false
-	}
-}
-
 // validateTelegramCredentials checks the two values the operator types and the
 // optional topic id, before anything reaches the network (FR-004).
 func validateTelegramCredentials(secret, config string) error {
@@ -607,7 +588,7 @@ func validateTelegramCredentials(secret, config string) error {
 // refuseChannelCapability writes the refusal when the running edition does not
 // open this channel type, and reports whether it did.
 func refuseChannelCapability(w http.ResponseWriter, channelType string) bool {
-	c, gated := channelCapability(channelType)
+	c, gated := extension.ChannelCapability(channelType)
 	if !gated || extension.Allows(c) {
 		return false
 	}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -85,6 +85,7 @@ type App struct {
 	// Alert pipeline
 	alertEngine     *alert.Engine
 	notifier        *alert.Notifier
+	downDetector    *alert.DownDetector
 	escalationStore *store.EscalationStore
 	escalationSvc   *escalation.Service
 
@@ -440,6 +441,13 @@ func New(cfg Config, logger *slog.Logger) (*App, error) {
 		}),
 	})
 
+	// Sustained container downtime. Off unless the operator sets a threshold:
+	// enabling it retroactively alerts on every container already stopped.
+	if cfg.ContainerDownAfter > 0 {
+		a.downDetector = alert.NewDownDetector(containerStore, alertStore, cfg.ContainerDownAfter,
+			logger.With("component", "container-down"))
+	}
+
 	// --- Public Status Page ---
 	a.subscriberSvc = status.NewSubscriberService(subscriberStore, nil, cfg.BaseURL, logger)
 	a.statusSvc = status.NewService(status.Deps{
@@ -639,6 +647,7 @@ func New(cfg Config, logger *slog.Logger) (*App, error) {
 		Channels:      channelStore,
 		Triggers:      triggerStore,
 		Escalator:     a.alertEngine.Escalator(),
+		ChannelTester: a.notifier,
 		Updates:       a.updateSvc,
 		Incidents:     incidentStore,
 		Maintenance:   maintenanceStore,
@@ -653,13 +662,17 @@ func New(cfg Config, logger *slog.Logger) (*App, error) {
 		Scorer:      a.scorer,
 		UpdateStore: updateStore,
 		// Orchestrators (read-only)
-		Kubernetes:     a.k8sStore,
-		SwarmCluster:   func() *swarm.SwarmCluster { return a.swarmCluster },
-		SwarmDiscovery: func() *swarm.ServiceDiscovery { return a.swarmDiscovery },
-		SwarmTopology:  a.swarmTopologyStore,
-		SwarmNodes:     a.swarmNodeStore,
-		Version:        cfg.Version,
-		Logger:         logger.With("component", "mcp"),
+		Kubernetes:           a.k8sStore,
+		SwarmCluster:         func() *swarm.SwarmCluster { return a.swarmCluster },
+		SwarmDiscovery:       func() *swarm.ServiceDiscovery { return a.swarmDiscovery },
+		SwarmTopology:        a.swarmTopologyStore,
+		SwarmNodes:           a.swarmNodeStore,
+		AllowPrivateWebhooks: cfg.AllowPrivateWebhooks,
+		Broadcast: func(eventType string, data any) {
+			a.broker.Broadcast(v1.SSEEvent{Type: eventType, Data: data})
+		},
+		Version: cfg.Version,
+		Logger:  logger.With("component", "mcp"),
 	}
 	a.mcpServer = mcp.NewServer(mcpSvc)
 
@@ -842,6 +855,11 @@ func (a *App) Start(ctx context.Context) error {
 	// no-op unless the matching runtime is active.
 	go a.startKubernetesReconcile(ctx)
 	go a.startSwarmTopologyReconcile(ctx)
+
+	// Sustained container downtime (opt-in via MAINTENANT_CONTAINER_DOWN_AFTER).
+	if a.downDetector != nil {
+		go a.startContainerDownCheck(ctx)
+	}
 
 	// Swarm context recheck (60s) — detects swarm activation/deactivation.
 	if a.swarmDetector != nil {

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -68,6 +68,13 @@ type Config struct {
 	// Security
 	SecurityScoreThreshold int
 
+	// ContainerDownAfter is how long a container must stay stopped before it
+	// raises an alert. Zero disables the check.
+	ContainerDownAfter time.Duration
+	// ContainerDownAfterInvalid holds a rejected threshold verbatim, so a typo
+	// stops startup instead of silently leaving the check off.
+	ContainerDownAfterInvalid string
+
 	// Telemetry
 	DisableTelemetry bool
 
@@ -173,6 +180,19 @@ func (c Config) ValidateStorage() error {
 	return nil
 }
 
+// ErrContainerDownAfter refuses a container-down threshold that does not parse.
+var ErrContainerDownAfter = errors.New(
+	"MAINTENANT_CONTAINER_DOWN_AFTER is not a valid duration: use a Go duration such as 5m, 30s or 1h30m")
+
+// ValidateAlerting refuses an alerting configuration that would leave a check
+// silently off.
+func (c Config) ValidateAlerting() error {
+	if c.ContainerDownAfterInvalid != "" {
+		return fmt.Errorf("%w (got %q)", ErrContainerDownAfter, c.ContainerDownAfterInvalid)
+	}
+	return nil
+}
+
 func (c Config) ValidateHTTP() error {
 	if c.MCP.Enabled && !c.MCP.AllowUnauthenticated &&
 		(c.MCP.ClientID == "" || c.MCP.ClientSecret == "") {
@@ -236,6 +256,8 @@ func ConfigFromEnv() Config {
 		BatchSize: envIntOr("MAINTENANT_RETENTION_BATCH_SIZE", 1000),
 	}
 
+	cfg.ContainerDownAfter, cfg.ContainerDownAfterInvalid = envOptionalDuration("MAINTENANT_CONTAINER_DOWN_AFTER")
+
 	cfg.DisableTelemetry = parseTruthy(os.Getenv("MAINTENANT_DISABLE_TELEMETRY"))
 	cfg.AllowPrivateWebhooks = parseTruthy(os.Getenv("MAINTENANT_ALLOW_PRIVATE_WEBHOOKS"))
 
@@ -292,6 +314,21 @@ func envIntOr(key string, fallback int) int {
 		}
 	}
 	return fallback
+}
+
+// envOptionalDuration parses a duration whose absence is meaningful. It returns
+// the rejected raw value rather than a fallback: for a threshold that switches
+// a check on, falling back to "off" would read as accepted.
+func envOptionalDuration(key string) (time.Duration, string) {
+	v := strings.TrimSpace(os.Getenv(key))
+	if v == "" {
+		return 0, ""
+	}
+	d, err := time.ParseDuration(v)
+	if err != nil || d < 0 {
+		return 0, v
+	}
+	return d, ""
 }
 
 func envDurationOr(key string, fallback time.Duration) time.Duration {

--- a/internal/app/config_test.go
+++ b/internal/app/config_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/kolapsis/maintenant/internal/resource"
 )
@@ -104,4 +105,37 @@ func TestConfigFromEnv_MCPAllowUnauthenticated(t *testing.T) {
 		t.Setenv("MAINTENANT_MCP_ALLOW_UNAUTHENTICATED", "yes")
 		assert.True(t, ConfigFromEnv().MCP.AllowUnauthenticated)
 	})
+}
+
+func TestConfigFromEnv_ContainerDownAfter(t *testing.T) {
+	t.Setenv("MAINTENANT_CONTAINER_DOWN_AFTER", "5m")
+	cfg := ConfigFromEnv()
+
+	assert.Equal(t, 5*time.Minute, cfg.ContainerDownAfter)
+	assert.NoError(t, cfg.ValidateAlerting())
+}
+
+func TestConfigFromEnv_ContainerDownAfterUnsetIsOff(t *testing.T) {
+	t.Setenv("MAINTENANT_CONTAINER_DOWN_AFTER", "")
+	cfg := ConfigFromEnv()
+
+	assert.Zero(t, cfg.ContainerDownAfter)
+	assert.NoError(t, cfg.ValidateAlerting())
+}
+
+// A typo must stop startup rather than silently disable the check: an operator
+// who set a threshold believes containers are being watched.
+func TestConfigFromEnv_ContainerDownAfterInvalidIsRefused(t *testing.T) {
+	for _, raw := range []string{"5", "later", "-5m"} {
+		t.Run(raw, func(t *testing.T) {
+			t.Setenv("MAINTENANT_CONTAINER_DOWN_AFTER", raw)
+			cfg := ConfigFromEnv()
+
+			assert.Zero(t, cfg.ContainerDownAfter)
+			err := cfg.ValidateAlerting()
+			require.Error(t, err)
+			assert.ErrorIs(t, err, ErrContainerDownAfter)
+			assert.Contains(t, err.Error(), raw)
+		})
+	}
 }

--- a/internal/app/container_down_wiring_test.go
+++ b/internal/app/container_down_wiring_test.go
@@ -1,0 +1,52 @@
+// Copyright 2026 Benjamin Touchard (Kolapsis)
+//
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+// or a commercial license. You may not use this file except in compliance
+// with one of these licenses.
+//
+// AGPL-3.0: https://www.gnu.org/licenses/agpl-3.0.html
+// Commercial: See COMMERCIAL-LICENSE.md
+//
+// Source: https://github.com/kolapsis/maintenant
+
+package app
+
+import (
+	"io"
+	"log/slog"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func downWiringConfig(t *testing.T, after time.Duration) (Config, *slog.Logger) {
+	t.Helper()
+	t.Setenv("MAINTENANT_RUNTIME", "docker")
+	t.Setenv("DOCKER_HOST", "unix:///nonexistent-test-socket-abc123.sock")
+	t.Setenv("KUBERNETES_SERVICE_HOST", "")
+	t.Setenv("KUBECONFIG", "")
+	return Config{
+		DBPath:             filepath.Join(t.TempDir(), "test.db"),
+		Addr:               "127.0.0.1:0",
+		ContainerDownAfter: after,
+	}, slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func TestNew_ContainerDownDetectorFollowsTheThreshold(t *testing.T) {
+	t.Run("off when unset", func(t *testing.T) {
+		cfg, logger := downWiringConfig(t, 0)
+		a, err := New(cfg, logger)
+		require.NoError(t, err)
+		assert.Nil(t, a.downDetector)
+	})
+
+	t.Run("on when set", func(t *testing.T) {
+		cfg, logger := downWiringConfig(t, 5*time.Minute)
+		a, err := New(cfg, logger)
+		require.NoError(t, err)
+		assert.NotNil(t, a.downDetector)
+	})
+}

--- a/internal/app/flags.go
+++ b/internal/app/flags.go
@@ -266,6 +266,24 @@ func init() {
 			Description: "Public status page URL advertised in notifications",
 			ApplyTo:     func(c *Config, v string) error { c.StatusURL = v; return nil },
 		},
+		// Alerting
+		{
+			EnvName: "MAINTENANT_CONTAINER_DOWN_AFTER", FlagName: "containerDownAfter",
+			Type: FlagTypeDuration, Default: "0",
+			Description: "Raise an alert for a container stopped this long (e.g. 5m; 0 disables)",
+			ApplyTo: func(c *Config, v string) error {
+				d, err := time.ParseDuration(v)
+				if err != nil {
+					return err
+				}
+				if d < 0 {
+					return fmt.Errorf("must not be negative")
+				}
+				c.ContainerDownAfter = d
+				c.ContainerDownAfterInvalid = ""
+				return nil
+			},
+		},
 		// Retention
 		{
 			EnvName: "MAINTENANT_RETENTION_SNAPSHOTS", FlagName: "retentionSnapshots",
@@ -472,6 +490,7 @@ func init() {
 	Categories = []FlagCategory{
 		{Name: "Server", Specs: specsFor("addr", "baseUrl", "corsOrigins")},
 		{Name: "Storage", Specs: specsFor("db")},
+		{Name: "Alerting", Specs: specsFor("containerDownAfter")},
 		{Name: "Retention", Specs: specsFor("retentionSnapshots", "retentionInterval", "retentionBatchSize")},
 		{Name: "Branding", Specs: specsFor("organisationName", "statusUrl")},
 		{Name: "Runtime", Specs: specsFor("runtime")},

--- a/internal/app/lifecycle.go
+++ b/internal/app/lifecycle.go
@@ -258,6 +258,29 @@ func (a *App) startNodeRefresh(ctx context.Context) {
 	}
 }
 
+// containerDownCheckInterval is how often the container-down sweep runs. It is
+// the alert's resolution, not its threshold: the threshold comes from the
+// operator's MAINTENANT_CONTAINER_DOWN_AFTER.
+const containerDownCheckInterval = 30 * time.Second
+
+// startContainerDownCheck sweeps for containers stopped past the configured
+// threshold. The first pass waits one tick so the initial runtime reconcile has
+// refreshed states the store may have been holding since the last shutdown.
+func (a *App) startContainerDownCheck(ctx context.Context) {
+	ticker := time.NewTicker(containerDownCheckInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := a.downDetector.Check(ctx); err != nil {
+				a.logger.Warn("container down check failed", "error", err)
+			}
+		}
+	}
+}
+
 // startKubernetesReconcile periodically snapshots the server's own Kubernetes
 // runtime into the per-agent store under the LocalAgent id, so the store-backed
 // Workloads/Pods/Nodes views reflect the local cluster the same way they reflect

--- a/internal/app/wiring.go
+++ b/internal/app/wiring.go
@@ -73,6 +73,10 @@ func (a *App) wireAlertCallbacks(alertDetector *alert.EndpointAlertDetector) {
 		a.statusSvc.HandleAlertEvent(ctx, evt)
 	}
 
+	if a.downDetector != nil {
+		a.downDetector.SetEmitter(sendAlert)
+	}
+
 	// Container events
 	a.containerSvc.SetEventCallback(func(eventType string, data any) {
 		a.broker.Broadcast(v1.SSEEvent{Type: eventType, Data: data})

--- a/internal/extension/capability.go
+++ b/internal/extension/capability.go
@@ -82,6 +82,22 @@ var minEdition = map[Capability]Edition{
 
 // MinEdition returns the lowest edition that opens c. An unknown capability
 // resolves to Pro: a capability nobody declared is not one we hand out.
+// channelCapabilities maps a notification channel type to the capability that
+// opens it. A type absent from the map is open in every edition.
+var channelCapabilities = map[string]Capability{
+	"slack":    CapSlack,
+	"teams":    CapTeams,
+	"email":    CapSMTP,
+	"telegram": CapTelegram,
+}
+
+// ChannelCapability returns the capability gating a channel type, and whether
+// that type is gated at all.
+func ChannelCapability(channelType string) (Capability, bool) {
+	c, ok := channelCapabilities[channelType]
+	return c, ok
+}
+
 func MinEdition(c Capability) Edition {
 	if e, ok := minEdition[c]; ok {
 		return e

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -43,6 +43,10 @@ type AgentLister interface {
 }
 
 // SessionChecker reports whether an agent currently has an active gRPC stream.
+type ChannelTester interface {
+	SendTestWebhook(ctx context.Context, ch *alert.NotificationChannel) (int, error)
+}
+
 type SessionChecker interface {
 	IsConnected(agentID string) bool
 }
@@ -83,6 +87,7 @@ type Services struct {
 	Channels      alert.ChannelStore
 	Triggers      alert.TriggerStore
 	Escalator     alert.Escalator
+	ChannelTester ChannelTester
 	Updates       *update.Service
 	Incidents     status.IncidentStore
 	Maintenance   status.MaintenanceStore
@@ -105,8 +110,22 @@ type Services struct {
 	SwarmTopology  SwarmTopologyReader
 	SwarmNodes     SwarmNodeReader
 
+	// AllowPrivateWebhooks mirrors the REST flag: it relaxes the SSRF guard on
+	// channel destinations in development.
+	AllowPrivateWebhooks bool
+	// Broadcast forwards a store change to the SSE brokers so an interface open
+	// on the page sees an MCP write without reloading.
+	Broadcast func(eventType string, data any)
+
 	Version string
 	Logger  *slog.Logger
+}
+
+func (s *Services) logger() *slog.Logger {
+	if s.Logger != nil {
+		return s.Logger
+	}
+	return slog.Default()
 }
 
 // NewServer creates and configures an MCP server with all maintenant tools registered.
@@ -123,6 +142,8 @@ func NewServer(svc *Services) *gomcp.Server {
 	registerWriteTools(server, svc)
 	registerEscalationTools(server, svc)
 	registerTriggerTools(server, svc)
+	registerChannelTools(server, svc)
+	registerEditionTools(server, svc)
 	registerSecurityTools(server, svc)
 	registerKubernetesTools(server, svc)
 	registerSwarmTools(server, svc)

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -114,6 +114,15 @@ func TestNewServer_RegistersAllTools(t *testing.T) {
 		"create_trigger",
 		"update_trigger",
 		"delete_trigger",
+		// Channel tools (6)
+		"list_channels",
+		"get_channel",
+		"create_channel",
+		"update_channel",
+		"delete_channel",
+		"test_channel",
+		// Edition tool (1)
+		"get_edition",
 		// Security tools (4)
 		"get_security_insights",
 		"list_cve",
@@ -136,7 +145,7 @@ func TestNewServer_RegistersAllTools(t *testing.T) {
 		toolNames[tool.Name] = true
 	}
 
-	assert.Len(t, result.Tools, 44, "expected exactly 44 tools registered")
+	assert.Len(t, result.Tools, 51, "expected exactly 51 tools registered")
 	for _, name := range expectedTools {
 		assert.True(t, toolNames[name], "expected tool %q to be registered", name)
 	}
@@ -177,6 +186,9 @@ func TestNewServer_ReadToolsAreReadOnly(t *testing.T) {
 		"list_certificates":    true,
 		"get_updates":          true,
 		"get_health":           true,
+		"list_channels":        true,
+		"get_channel":          true,
+		"get_edition":          true,
 	}
 
 	for _, tool := range result.Tools {

--- a/internal/mcp/tools_channels.go
+++ b/internal/mcp/tools_channels.go
@@ -1,0 +1,385 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/mail"
+	"strings"
+
+	"github.com/kolapsis/maintenant/internal/alert"
+	"github.com/kolapsis/maintenant/internal/event"
+	"github.com/kolapsis/maintenant/internal/extension"
+	"github.com/kolapsis/maintenant/internal/ssrf"
+	"github.com/kolapsis/maintenant/internal/store"
+	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func registerChannelTools(server *gomcp.Server, svc *Services) {
+	gomcp.AddTool(server, &gomcp.Tool{
+		Name:        "list_channels",
+		Description: "List notification channels. Channels are silent on their own: an alert reaches one only through an alert trigger or an escalation level. Secrets are never returned.",
+		Annotations: &gomcp.ToolAnnotations{ReadOnlyHint: true},
+	}, listChannelsHandler(svc))
+
+	gomcp.AddTool(server, &gomcp.Tool{
+		Name:        "get_channel",
+		Description: "Get a single notification channel by ID, with its delivery health and the triggers routing to it.",
+		Annotations: &gomcp.ToolAnnotations{ReadOnlyHint: true},
+	}, getChannelHandler(svc))
+
+	gomcp.AddTool(server, &gomcp.Tool{
+		Name:        "create_channel",
+		Description: "Create a notification channel. The webhook type is open in every edition; " + gatedChannelTypes() + ".",
+	}, createChannelHandler(svc))
+
+	gomcp.AddTool(server, &gomcp.Tool{
+		Name:        "update_channel",
+		Description: "Update a notification channel. Omitted fields keep their stored value; a stored secret is never cleared this way.",
+	}, updateChannelHandler(svc))
+
+	gomcp.AddTool(server, &gomcp.Tool{
+		Name:        "delete_channel",
+		Description: "Delete a notification channel. Triggers and escalation levels pointing at it lose that destination.",
+	}, deleteChannelHandler(svc))
+
+	gomcp.AddTool(server, &gomcp.Tool{
+		Name:        "test_channel",
+		Description: "Send a test notification through a channel and report whether it was delivered.",
+	}, testChannelHandler(svc))
+}
+
+// gatedChannelTypes renders the edition each gated channel type needs, read
+// from the registry so a description cannot name a tier the gate does not
+// enforce.
+func gatedChannelTypes() string {
+	types := []string{"email", "slack", "teams", "telegram"}
+	parts := make([]string, 0, len(types))
+	for _, t := range types {
+		c, _ := extension.ChannelCapability(t)
+		parts = append(parts, t+" needs "+titleEdition(extension.MinEdition(c)))
+	}
+	return strings.Join(parts, ", ")
+}
+
+type listChannelsInput struct{}
+
+type getChannelInput struct {
+	ID string `json:"id" jsonschema:"Channel ID"`
+}
+
+type createChannelInput struct {
+	Name    string `json:"name" jsonschema:"Channel name, unique across channels"`
+	Type    string `json:"type" jsonschema:"Channel type: webhook, email, telegram, slack or teams. Defaults to webhook."`
+	URL     string `json:"url" jsonschema:"Destination: an HTTPS webhook URL, an email address, or a Telegram chat id"`
+	Headers string `json:"headers,omitempty" jsonschema:"Extra HTTP headers as a JSON object, webhook types only"`
+	Secret  string `json:"secret,omitempty" jsonschema:"Channel credential, a Telegram bot token today. Write-only: it is never read back."`
+	Config  string `json:"config,omitempty" jsonschema:"Non-secret per-type settings as a JSON object, e.g. {\"thread_id\":\"42\"} for Telegram"`
+	Enabled *bool  `json:"enabled,omitempty" jsonschema:"Whether the channel accepts deliveries, default true"`
+}
+
+type updateChannelInput struct {
+	ID      string  `json:"id" jsonschema:"Channel ID to update"`
+	Name    *string `json:"name,omitempty" jsonschema:"New channel name"`
+	Type    *string `json:"type,omitempty" jsonschema:"New channel type"`
+	URL     *string `json:"url,omitempty" jsonschema:"New destination"`
+	Headers *string `json:"headers,omitempty" jsonschema:"New extra HTTP headers as a JSON object"`
+	Secret  *string `json:"secret,omitempty" jsonschema:"New credential. Omit to keep the stored one; it cannot be set to empty."`
+	Config  *string `json:"config,omitempty" jsonschema:"New non-secret per-type settings as a JSON object"`
+	Enabled *bool   `json:"enabled,omitempty" jsonschema:"Whether the channel accepts deliveries"`
+}
+
+type deleteChannelInput struct {
+	ID string `json:"id" jsonschema:"Channel ID to delete"`
+}
+
+type testChannelInput struct {
+	ID string `json:"id" jsonschema:"Channel ID to test"`
+}
+
+// refuseChannelType is the MCP half of the REST refuseChannelCapability: same
+// registry, same decision, named per channel type so the refusal says which
+// edition opens that one.
+func refuseChannelType(chType string) (*gomcp.CallToolResult, any, error) {
+	c, gated := extension.ChannelCapability(chType)
+	if !gated || extension.Allows(c) {
+		return nil, nil, nil
+	}
+	required := extension.MinEdition(c)
+	msg := fmt.Sprintf(
+		`{"error":"edition_required","feature":%q,"required_edition":%q,"message":"The %s channel requires the %s edition of Maintenant."}`,
+		string(c), string(required), chType, titleEdition(required),
+	)
+	return &gomcp.CallToolResult{
+		Content: []gomcp.Content{&gomcp.TextContent{Text: msg}},
+		IsError: true,
+	}, nil, nil
+}
+
+func validateChannelDestination(ctx context.Context, svc *Services, chType, rawURL string) error {
+	switch chType {
+	case "telegram":
+		return alert.ValidateChatID(rawURL)
+	case "email":
+		if _, err := mail.ParseAddress(rawURL); err != nil {
+			return errors.New("invalid email address")
+		}
+		return nil
+	}
+	if svc.AllowPrivateWebhooks {
+		return nil
+	}
+	return ssrf.ValidateURL(ctx, rawURL)
+}
+
+func validateChannelCredentials(chType, secret, config string) error {
+	if chType != "telegram" {
+		return nil
+	}
+	if err := alert.ValidateBotToken(secret); err != nil {
+		return err
+	}
+	cfg, err := alert.ParseTelegramConfig(config)
+	if err != nil {
+		return errors.New("config must be a JSON object")
+	}
+	return alert.ValidateThreadID(cfg.ThreadID)
+}
+
+func normalizeConfig(config string) string {
+	config = strings.TrimSpace(config)
+	if config == "null" {
+		return ""
+	}
+	return config
+}
+
+func (s *Services) broadcast(eventType string, data any) {
+	if s.Broadcast != nil {
+		s.Broadcast(eventType, data)
+	}
+}
+
+func listChannelsHandler(svc *Services) gomcp.ToolHandlerFor[listChannelsInput, any] {
+	return func(ctx context.Context, _ *gomcp.CallToolRequest, _ listChannelsInput) (*gomcp.CallToolResult, any, error) {
+		if svc.Channels == nil {
+			return errResult("channel store not available")
+		}
+		channels, err := svc.Channels.ListChannels(ctx)
+		if err != nil {
+			return nil, nil, fmt.Errorf("list channels: %w", err)
+		}
+		if channels == nil {
+			channels = []*alert.NotificationChannel{}
+		}
+		return jsonResult(map[string]any{"channels": channels})
+	}
+}
+
+func getChannelHandler(svc *Services) gomcp.ToolHandlerFor[getChannelInput, any] {
+	return func(ctx context.Context, _ *gomcp.CallToolRequest, input getChannelInput) (*gomcp.CallToolResult, any, error) {
+		if svc.Channels == nil {
+			return errResult("channel store not available")
+		}
+		ch, err := svc.Channels.GetChannel(ctx, input.ID)
+		if err != nil {
+			return nil, nil, fmt.Errorf("get channel: %w", err)
+		}
+		if ch == nil {
+			return errResult("channel not found")
+		}
+
+		out := map[string]any{"channel": ch}
+		if health, err := svc.Channels.GetChannelHealth(ctx, ch.ID); err == nil {
+			out["health"] = health
+		}
+		if svc.Triggers != nil {
+			triggers, err := svc.Triggers.ListTriggersForChannel(ctx, ch.ID)
+			if err != nil {
+				return nil, nil, fmt.Errorf("get channel: triggers: %w", err)
+			}
+			if triggers == nil {
+				triggers = []*alert.AlertTrigger{}
+			}
+			out["triggers"] = triggers
+		}
+		return jsonResult(out)
+	}
+}
+
+func createChannelHandler(svc *Services) gomcp.ToolHandlerFor[createChannelInput, any] {
+	return func(ctx context.Context, _ *gomcp.CallToolRequest, input createChannelInput) (*gomcp.CallToolResult, any, error) {
+		if svc.Channels == nil {
+			return errResult("channel store not available")
+		}
+		if input.Type == "" {
+			input.Type = "webhook"
+		}
+		if r, v, err := refuseChannelType(input.Type); r != nil {
+			return r, v, err
+		}
+		if input.Name == "" {
+			return errResult("field=name: required")
+		}
+		if input.URL == "" {
+			return errResult("field=url: required")
+		}
+		if err := validateChannelDestination(ctx, svc, input.Type, input.URL); err != nil {
+			return errResult("field=url: " + err.Error())
+		}
+		config := normalizeConfig(input.Config)
+		if err := validateChannelCredentials(input.Type, input.Secret, config); err != nil {
+			return errResult(err.Error())
+		}
+
+		enabled := true
+		if input.Enabled != nil {
+			enabled = *input.Enabled
+		}
+
+		ch := &alert.NotificationChannel{
+			Name:    input.Name,
+			Type:    input.Type,
+			URL:     input.URL,
+			Headers: input.Headers,
+			Secret:  input.Secret,
+			Config:  config,
+			Enabled: enabled,
+		}
+		id, err := svc.Channels.InsertChannel(ctx, ch)
+		if err != nil {
+			if store.IsUniqueViolation(err) {
+				return errResult("a channel with this name already exists")
+			}
+			return nil, nil, fmt.Errorf("create channel: %w", err)
+		}
+		ch.ID = id
+		ch.HasSecret = ch.Secret != ""
+
+		svc.broadcast(event.ChannelCreated, ch)
+		return jsonResult(ch)
+	}
+}
+
+func updateChannelHandler(svc *Services) gomcp.ToolHandlerFor[updateChannelInput, any] {
+	return func(ctx context.Context, _ *gomcp.CallToolRequest, input updateChannelInput) (*gomcp.CallToolResult, any, error) {
+		if svc.Channels == nil {
+			return errResult("channel store not available")
+		}
+		ch, err := svc.Channels.GetChannel(ctx, input.ID)
+		if err != nil {
+			return nil, nil, fmt.Errorf("update channel: lookup: %w", err)
+		}
+		if ch == nil {
+			return errResult("channel not found")
+		}
+
+		// Switching a channel off never needs the edition that opens its type:
+		// a downgraded instance must still be able to silence it.
+		extends := input.Name != nil || input.Type != nil || input.URL != nil ||
+			input.Headers != nil || input.Secret != nil || input.Config != nil ||
+			(input.Enabled != nil && *input.Enabled)
+		if extends {
+			if r, v, err := refuseChannelType(ch.Type); r != nil {
+				return r, v, err
+			}
+			if input.Type != nil {
+				if r, v, err := refuseChannelType(*input.Type); r != nil {
+					return r, v, err
+				}
+			}
+		}
+
+		if input.Name != nil {
+			ch.Name = *input.Name
+		}
+		if input.Type != nil {
+			ch.Type = *input.Type
+		}
+		if input.URL != nil {
+			ch.URL = *input.URL
+		}
+		if input.Headers != nil {
+			ch.Headers = *input.Headers
+		}
+		if input.Secret != nil {
+			if *input.Secret == "" {
+				return errResult("field=secret: cannot be cleared; delete the channel instead")
+			}
+			ch.Secret = *input.Secret
+		}
+		if input.Config != nil {
+			ch.Config = normalizeConfig(*input.Config)
+		}
+		if input.Enabled != nil {
+			ch.Enabled = *input.Enabled
+		}
+
+		if input.Secret != nil || input.Config != nil {
+			if err := validateChannelCredentials(ch.Type, ch.Secret, ch.Config); err != nil {
+				return errResult(err.Error())
+			}
+		}
+		if input.URL != nil || input.Type != nil {
+			if err := validateChannelDestination(ctx, svc, ch.Type, ch.URL); err != nil {
+				return errResult("field=url: " + err.Error())
+			}
+		}
+
+		if err := svc.Channels.UpdateChannel(ctx, ch); err != nil {
+			return nil, nil, fmt.Errorf("update channel: %w", err)
+		}
+		ch.HasSecret = ch.Secret != ""
+
+		svc.broadcast(event.ChannelUpdated, ch)
+		return jsonResult(ch)
+	}
+}
+
+func deleteChannelHandler(svc *Services) gomcp.ToolHandlerFor[deleteChannelInput, any] {
+	return func(ctx context.Context, _ *gomcp.CallToolRequest, input deleteChannelInput) (*gomcp.CallToolResult, any, error) {
+		if svc.Channels == nil {
+			return errResult("channel store not available")
+		}
+		ch, err := svc.Channels.GetChannel(ctx, input.ID)
+		if err != nil {
+			return nil, nil, fmt.Errorf("delete channel: lookup: %w", err)
+		}
+		if ch == nil {
+			return errResult("channel not found")
+		}
+		if err := svc.Channels.DeleteChannel(ctx, input.ID); err != nil {
+			return nil, nil, fmt.Errorf("delete channel: %w", err)
+		}
+
+		svc.broadcast(event.ChannelDeleted, map[string]any{"id": input.ID})
+		return jsonResult(map[string]any{"deleted": true, "id": input.ID})
+	}
+}
+
+func testChannelHandler(svc *Services) gomcp.ToolHandlerFor[testChannelInput, any] {
+	return func(ctx context.Context, _ *gomcp.CallToolRequest, input testChannelInput) (*gomcp.CallToolResult, any, error) {
+		if svc.Channels == nil {
+			return errResult("channel store not available")
+		}
+		if svc.ChannelTester == nil {
+			return errResult("notifier not available")
+		}
+		ch, err := svc.Channels.GetChannel(ctx, input.ID)
+		if err != nil {
+			return nil, nil, fmt.Errorf("test channel: lookup: %w", err)
+		}
+		if ch == nil {
+			return errResult("channel not found")
+		}
+		if r, v, err := refuseChannelType(ch.Type); r != nil {
+			return r, v, err
+		}
+
+		statusCode, testErr := svc.ChannelTester.SendTestWebhook(ctx, ch)
+		if testErr != nil {
+			return jsonResult(map[string]any{"status": "failed", "error": testErr.Error()})
+		}
+		return jsonResult(map[string]any{"status": "delivered", "response_code": statusCode})
+	}
+}

--- a/internal/mcp/tools_channels_test.go
+++ b/internal/mcp/tools_channels_test.go
@@ -1,0 +1,385 @@
+// Copyright 2026 Benjamin Touchard (Kolapsis)
+//
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+// or a commercial license. You may not use this file except in compliance
+// with one of these licenses.
+//
+// AGPL-3.0: https://www.gnu.org/licenses/agpl-3.0.html
+// Commercial: See COMMERCIAL-LICENSE.md
+//
+// Source: https://github.com/kolapsis/maintenant
+
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/kolapsis/maintenant/internal/alert"
+	"github.com/kolapsis/maintenant/internal/event"
+	"github.com/kolapsis/maintenant/internal/extension"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- mutable channel store ---
+
+type mcpLiveChannelStore struct {
+	channels map[string]*alert.NotificationChannel
+	nextID   int64
+}
+
+func newMCPLiveChannelStore() *mcpLiveChannelStore {
+	return &mcpLiveChannelStore{channels: map[string]*alert.NotificationChannel{}}
+}
+
+func (m *mcpLiveChannelStore) InsertChannel(_ context.Context, ch *alert.NotificationChannel) (string, error) {
+	m.nextID++
+	id := strconv.FormatInt(m.nextID, 10)
+	cp := *ch
+	cp.ID = id
+	cp.CreatedAt = time.Now()
+	m.channels[id] = &cp
+	return id, nil
+}
+func (m *mcpLiveChannelStore) GetChannel(_ context.Context, id string) (*alert.NotificationChannel, error) {
+	ch, ok := m.channels[id]
+	if !ok {
+		return nil, nil
+	}
+	cp := *ch
+	return &cp, nil
+}
+func (m *mcpLiveChannelStore) ListChannels(_ context.Context) ([]*alert.NotificationChannel, error) {
+	out := make([]*alert.NotificationChannel, 0, len(m.channels))
+	for _, ch := range m.channels {
+		out = append(out, ch)
+	}
+	return out, nil
+}
+func (m *mcpLiveChannelStore) UpdateChannel(_ context.Context, ch *alert.NotificationChannel) error {
+	cp := *ch
+	m.channels[ch.ID] = &cp
+	return nil
+}
+func (m *mcpLiveChannelStore) DeleteChannel(_ context.Context, id string) error {
+	delete(m.channels, id)
+	return nil
+}
+func (m *mcpLiveChannelStore) GetChannelHealth(_ context.Context, _ string) (string, error) {
+	return "healthy", nil
+}
+func (m *mcpLiveChannelStore) InsertDelivery(_ context.Context, _ *alert.NotificationDelivery) (string, error) {
+	return "1", nil
+}
+func (m *mcpLiveChannelStore) UpdateDelivery(_ context.Context, _ *alert.NotificationDelivery) error {
+	return nil
+}
+func (m *mcpLiveChannelStore) ListDeliveriesByAlert(_ context.Context, _ string) ([]*alert.NotificationDelivery, error) {
+	return nil, nil
+}
+
+// --- notifier mock ---
+
+type mcpChannelTester struct {
+	code int
+	err  error
+	sent []string
+}
+
+func (m *mcpChannelTester) SendTestWebhook(_ context.Context, ch *alert.NotificationChannel) (int, error) {
+	m.sent = append(m.sent, ch.ID)
+	return m.code, m.err
+}
+
+// --- helpers ---
+
+func buildChannelServices() (*Services, *mcpLiveChannelStore, *[]string) {
+	cs := newMCPLiveChannelStore()
+	var events []string
+	svc := &Services{
+		Channels: cs,
+		// The SSRF guard resolves DNS; the destination rules have their own
+		// tests in internal/ssrf, so keep these off the network.
+		AllowPrivateWebhooks: true,
+		Broadcast: func(eventType string, _ any) {
+			events = append(events, eventType)
+		},
+	}
+	return svc, cs, &events
+}
+
+func parseChannelResult(t *testing.T, text string) map[string]any {
+	t.Helper()
+	var m map[string]any
+	require.NoError(t, json.Unmarshal([]byte(text), &m))
+	return m
+}
+
+// --- list_channels ---
+
+func TestListChannelsHandler_Empty(t *testing.T) {
+	svc, _, _ := buildChannelServices()
+
+	result, _, err := listChannelsHandler(svc)(context.Background(), nil, listChannelsInput{})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	m := parseChannelResult(t, textFromContent(t, result.Content))
+	assert.Empty(t, m["channels"])
+}
+
+func TestListChannelsHandler_NeverLeaksTheSecret(t *testing.T) {
+	withEdition(t, extension.Personal)
+	svc, cs, _ := buildChannelServices()
+	_, err := cs.InsertChannel(context.Background(), &alert.NotificationChannel{
+		Name: "telegram", Type: "telegram", URL: "123", Secret: "123456:SUPER-SECRET-TOKEN",
+	})
+	require.NoError(t, err)
+
+	result, _, err := listChannelsHandler(svc)(context.Background(), nil, listChannelsInput{})
+	require.NoError(t, err)
+	assert.NotContains(t, textFromContent(t, result.Content), "SUPER-SECRET-TOKEN")
+}
+
+// --- get_channel ---
+
+func TestGetChannelHandler_NotFound(t *testing.T) {
+	svc, _, _ := buildChannelServices()
+
+	result, _, err := getChannelHandler(svc)(context.Background(), nil, getChannelInput{ID: "404"})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+}
+
+func TestGetChannelHandler_ReportsHealthAndTriggers(t *testing.T) {
+	svc, cs, _ := buildChannelServices()
+	ts := newMCPTriggerStore()
+	svc.Triggers = ts
+	id, err := cs.InsertChannel(context.Background(), &alert.NotificationChannel{Name: "ops", Type: "webhook"})
+	require.NoError(t, err)
+
+	result, _, err := getChannelHandler(svc)(context.Background(), nil, getChannelInput{ID: id})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	m := parseChannelResult(t, textFromContent(t, result.Content))
+	assert.Equal(t, "healthy", m["health"])
+	assert.Equal(t, []any{}, m["triggers"])
+}
+
+// --- create_channel ---
+
+func TestCreateChannelHandler_DefaultsToWebhook(t *testing.T) {
+	svc, cs, events := buildChannelServices()
+
+	result, _, err := createChannelHandler(svc)(context.Background(), nil, createChannelInput{
+		Name: "ops", URL: "https://hooks.example.com/abc",
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	m := parseChannelResult(t, textFromContent(t, result.Content))
+	assert.Equal(t, "webhook", m["type"])
+	assert.Equal(t, true, m["enabled"], "a channel created without an explicit flag is live")
+	assert.Len(t, cs.channels, 1)
+	assert.Equal(t, []string{event.ChannelCreated}, *events)
+}
+
+func TestCreateChannelHandler_RequiresNameAndURL(t *testing.T) {
+	svc, _, _ := buildChannelServices()
+
+	result, _, err := createChannelHandler(svc)(context.Background(), nil, createChannelInput{URL: "https://x.example.com"})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+
+	result, _, err = createChannelHandler(svc)(context.Background(), nil, createChannelInput{Name: "ops"})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+}
+
+func TestCreateChannelHandler_RejectsInvalidEmail(t *testing.T) {
+	withEdition(t, extension.Personal)
+	svc, _, _ := buildChannelServices()
+
+	result, _, err := createChannelHandler(svc)(context.Background(), nil, createChannelInput{
+		Name: "mail", Type: "email", URL: "not-an-address",
+	})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+}
+
+func TestCreateChannelHandler_RefusesGatedTypeOnCommunity(t *testing.T) {
+	withEdition(t, extension.Community)
+	svc, cs, events := buildChannelServices()
+
+	result, _, err := createChannelHandler(svc)(context.Background(), nil, createChannelInput{
+		Name: "slack", Type: "slack", URL: "https://hooks.slack.com/services/x",
+	})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+
+	var payload struct {
+		Error           string `json:"error"`
+		Feature         string `json:"feature"`
+		RequiredEdition string `json:"required_edition"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(textFromContent(t, result.Content)), &payload))
+	assert.Equal(t, "edition_required", payload.Error)
+	assert.Equal(t, string(extension.CapSlack), payload.Feature)
+	assert.Equal(t, string(extension.Pro), payload.RequiredEdition)
+	assert.Empty(t, cs.channels)
+	assert.Empty(t, *events)
+}
+
+func TestCreateChannelHandler_TelegramNeedsAValidToken(t *testing.T) {
+	withEdition(t, extension.Personal)
+	svc, _, _ := buildChannelServices()
+
+	result, _, err := createChannelHandler(svc)(context.Background(), nil, createChannelInput{
+		Name: "tg", Type: "telegram", URL: "123456789", Secret: "not-a-token",
+	})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+}
+
+// --- update_channel ---
+
+func TestUpdateChannelHandler_KeepsTheStoredSecret(t *testing.T) {
+	withEdition(t, extension.Personal)
+	svc, cs, _ := buildChannelServices()
+	id, err := cs.InsertChannel(context.Background(), &alert.NotificationChannel{
+		Name: "tg", Type: "telegram", URL: "123", Secret: "123456:kept",
+	})
+	require.NoError(t, err)
+
+	name := "renamed"
+	result, _, err := updateChannelHandler(svc)(context.Background(), nil, updateChannelInput{ID: id, Name: &name})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	assert.Equal(t, "renamed", cs.channels[id].Name)
+	assert.Equal(t, "123456:kept", cs.channels[id].Secret)
+}
+
+func TestUpdateChannelHandler_RefusesToClearTheSecret(t *testing.T) {
+	withEdition(t, extension.Personal)
+	svc, cs, _ := buildChannelServices()
+	id, err := cs.InsertChannel(context.Background(), &alert.NotificationChannel{
+		Name: "tg", Type: "telegram", URL: "123", Secret: "123456:kept",
+	})
+	require.NoError(t, err)
+
+	empty := ""
+	result, _, err := updateChannelHandler(svc)(context.Background(), nil, updateChannelInput{ID: id, Secret: &empty})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Equal(t, "123456:kept", cs.channels[id].Secret)
+}
+
+// A downgraded instance must still be able to switch a gated channel off,
+// otherwise deleting it is the only way to stop the deliveries.
+func TestUpdateChannelHandler_DisablingAGatedChannelStaysAllowed(t *testing.T) {
+	svc, cs, _ := buildChannelServices()
+	id, err := cs.InsertChannel(context.Background(), &alert.NotificationChannel{
+		Name: "slack", Type: "slack", URL: "https://hooks.slack.com/services/x", Enabled: true,
+	})
+	require.NoError(t, err)
+
+	withEdition(t, extension.Community)
+	off := false
+	result, _, err := updateChannelHandler(svc)(context.Background(), nil, updateChannelInput{ID: id, Enabled: &off})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	assert.False(t, cs.channels[id].Enabled)
+
+	on := true
+	result, _, err = updateChannelHandler(svc)(context.Background(), nil, updateChannelInput{ID: id, Enabled: &on})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+}
+
+func TestUpdateChannelHandler_NotFound(t *testing.T) {
+	svc, _, _ := buildChannelServices()
+
+	name := "x"
+	result, _, err := updateChannelHandler(svc)(context.Background(), nil, updateChannelInput{ID: "404", Name: &name})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+}
+
+// --- delete_channel ---
+
+func TestDeleteChannelHandler(t *testing.T) {
+	svc, cs, events := buildChannelServices()
+	id, err := cs.InsertChannel(context.Background(), &alert.NotificationChannel{Name: "ops", Type: "webhook"})
+	require.NoError(t, err)
+
+	result, _, err := deleteChannelHandler(svc)(context.Background(), nil, deleteChannelInput{ID: id})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	assert.Empty(t, cs.channels)
+	assert.Equal(t, []string{event.ChannelDeleted}, *events)
+
+	result, _, err = deleteChannelHandler(svc)(context.Background(), nil, deleteChannelInput{ID: id})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+}
+
+// --- test_channel ---
+
+func TestTestChannelHandler_Delivered(t *testing.T) {
+	svc, cs, _ := buildChannelServices()
+	svc.ChannelTester = &mcpChannelTester{code: 204}
+	id, err := cs.InsertChannel(context.Background(), &alert.NotificationChannel{Name: "ops", Type: "webhook"})
+	require.NoError(t, err)
+
+	result, _, err := testChannelHandler(svc)(context.Background(), nil, testChannelInput{ID: id})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	m := parseChannelResult(t, textFromContent(t, result.Content))
+	assert.Equal(t, "delivered", m["status"])
+	assert.Equal(t, float64(204), m["response_code"])
+}
+
+func TestTestChannelHandler_ReportsTheFailure(t *testing.T) {
+	svc, cs, _ := buildChannelServices()
+	svc.ChannelTester = &mcpChannelTester{err: errors.New("connection refused")}
+	id, err := cs.InsertChannel(context.Background(), &alert.NotificationChannel{Name: "ops", Type: "webhook"})
+	require.NoError(t, err)
+
+	result, _, err := testChannelHandler(svc)(context.Background(), nil, testChannelInput{ID: id})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	m := parseChannelResult(t, textFromContent(t, result.Content))
+	assert.Equal(t, "failed", m["status"])
+	assert.Equal(t, "connection refused", m["error"])
+}
+
+func TestTestChannelHandler_RefusesAGatedTypeWithoutSending(t *testing.T) {
+	svc, cs, _ := buildChannelServices()
+	tester := &mcpChannelTester{code: 200}
+	svc.ChannelTester = tester
+	id, err := cs.InsertChannel(context.Background(), &alert.NotificationChannel{Name: "slack", Type: "slack"})
+	require.NoError(t, err)
+
+	withEdition(t, extension.Community)
+	result, _, err := testChannelHandler(svc)(context.Background(), nil, testChannelInput{ID: id})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Empty(t, tester.sent)
+}
+
+// The create_channel description names editions from the registry, so it can
+// never advertise a tier the gate does not enforce.
+func TestGatedChannelTypes_ReadsTheRegistry(t *testing.T) {
+	assert.Equal(t,
+		"email needs Personal, slack needs Pro, teams needs Pro, telegram needs Personal",
+		gatedChannelTypes())
+}

--- a/internal/mcp/tools_edition.go
+++ b/internal/mcp/tools_edition.go
@@ -1,0 +1,84 @@
+package mcp
+
+import (
+	"context"
+	"time"
+
+	"github.com/kolapsis/maintenant/internal/extension"
+	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func registerEditionTools(server *gomcp.Server, svc *Services) {
+	gomcp.AddTool(server, &gomcp.Tool{
+		Name:        "get_edition",
+		Description: "Report the running edition, which capability each edition opens, the quota usage of capped resources, and the resource-history windows. Call this before offering a feature that may be gated, instead of asking the operator which edition they run.",
+		Annotations: &gomcp.ToolAnnotations{ReadOnlyHint: true},
+	}, getEditionHandler(svc))
+}
+
+type getEditionInput struct{}
+
+func getEditionHandler(svc *Services) gomcp.ToolHandlerFor[getEditionInput, any] {
+	return func(ctx context.Context, _ *gomcp.CallToolRequest, _ getEditionInput) (*gomcp.CallToolResult, any, error) {
+		catalog := extension.Catalog()
+		features := make(map[string]bool, len(catalog))
+		featureEditions := make(map[string]string, len(catalog))
+		for c, min := range catalog {
+			features[string(c)] = extension.Allows(c)
+			featureEditions[string(c)] = string(min)
+		}
+
+		maxWindow := extension.MaxHistoryWindow()
+
+		return jsonResult(map[string]any{
+			"edition":          string(extension.CurrentEdition()),
+			"features":         features,
+			"feature_editions": featureEditions,
+			"quotas":           editionQuotas(ctx, svc),
+			"resource_history": map[string]any{
+				"max_window":         maxWindow.Name,
+				"max_window_seconds": int64(maxWindow.Duration / time.Second),
+				"windows":            extension.HistoryWindowCatalog(),
+			},
+		})
+	}
+}
+
+// editionQuotas reports usage and limit for every capped resource this server
+// can count. A limit of -1 means unlimited.
+func editionQuotas(ctx context.Context, svc *Services) map[string]any {
+	quotas := make(map[string]any, 4)
+
+	count := func(name string, r extension.Resource, used func() (int, error)) {
+		n, err := used()
+		if err != nil {
+			svc.logger().Error("failed to count resource for quota", "resource", string(r), "error", err)
+			n = 0
+		}
+		quotas[name] = map[string]any{"used": n, "limit": extension.Limit(r)}
+	}
+
+	if svc.Agents != nil {
+		count("agent_hosts", extension.ResourceAgentHosts, func() (int, error) {
+			agents, err := svc.Agents.List(ctx, "active")
+			return len(agents), err
+		})
+	}
+	if svc.Endpoints != nil {
+		count("endpoints", extension.ResourceEndpoints, func() (int, error) {
+			return svc.Endpoints.CountStandaloneEndpoints(ctx)
+		})
+	}
+	if svc.Heartbeats != nil {
+		count("heartbeats", extension.ResourceHeartbeats, func() (int, error) {
+			return svc.Heartbeats.CountActiveHeartbeats(ctx)
+		})
+	}
+	if svc.Certificates != nil {
+		count("certificates", extension.ResourceCertificates, func() (int, error) {
+			return svc.Certificates.CountStandaloneMonitors(ctx)
+		})
+	}
+
+	return quotas
+}

--- a/internal/mcp/tools_edition_test.go
+++ b/internal/mcp/tools_edition_test.go
@@ -1,0 +1,106 @@
+// Copyright 2026 Benjamin Touchard (Kolapsis)
+//
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+// or a commercial license. You may not use this file except in compliance
+// with one of these licenses.
+//
+// AGPL-3.0: https://www.gnu.org/licenses/agpl-3.0.html
+// Commercial: See COMMERCIAL-LICENSE.md
+//
+// Source: https://github.com/kolapsis/maintenant
+
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/kolapsis/maintenant/internal/agent"
+	"github.com/kolapsis/maintenant/internal/extension"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func callGetEdition(t *testing.T, svc *Services) map[string]any {
+	t.Helper()
+	result, _, err := getEditionHandler(svc)(context.Background(), nil, getEditionInput{})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	var m map[string]any
+	require.NoError(t, json.Unmarshal([]byte(textFromContent(t, result.Content)), &m))
+	return m
+}
+
+// The tool reports the running edition rather than making the caller ask.
+func TestGetEditionHandler_ReportsTheRunningEdition(t *testing.T) {
+	for _, e := range []extension.Edition{extension.Community, extension.Personal, extension.Pro} {
+		t.Run(string(e), func(t *testing.T) {
+			withEdition(t, e)
+			m := callGetEdition(t, &Services{})
+			assert.Equal(t, string(e), m["edition"])
+		})
+	}
+}
+
+// features and feature_editions are projected from the same registry the gate
+// reads, so the tool can never advertise a capability the gate refuses.
+func TestGetEditionHandler_FeaturesMatchTheRegistry(t *testing.T) {
+	withEdition(t, extension.Personal)
+	m := callGetEdition(t, &Services{})
+
+	features, ok := m["features"].(map[string]any)
+	require.True(t, ok)
+	editions, ok := m["feature_editions"].(map[string]any)
+	require.True(t, ok)
+
+	catalog := extension.Catalog()
+	require.Len(t, features, len(catalog))
+	for c, min := range catalog {
+		assert.Equal(t, extension.Allows(c), features[string(c)], "feature %q", c)
+		assert.Equal(t, string(min), editions[string(c)], "feature edition %q", c)
+	}
+}
+
+func TestGetEditionHandler_ResourceHistoryWindow(t *testing.T) {
+	withEdition(t, extension.Pro)
+	m := callGetEdition(t, &Services{})
+
+	history, ok := m["resource_history"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, extension.MaxHistoryWindow().Name, history["max_window"])
+	assert.NotEmpty(t, history["windows"])
+}
+
+// Quotas are reported for the resources this server can count, and skipped for
+// the ones it has no store for — never guessed at zero.
+func TestGetEditionHandler_QuotasOnlyForCountableResources(t *testing.T) {
+	withEdition(t, extension.Community)
+	m := callGetEdition(t, &Services{})
+
+	quotas, ok := m["quotas"].(map[string]any)
+	require.True(t, ok)
+	assert.Empty(t, quotas)
+}
+
+func TestGetEditionHandler_QuotaCarriesUsageAndLimit(t *testing.T) {
+	withEdition(t, extension.Community)
+	svc := &Services{Agents: &mcpEditionAgentLister{count: 3}}
+
+	quotas := callGetEdition(t, svc)["quotas"].(map[string]any)
+	agents, ok := quotas["agent_hosts"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, float64(3), agents["used"])
+	assert.Equal(t, float64(extension.Limit(extension.ResourceAgentHosts)), agents["limit"])
+}
+
+type mcpEditionAgentLister struct{ count int }
+
+func (m *mcpEditionAgentLister) List(_ context.Context, _ string) ([]*agent.Agent, error) {
+	out := make([]*agent.Agent, m.count)
+	for i := range out {
+		out[i] = &agent.Agent{}
+	}
+	return out, nil
+}


### PR DESCRIPTION
An assistant driving the MCP server could create an alert trigger but had no way
to obtain a channel id, and had to ask the operator which edition was running.

**Channels** — `list_channels`, `get_channel`, `create_channel`,
`update_channel`, `delete_channel`, `test_channel`, mirroring the REST
validation rules: SSRF and HTTPS guards on webhooks, address parsing for email,
credentials for Telegram, an absent secret keeps the stored one, and disabling a
gated channel stays open to a downgraded instance. Secrets are never returned.

**Edition** — `get_edition` reports the running edition, the capability each
edition opens, quota usage and the history windows. Channel-type gating moves
into `extension.ChannelCapability` so REST and MCP read one registry.

MCP writes now broadcast on the SSE brokers, so a channel created from a chat
appears in an open interface without a reload.

**Container down** — a container that stops and stays stopped raised nothing:
`restart_loop` needs it to come back, `health_unhealthy` needs a `HEALTHCHECK`.
`container_down` fires past `MAINTENANT_CONTAINER_DOWN_AFTER` and resolves on
its own. State and firing alerts are read from the store each pass, so downtime
spanning a restart is caught and nothing is re-emitted. Exit code 0 is recorded
as `completed` and never counts as down. Unset by default, since enabling it
alerts retroactively on every container already stopped; an unparseable value
stops startup rather than leaving the check silently off.
