### PR TITLE
fix(endpoints): stop replaying the probe request to an untrusted peer

### DIFF
--- a/docs/features/certificates.md
+++ b/docs/features/certificates.md
@@ -91,6 +91,8 @@ A host that answers normally but presents a certificate maintenant cannot valida
 
 The certificate is still collected in this state, so expiry monitoring keeps working on internal-PKI hosts even before you configure the CA.
 
+To tell "degraded" from "down" after a certificate is rejected, the endpoint probe only completes a TLS handshake to capture the chain — it never resends the HTTP request, so headers and URL secrets never reach a peer whose identity was not verified. A degraded result therefore carries no HTTP status: the application behind the certificate is never actually reached.
+
 A host that is genuinely unreachable — timeout, DNS failure, connection refused — remains **down**.
 
 ---

--- a/internal/certificate/checker.go
+++ b/internal/certificate/checker.go
@@ -1,10 +1,9 @@
 package certificate
 
 import (
-	"crypto/tls"
+	"context"
 	"crypto/x509"
 	"fmt"
-	"net"
 	"strings"
 	"time"
 
@@ -55,23 +54,13 @@ func CheckCertificate(hostname string, port int, serverName string, timeout time
 		validationName = hostname
 	}
 
-	// Connect with InsecureSkipVerify so we can inspect even invalid certs
-	dialer := &net.Dialer{Timeout: timeout}
-	conn, err := tls.DialWithDialer(dialer, "tcp", addr, &tls.Config{
-		InsecureSkipVerify: true, // #nosec G402 -- inspection dial: invalid certs must be retrieved to be reported; chain is validated manually below.
-		ServerName:         validationName,
-		MinVersion:         tls.VersionTLS10, // inspection dial: reach legacy hosts down to TLS 1.0
-	})
+	state, err := trust.DialInspect(context.Background(), addr, validationName, timeout)
 	if err != nil {
 		return &CheckCertificateResult{
 			Error: classifyTLSError(err),
 		}
 	}
-	defer func(conn *tls.Conn) {
-		_ = conn.Close()
-	}(conn)
 
-	state := conn.ConnectionState()
 	if len(state.PeerCertificates) == 0 {
 		return &CheckCertificateResult{
 			Error: "no TLS certificate presented",

--- a/internal/endpoint/checker_http.go
+++ b/internal/endpoint/checker_http.go
@@ -67,36 +67,35 @@ func CheckHTTP(ctx context.Context, ep *Endpoint, logger interface{ Warn(string,
 
 	if err != nil {
 		reason, isTrustFailure := trustFailureReason(err)
-		if !isTrustFailure {
+		if !cfg.TLSVerify || !isTrustFailure {
 			result.ResponseTimeMs = time.Since(start).Milliseconds()
 			result.ErrorMessage = fmt.Sprintf("request failed: %v", err)
 			return result
 		}
 
-		// The certificate was rejected, but that says nothing about whether the
-		// host is serving. Retry once without verification purely to find out:
-		// a host behind an internal PKI that answers is degraded, not down. The
-		// retry never yields "up" — it only tells the two apart, and it hands
-		// back the chain so expiry monitoring keeps working on these hosts.
-		insecure := newHTTPClient(cfg, timeout, true)
-		defer insecure.CloseIdleConnections()
+		// A bare handshake tells degraded from down and yields the chain; the
+		// request is never resent, so its secrets never reach an unverified peer.
+		result.ResponseTimeMs = time.Since(start).Milliseconds()
 
-		retryReq, reqErr := newRequest()
-		if reqErr != nil {
-			result.ResponseTimeMs = time.Since(start).Milliseconds()
-			result.ErrorMessage = fmt.Sprintf("create request: %v", reqErr)
+		addr, host, addrErr := hostPort(ep.Target)
+		if addrErr != nil {
+			result.ErrorMessage = fmt.Sprintf("request failed: %v", err)
 			return result
 		}
 
-		resp, err = insecure.Do(retryReq)
-		if err != nil {
-			result.ResponseTimeMs = time.Since(start).Milliseconds()
+		state, dialErr := trust.DialInspect(ctx, addr, host, timeout)
+		if dialErr != nil {
 			result.ErrorMessage = fmt.Sprintf("request failed: %v", err)
 			return result
 		}
 
 		result.Degraded = true
 		result.DegradedReason = reason
+		result.Success = true
+		result.TLSPeerCertificates = state.PeerCertificates
+		result.TLSOCSPResponse = state.OCSPResponse
+		result.ErrorMessage = reason
+		return result
 	}
 
 	result.ResponseTimeMs = time.Since(start).Milliseconds()
@@ -132,8 +131,8 @@ func CheckHTTP(ctx context.Context, ep *Endpoint, logger interface{ Warn(string,
 	return result
 }
 
-// newHTTPClient builds the probe client. skipVerify is used both for the
-// per-endpoint opt-out and for the diagnostic retry after a rejected certificate.
+// newHTTPClient builds the probe client. skipVerify is the per-endpoint
+// TLS-verify opt-out.
 func newHTTPClient(cfg EndpointConfig, timeout time.Duration, skipVerify bool) *http.Client {
 	maxRedirects := cfg.MaxRedirects
 	if maxRedirects < 0 {
@@ -143,7 +142,7 @@ func newHTTPClient(cfg EndpointConfig, timeout time.Duration, skipVerify bool) *
 	return &http.Client{
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: skipVerify, // #nosec G402 -- per-endpoint opt-out, or the diagnostic retry that classifies a rejected certificate.
+				InsecureSkipVerify: skipVerify, // #nosec G402 -- per-endpoint opt-out (maintenant.endpoint.http.tls-verify=false).
 				MinVersion:         tls.VersionTLS12,
 				RootCAs:            trust.Pool(), // nil unless an extra CA was configured: system store
 			},
@@ -158,6 +157,26 @@ func newHTTPClient(cfg EndpointConfig, timeout time.Duration, skipVerify bool) *
 			return nil
 		},
 	}
+}
+
+// hostPort splits a target URL into a dial address (port 443 by default) and the name to validate.
+func hostPort(target string) (addr, host string, err error) {
+	u, err := url.Parse(target)
+	if err != nil {
+		return "", "", err
+	}
+
+	host = u.Hostname()
+	if host == "" {
+		return "", "", fmt.Errorf("no host in target %q", target)
+	}
+
+	port := u.Port()
+	if port == "" {
+		port = "443"
+	}
+
+	return net.JoinHostPort(host, port), host, nil
 }
 
 // trustFailureReason reports whether err is the peer's certificate being

--- a/internal/endpoint/checker_http_tls_test.go
+++ b/internal/endpoint/checker_http_tls_test.go
@@ -17,10 +17,13 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"errors"
+	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -40,7 +43,8 @@ func httpEndpoint(target string) *Endpoint {
 
 // Issue #36: a host answering over a certificate signed by an unknown authority
 // is not down. It must report as degraded, keep counting as a success, and still
-// surrender its certificate chain so expiry monitoring keeps working.
+// surrender its certificate chain so expiry monitoring keeps working. The probe
+// never gets far enough to learn an HTTP status: it stops at the handshake.
 func TestCheckHTTP_UntrustedCertificateIsDegradedNotDown(t *testing.T) {
 	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -56,8 +60,7 @@ func TestCheckHTTP_UntrustedCertificateIsDegradedNotDown(t *testing.T) {
 	assert.Contains(t, result.DegradedReason, "unknown authority")
 	assert.Contains(t, result.ErrorMessage, "unknown authority",
 		"the reason must reach the UI through last_error")
-	require.NotNil(t, result.HTTPStatus)
-	assert.Equal(t, http.StatusOK, *result.HTTPStatus)
+	assert.Nil(t, result.HTTPStatus, "a handshake-only probe never learns an HTTP status")
 	assert.NotEmpty(t, result.TLSPeerCertificates,
 		"the chain must still be captured, or expiry monitoring silently stops for these hosts")
 }
@@ -97,9 +100,10 @@ func TestCheckHTTP_UnreachableHostStaysDown(t *testing.T) {
 	assert.Contains(t, result.ErrorMessage, "request failed")
 }
 
-// An untrusted certificate on a host that also answers badly is still down: the
-// status check governs, and the trust problem is reported alongside it.
-func TestCheckHTTP_UntrustedAndBadStatusIsDown(t *testing.T) {
+// An untrusted certificate is reported as degraded regardless of what the
+// application behind it would have answered: the request is never sent, so a
+// 500 the handler is ready to return is never observed.
+func TestCheckHTTP_UntrustedCertificate_AppStatusNeverObserved(t *testing.T) {
 	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 	}))
@@ -107,10 +111,10 @@ func TestCheckHTTP_UntrustedAndBadStatusIsDown(t *testing.T) {
 
 	result := CheckHTTP(context.Background(), httpEndpoint(srv.URL), nil)
 
-	assert.False(t, result.Success, "a 500 is a failure regardless of the certificate")
-	assert.Contains(t, result.ErrorMessage, "unexpected status 500")
-	assert.Contains(t, result.ErrorMessage, "unknown authority",
-		"both problems must be visible, not just the first")
+	assert.True(t, result.Success, "the handshake succeeded; the never-sent request cannot fail it")
+	assert.True(t, result.Degraded)
+	assert.Nil(t, result.HTTPStatus)
+	assert.Contains(t, result.ErrorMessage, "unknown authority")
 }
 
 // With verification switched off per endpoint, nothing is degraded.
@@ -153,6 +157,122 @@ func TestTrustFailureReason(t *testing.T) {
 
 	_, ok = trustFailureReason(nil)
 	assert.False(t, ok)
+}
+
+// recordingServer starts a TLS test server that records every call it
+// receives, along with the headers it saw.
+func recordingServer(t *testing.T) (*httptest.Server, func() int, func() []http.Header) {
+	t.Helper()
+
+	var mu sync.Mutex
+	var calls int
+	var headers []http.Header
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		calls++
+		headers = append(headers, r.Header.Clone())
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	callCount := func() int {
+		mu.Lock()
+		defer mu.Unlock()
+		return calls
+	}
+	seenHeaders := func() []http.Header {
+		mu.Lock()
+		defer mu.Unlock()
+		return headers
+	}
+	return srv, callCount, seenHeaders
+}
+
+// A rejected certificate must never be followed by the actual request: the
+// secrets it carries (Authorization, API keys, the URL itself) must not reach
+// a peer whose identity was never verified.
+func TestCheckHTTP_TrustFailure_NeverSendsTheRequest(t *testing.T) {
+	srv, callCount, _ := recordingServer(t)
+
+	ep := httpEndpoint(srv.URL + "/probe?token=s")
+	ep.Config.TLSVerify = true
+	ep.Config.Headers = map[string]string{
+		"Authorization": "Bearer audit-fixture",
+		"X-Api-Key":     "k",
+	}
+
+	result := CheckHTTP(context.Background(), ep, nil)
+
+	assert.Equal(t, 0, callCount(), "the request must never be sent to an unverified peer")
+	assert.True(t, result.Degraded)
+	assert.True(t, result.Success)
+	assert.Nil(t, result.HTTPStatus, "a handshake-only probe carries no HTTP status")
+	assert.NotEmpty(t, result.TLSPeerCertificates)
+	assert.NotEmpty(t, result.DegradedReason)
+}
+
+// Same guarantee for a method with a body-bearing semantics: it must not be
+// replayed either.
+func TestCheckHTTP_TrustFailure_POSTIsNotReplayedEither(t *testing.T) {
+	srv, callCount, _ := recordingServer(t)
+
+	ep := httpEndpoint(srv.URL + "/probe?token=s")
+	ep.Config.TLSVerify = true
+	ep.Config.Method = "POST"
+	ep.Config.Headers = map[string]string{
+		"Authorization": "Bearer audit-fixture",
+	}
+
+	CheckHTTP(context.Background(), ep, nil)
+
+	assert.Equal(t, 0, callCount())
+}
+
+// With verification switched off per endpoint, the request is sent as before
+// (once), headers included.
+func TestCheckHTTP_TLSVerifyOff_SendsHeadersOnce(t *testing.T) {
+	srv, callCount, seenHeaders := recordingServer(t)
+
+	ep := httpEndpoint(srv.URL)
+	ep.Config.TLSVerify = false
+	ep.Config.Headers = map[string]string{
+		"Authorization": "Bearer audit-fixture",
+	}
+
+	result := CheckHTTP(context.Background(), ep, nil)
+
+	require.True(t, result.Success)
+	assert.Equal(t, 1, callCount())
+	require.Len(t, seenHeaders(), 1)
+	assert.Equal(t, "Bearer audit-fixture", seenHeaders()[0].Get("Authorization"))
+}
+
+// A host whose handshake fails outright (no certificate to report at all) is
+// down, not degraded: the no-retry path must not paper over it.
+func TestCheckHTTP_TrustFailureThenNoTLS_IsDown(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer func() { _ = ln.Close() }()
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			_ = conn.Close()
+		}
+	}()
+
+	ep := httpEndpoint(fmt.Sprintf("https://%s/", ln.Addr().String()))
+
+	result := CheckHTTP(context.Background(), ep, nil)
+
+	assert.False(t, result.Success)
+	assert.False(t, result.Degraded)
+	assert.NotEmpty(t, result.ErrorMessage)
 }
 
 func TestCheckHTTP_DegradedResolvesToDegradedStatus(t *testing.T) {

--- a/internal/trust/dialinspect.go
+++ b/internal/trust/dialinspect.go
@@ -1,0 +1,45 @@
+// Copyright 2026 Benjamin Touchard (Kolapsis)
+//
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+// or a commercial license. You may not use this file except in compliance
+// with one of these licenses.
+//
+// AGPL-3.0: https://www.gnu.org/licenses/agpl-3.0.html
+// Commercial: See COMMERCIAL-LICENSE.md
+//
+// Source: https://github.com/kolapsis/maintenant
+
+package trust
+
+import (
+	"context"
+	"crypto/tls"
+	"net"
+	"time"
+)
+
+// DialInspect opens a TLS connection that accepts any certificate, so a chain
+// can be reported even when it is invalid, and returns its state.
+// DialInspect completes a TLS handshake that accepts any certificate and returns the connection state, without sending a single application byte.
+func DialInspect(ctx context.Context, addr, serverName string, timeout time.Duration) (tls.ConnectionState, error) {
+	dialer := &net.Dialer{Timeout: timeout}
+	conn, err := dialer.DialContext(ctx, "tcp", addr)
+	if err != nil {
+		return tls.ConnectionState{}, err
+	}
+
+	tlsConn := tls.Client(conn, &tls.Config{
+		InsecureSkipVerify: true, // #nosec G402 -- inspection dial: invalid certs must be retrieved to be reported; chain is validated by the caller.
+		ServerName:         serverName,
+		MinVersion:         tls.VersionTLS10, // inspection dial: reach legacy hosts down to TLS 1.0
+	})
+
+	if err := tlsConn.HandshakeContext(ctx); err != nil {
+		_ = conn.Close()
+		return tls.ConnectionState{}, err
+	}
+
+	state := tlsConn.ConnectionState()
+	_ = conn.Close()
+	return state, nil
+}

--- a/internal/trust/dialinspect_test.go
+++ b/internal/trust/dialinspect_test.go
@@ -1,0 +1,66 @@
+// Copyright 2026 Benjamin Touchard (Kolapsis)
+//
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+// or a commercial license. You may not use this file except in compliance
+// with one of these licenses.
+//
+// AGPL-3.0: https://www.gnu.org/licenses/agpl-3.0.html
+// Commercial: See COMMERCIAL-LICENSE.md
+//
+// Source: https://github.com/kolapsis/maintenant
+
+package trust
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDialInspect_ReturnsPeerCertificates(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	addr := strings.TrimPrefix(srv.URL, "https://")
+
+	state, err := DialInspect(context.Background(), addr, "example.com", time.Second)
+
+	require.NoError(t, err)
+	assert.NotEmpty(t, state.PeerCertificates, "the untrusted certificate must still be returned")
+}
+
+func TestDialInspect_ClosedPortIsAnError(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := ln.Addr().String()
+	require.NoError(t, ln.Close()) // nothing listening any more
+
+	_, err = DialInspect(context.Background(), addr, "example.com", time.Second)
+
+	assert.Error(t, err)
+}
+
+func TestDialInspect_RespectsCancelledContext(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	addr := strings.TrimPrefix(srv.URL, "https://")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := DialInspect(ctx, addr, "example.com", time.Second)
+
+	assert.Error(t, err)
+}


### PR DESCRIPTION
A rejected certificate says nothing about whether the host is serving, so the
HTTPS probe retried once without verification to tell degraded from down. That
retry rebuilt the whole request: the configured method, the target URL with its
query string, and every header. An endpoint carrying an `Authorization` header,
a cookie or an API key handed it to whoever presented the certificate.

Complete a bare TLS handshake instead. It answers the same question and still
yields the chain and the OCSP staple that certificate monitoring needs, without
a single application byte reaching a peer whose identity was not verified. A
degraded result therefore carries no HTTP status: the status matcher never
runs, because the application was never reached.

The handshake lives in `internal/trust`, which the endpoint probe and the
certificate checker now share, so the inspection dial has one policy rather
than two. The per-endpoint `tls-verify` opt-out is unchanged: an operator who
asked for it still gets the request sent on the first try.

Tests assert that a server presenting an untrusted certificate never sees the
request at all — headers, query-string secret, GET and POST alike.

Found by an external security audit of `2c6654c` (finding S-01).
