### PR TITLE
fix(multihost): bind container identity to the agent that reports it

### DIFF
--- a/internal/agent/collector.go
+++ b/internal/agent/collector.go
@@ -93,25 +93,26 @@ type labeledDiscoverer interface {
 }
 
 // syncInventory pushes a full snapshot of every container the runtime currently
-// knows about. The live event stream only carries state transitions, so without
-// this containers already running at connect time would never reach the server;
-// resent periodically, it also lets the server retire containers whose removal
-// we missed (destroy events are not streamed).
-//
-// Discovery failure yields no message at all: an empty snapshot would tell the
-// server this host has no containers and archive the lot.
+// knows about, marked complete so the server can reconcile away what it no
+// longer sees. Discovery failure yields no message at all.
 func syncInventory(ctx context.Context, id *Identity, rt runtime.Runtime, stream *PushStream, logger *slog.Logger) error {
 	entry := func(c *cmodel.Container, labels map[string]string) *agentpb.ContainerEvent {
 		state, ok := containerStateToProto(c.State)
 		if !ok {
 			return nil
 		}
+		health := ""
+		if c.HealthStatus != nil {
+			health = string(*c.HealthStatus)
+		}
 		return &agentpb.ContainerEvent{
-			ContainerId: c.ExternalID,
-			Name:        c.Name,
-			Image:       c.Image,
-			State:       state,
-			Labels:      labels,
+			ContainerId:    c.ExternalID,
+			Name:           c.Name,
+			Image:          c.Image,
+			State:          state,
+			Labels:         labels,
+			HealthStatus:   health,
+			HasHealthCheck: c.HasHealthCheck,
 		}
 	}
 
@@ -140,19 +141,22 @@ func syncInventory(ctx context.Context, id *Identity, rt runtime.Runtime, stream
 		}
 	}
 
-	if len(entries) == 0 {
-		return nil
-	}
-
-	if err := stream.Send(&agentpb.AgentEvent{
-		AgentId:    id.AgentID,
-		EventId:    uuid.NewString(),
-		ObservedAt: timestamppb.Now(),
-		Body:       &agentpb.AgentEvent_Inventory{Inventory: &agentpb.ContainerInventory{Containers: entries}},
-	}); err != nil {
+	if err := stream.Send(inventoryEvent(id.AgentID, entries)); err != nil {
 		return fmt.Errorf("send inventory: %w", err)
 	}
 	return nil
+}
+
+func inventoryEvent(agentID string, entries []*agentpb.ContainerEvent) *agentpb.AgentEvent {
+	return &agentpb.AgentEvent{
+		AgentId:    agentID,
+		EventId:    uuid.NewString(),
+		ObservedAt: timestamppb.Now(),
+		Body: &agentpb.AgentEvent_Inventory{Inventory: &agentpb.ContainerInventory{
+			Containers: entries,
+			Complete:   true,
+		}},
+	}
 }
 
 // streamInventory resends the full container inventory on a fixed cadence so the
@@ -331,9 +335,33 @@ func collectResourceSnapshots(ctx context.Context, id *Identity, rt runtime.Runt
 	return nil
 }
 
-// runtimeEventToProto converts a runtime.RuntimeEvent to a ContainerEvent proto.
-// Returns nil for event types that should not be pushed (e.g. destroy, health_status).
+// runtimeEventToProto converts a runtime.RuntimeEvent to a ContainerEvent proto,
+// or nil for an action the server has no use for.
 func runtimeEventToProto(ev runtime.RuntimeEvent) *agentpb.ContainerEvent {
+	switch ev.Action {
+	case "destroy":
+		// EXITED, not UNSPECIFIED: a server that predates Destroyed maps every
+		// event to a state action, and UNSPECIFIED would read as a restart.
+		return &agentpb.ContainerEvent{
+			ContainerId: ev.ExternalID,
+			Name:        ev.Name,
+			Image:       ev.Image,
+			State:       agentpb.ContainerState_CONTAINER_STATE_EXITED,
+			Labels:      ev.Labels,
+			Destroyed:   true,
+		}
+	case "health_status":
+		return &agentpb.ContainerEvent{
+			ContainerId:    ev.ExternalID,
+			Name:           ev.Name,
+			Image:          ev.Image,
+			State:          agentpb.ContainerState_CONTAINER_STATE_UNSPECIFIED,
+			Labels:         ev.Labels,
+			HealthStatus:   ev.HealthStatus,
+			HasHealthCheck: true,
+		}
+	}
+
 	state, ok := actionToContainerState(ev.Action)
 	if !ok {
 		return nil

--- a/internal/agent/collector_test.go
+++ b/internal/agent/collector_test.go
@@ -38,7 +38,43 @@ func TestRuntimeEventToProto_MapsImageAndState(t *testing.T) {
 }
 
 func TestRuntimeEventToProto_NilForUnmappedAction(t *testing.T) {
-	assert.Nil(t, runtimeEventToProto(runtime.RuntimeEvent{Action: "health_status"}))
+	assert.Nil(t, runtimeEventToProto(runtime.RuntimeEvent{Action: "exec_start"}))
+}
+
+func TestRuntimeEventToProto_HealthStatus(t *testing.T) {
+	out := runtimeEventToProto(runtime.RuntimeEvent{
+		Action:       "health_status",
+		ExternalID:   "c1",
+		Name:         "demo",
+		HealthStatus: "unhealthy",
+	})
+	require.NotNil(t, out)
+	assert.Equal(t, agentpb.ContainerState_CONTAINER_STATE_UNSPECIFIED, out.State)
+	assert.Equal(t, "unhealthy", out.HealthStatus)
+	assert.True(t, out.HasHealthCheck)
+	assert.False(t, out.Destroyed)
+}
+
+func TestRuntimeEventToProto_Destroy(t *testing.T) {
+	out := runtimeEventToProto(runtime.RuntimeEvent{
+		Action:     "destroy",
+		ExternalID: "c1",
+		Name:       "demo",
+		Image:      "adminer:latest",
+	})
+	require.NotNil(t, out)
+	assert.True(t, out.Destroyed)
+	assert.Equal(t, agentpb.ContainerState_CONTAINER_STATE_EXITED, out.State,
+		"a server without the destroyed field must read this as a stop, not a start")
+	assert.Equal(t, "c1", out.ContainerId)
+}
+
+func TestSyncInventory_EmptySnapshotIsSentComplete(t *testing.T) {
+	ev := inventoryEvent("agent-1", nil)
+	inv := ev.GetInventory()
+	require.NotNil(t, inv)
+	assert.Empty(t, inv.GetContainers())
+	assert.True(t, inv.GetComplete(), "a successful discovery that found nothing is still complete")
 }
 
 func TestContainerStateToProto(t *testing.T) {

--- a/internal/agentpb/ingest.pb.go
+++ b/internal/agentpb/ingest.pb.go
@@ -1438,6 +1438,11 @@ type ContainerEvent struct {
 	StatusMessage string                 `protobuf:"bytes,6,opt,name=status_message,json=statusMessage,proto3" json:"status_message,omitempty"`
 	StartedAt     *timestamppb.Timestamp `protobuf:"bytes,7,opt,name=started_at,json=startedAt,proto3" json:"started_at,omitempty"`
 	Labels        map[string]string      `protobuf:"bytes,8,rep,name=labels,proto3" json:"labels,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	// Docker healthcheck state ("healthy", "unhealthy", "starting"); empty when the container has no healthcheck.
+	HealthStatus   string `protobuf:"bytes,9,opt,name=health_status,json=healthStatus,proto3" json:"health_status,omitempty"`
+	HasHealthCheck bool   `protobuf:"varint,10,opt,name=has_health_check,json=hasHealthCheck,proto3" json:"has_health_check,omitempty"`
+	// Set when the container was removed from the host; state is then EXITED so an older server treats it as a stop.
+	Destroyed     bool `protobuf:"varint,11,opt,name=destroyed,proto3" json:"destroyed,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1528,6 +1533,27 @@ func (x *ContainerEvent) GetLabels() map[string]string {
 	return nil
 }
 
+func (x *ContainerEvent) GetHealthStatus() string {
+	if x != nil {
+		return x.HealthStatus
+	}
+	return ""
+}
+
+func (x *ContainerEvent) GetHasHealthCheck() bool {
+	if x != nil {
+		return x.HasHealthCheck
+	}
+	return false
+}
+
+func (x *ContainerEvent) GetDestroyed() bool {
+	if x != nil {
+		return x.Destroyed
+	}
+	return false
+}
+
 // A full snapshot of every container the agent's runtime knows about, sent on
 // connect and periodically thereafter. The server reconciles it against the
 // rows it holds for this agent: containers present are un-archived, containers
@@ -1535,12 +1561,14 @@ func (x *ContainerEvent) GetLabels() map[string]string {
 // archived rather than deleted — containers carry history (transitions,
 // uptime, CVEs) that must outlive their removal.
 //
-// An inventory with no entries is never sent and never acted upon: the agent
-// skips it when discovery fails, so an empty snapshot could only mean "I could
-// not look", which the protocol cannot distinguish from "this host is empty".
+// `complete` disambiguates an empty snapshot: true means discovery succeeded
+// and the host genuinely has no containers, false means discovery failed and
+// the inventory must not be acted upon.
 type ContainerInventory struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Containers    []*ContainerEvent      `protobuf:"bytes,1,rep,name=containers,proto3" json:"containers,omitempty"`
+	state      protoimpl.MessageState `protogen:"open.v1"`
+	Containers []*ContainerEvent      `protobuf:"bytes,1,rep,name=containers,proto3" json:"containers,omitempty"`
+	// True when discovery succeeded; an empty complete snapshot is authoritative and retires every container of the agent.
+	Complete      bool `protobuf:"varint,2,opt,name=complete,proto3" json:"complete,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1580,6 +1608,13 @@ func (x *ContainerInventory) GetContainers() []*ContainerEvent {
 		return x.Containers
 	}
 	return nil
+}
+
+func (x *ContainerInventory) GetComplete() bool {
+	if x != nil {
+		return x.Complete
+	}
+	return false
 }
 
 type EndpointEvent struct {
@@ -3086,7 +3121,7 @@ const file_proto_ingest_proto_rawDesc = "" +
 	"kubernetes\x18\x10 \x01(\v2'.maintenant.agent.v1.KubernetesTopologyH\x00R\n" +
 	"kubernetes\x12G\n" +
 	"\tinventory\x18\x11 \x01(\v2'.maintenant.agent.v1.ContainerInventoryH\x00R\tinventoryB\x06\n" +
-	"\x04body\"\xa1\x03\n" +
+	"\x04body\"\x8e\x04\n" +
 	"\x0eContainerEvent\x12!\n" +
 	"\fcontainer_id\x18\x01 \x01(\tR\vcontainerId\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x14\n" +
@@ -3096,14 +3131,19 @@ const file_proto_ingest_proto_rawDesc = "" +
 	"\x0estatus_message\x18\x06 \x01(\tR\rstatusMessage\x129\n" +
 	"\n" +
 	"started_at\x18\a \x01(\v2\x1a.google.protobuf.TimestampR\tstartedAt\x12G\n" +
-	"\x06labels\x18\b \x03(\v2/.maintenant.agent.v1.ContainerEvent.LabelsEntryR\x06labels\x1a9\n" +
+	"\x06labels\x18\b \x03(\v2/.maintenant.agent.v1.ContainerEvent.LabelsEntryR\x06labels\x12#\n" +
+	"\rhealth_status\x18\t \x01(\tR\fhealthStatus\x12(\n" +
+	"\x10has_health_check\x18\n" +
+	" \x01(\bR\x0ehasHealthCheck\x12\x1c\n" +
+	"\tdestroyed\x18\v \x01(\bR\tdestroyed\x1a9\n" +
 	"\vLabelsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"Y\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"u\n" +
 	"\x12ContainerInventory\x12C\n" +
 	"\n" +
 	"containers\x18\x01 \x03(\v2#.maintenant.agent.v1.ContainerEventR\n" +
-	"containers\"\xe4\x01\n" +
+	"containers\x12\x1a\n" +
+	"\bcomplete\x18\x02 \x01(\bR\bcomplete\"\xe4\x01\n" +
 	"\rEndpointEvent\x12\x1f\n" +
 	"\vendpoint_id\x18\x01 \x01(\tR\n" +
 	"endpointId\x12\x10\n" +

--- a/internal/agentserver/dispatcher.go
+++ b/internal/agentserver/dispatcher.go
@@ -110,7 +110,11 @@ func (d *Dispatcher) Dispatch(ctx context.Context, agentID string, evt *agentpb.
 			}
 		}
 		if d.deps.LabelSync != nil {
-			d.deps.LabelSync(ctx, agentID, body.Container.GetName(), body.Container.GetContainerId(), body.Container.GetLabels())
+			labels := body.Container.GetLabels()
+			if body.Container.GetDestroyed() {
+				labels = nil
+			}
+			d.deps.LabelSync(ctx, agentID, body.Container.GetName(), body.Container.GetContainerId(), labels)
 		}
 	case *agentpb.AgentEvent_Inventory:
 		if d.deps.Inventory != nil {

--- a/internal/agentserver/dispatcher_test.go
+++ b/internal/agentserver/dispatcher_test.go
@@ -355,3 +355,28 @@ func TestDispatcher_AllNilHandlersNoError(t *testing.T) {
 		assert.NoError(t, err)
 	}
 }
+
+func TestDispatcher_DestroyedEventSyncsLabelsWithNilLabels(t *testing.T) {
+	var gotLabels map[string]string
+	var called bool
+	d := NewDispatcher(DispatchDeps{
+		LabelSync: func(_ context.Context, _, _, _ string, labels map[string]string) {
+			called = true
+			gotLabels = labels
+		},
+	})
+
+	err := d.Dispatch(context.Background(), dispatchAgentID, &agentpb.AgentEvent{
+		AgentId: dispatchAgentID,
+		Body: &agentpb.AgentEvent_Container{Container: &agentpb.ContainerEvent{
+			ContainerId: "ctr-1",
+			Name:        "demo",
+			Labels:      map[string]string{"maintenant.endpoint.web": "http://x/health"},
+			Destroyed:   true,
+		}},
+	})
+
+	require.NoError(t, err)
+	require.True(t, called)
+	assert.Nil(t, gotLabels, "a destroyed container must retract its label-discovered monitors")
+}

--- a/internal/agentserver/enrollment.go
+++ b/internal/agentserver/enrollment.go
@@ -183,7 +183,7 @@ func (impl *ingestImpl) Push(stream grpc.BidiStreamingServer[agentpb.ClientMessa
 	logger.Debug("agent.auth_ok", "agent_id", ag.AgentID)
 
 	// Phase 3: open session with a cancellable context.
-	// sessions.Close() calls cancel() which unblocks the recv loop below.
+	// sessions.CloseStream() calls cancel() which unblocks the recv loop below.
 	addr := ""
 	if p, ok := peer.FromContext(stream.Context()); ok {
 		addr = p.Addr.String()
@@ -194,8 +194,8 @@ func (impl *ingestImpl) Push(stream grpc.BidiStreamingServer[agentpb.ClientMessa
 	// only, keeping the single-writer invariant on the gRPC stream.
 	sendCh := make(chan *agentpb.ServerMessage, 16)
 	if sessions != nil {
-		sessions.Open(ag.AgentID, cancel, addr, resp.GetCapabilities(), sendCh)
-		defer sessions.Close(ag.AgentID, "stream_ended")
+		tok := sessions.Open(ag.AgentID, cancel, addr, resp.GetCapabilities(), sendCh)
+		defer sessions.CloseStream(ag.AgentID, tok, "stream_ended")
 	}
 
 	// RegisterRequest.agent_version freezes at enrollment; AuthResponse carries

--- a/internal/agentserver/integration_test.go
+++ b/internal/agentserver/integration_test.go
@@ -442,7 +442,7 @@ func TestIntegration_PushStream(t *testing.T) {
 
 	// === Step 5: Verify DB — container state changed to Running (< 4s) ===
 	require.Eventually(t, func() bool {
-		c, err := containerSvc.GetContainerByExternalID(ctx, testExternalID)
+		c, err := containerSvc.GetContainerByExternalID(ctx, agentID, testExternalID)
 		if err != nil || c == nil {
 			return false
 		}

--- a/internal/agentserver/sessions.go
+++ b/internal/agentserver/sessions.go
@@ -174,14 +174,27 @@ func (s *Sessions) SetLifecycleAlertHook(fn func(agentID, reason string, connect
 	s.alertHook = fn
 }
 
+// Token identifies one stream, so a handler closes only the session it opened.
+type Token struct{ stream *activeStream }
+
 // Open registers an active stream for agentID and cancels any pre-existing one.
 // caps are the command families the agent advertised; send is the queue its Push
 // goroutine drains to write to the stream (both may be nil for a telemetry-only
-// stream, in which case no command can be issued to this agent).
-func (s *Sessions) Open(agentID string, cancel context.CancelCauseFunc, addr string, caps []string, send chan *agentpb.ServerMessage) {
+// stream, in which case no command can be issued to this agent). The returned
+// Token identifies this stream for CloseStream.
+func (s *Sessions) Open(agentID string, cancel context.CancelCauseFunc, addr string, caps []string, send chan *agentpb.ServerMessage) Token {
 	capSet := make(map[string]struct{}, len(caps))
 	for _, c := range caps {
 		capSet[c] = struct{}{}
+	}
+
+	st := &activeStream{
+		cancel:      cancel,
+		addr:        addr,
+		connectedAt: time.Now(),
+		send:        send,
+		caps:        capSet,
+		pending:     make(map[string]chan *agentpb.CommandResult),
 	}
 
 	s.mu.Lock()
@@ -190,14 +203,7 @@ func (s *Sessions) Open(agentID string, cancel context.CancelCauseFunc, addr str
 		existing.closeAll()
 	}
 	delete(s.offlineReported, agentID)
-	s.active[agentID] = &activeStream{
-		cancel:      cancel,
-		addr:        addr,
-		connectedAt: time.Now(),
-		send:        send,
-		caps:        capSet,
-		pending:     make(map[string]chan *agentpb.CommandResult),
-	}
+	s.active[agentID] = st
 	s.mu.Unlock()
 
 	s.logger.Info("agent.connected", "agent_id", agentID, "addr", addr)
@@ -209,12 +215,37 @@ func (s *Sessions) Open(agentID string, cancel context.CancelCauseFunc, addr str
 	if s.alertHook != nil {
 		s.alertHook(agentID, "", true)
 	}
+	return Token{stream: st}
 }
 
-// Close removes and cancels the active stream for agentID.
+// Close removes and cancels whatever active stream currently exists for
+// agentID, regardless of which one opened it. For administrative teardown
+// (revoke, delete) where any live session must go.
 func (s *Sessions) Close(agentID, reason string) {
+	s.remove(agentID, nil, reason)
+}
+
+// CloseStream removes and cancels the active stream for agentID only if it is
+// still the one identified by tok. A stale tok (superseded by a reconnect) or
+// a zero Token is a no-op, so a handler unwinding after being replaced can
+// never tear down the session that replaced it.
+func (s *Sessions) CloseStream(agentID string, tok Token, reason string) {
+	if tok.stream == nil {
+		return
+	}
+	s.remove(agentID, tok.stream, reason)
+}
+
+// remove tears down the active stream for agentID. only, when non-nil,
+// restricts the removal to that specific stream; a mismatch is a no-op before
+// any disconnect side effect.
+func (s *Sessions) remove(agentID string, only *activeStream, reason string) {
 	s.mu.Lock()
 	st, had := s.active[agentID]
+	if had && only != nil && st != only {
+		s.mu.Unlock()
+		return
+	}
 	if had {
 		st.cancel(CauseForReason(reason))
 		delete(s.active, agentID)
@@ -526,6 +557,7 @@ func (s *Sessions) StartStaleWatcher(ctx context.Context, interval, threshold, g
 			case <-ctx.Done():
 				return
 			case <-t.C:
+				sweepStart := time.Now()
 				ids, err := staleAgents(ctx, threshold)
 				if err != nil {
 					s.logger.Error("stale watcher query failed", "err", err)
@@ -535,6 +567,10 @@ func (s *Sessions) StartStaleWatcher(ctx context.Context, interval, threshold, g
 				for _, agentID := range ids {
 					s.mu.Lock()
 					st, connected := s.active[agentID]
+					if connected && st.connectedAt.After(sweepStart) {
+						s.mu.Unlock()
+						continue
+					}
 					if connected {
 						st.cancel(ErrSessionStale)
 						delete(s.active, agentID)

--- a/internal/agentserver/sessions_test.go
+++ b/internal/agentserver/sessions_test.go
@@ -306,3 +306,89 @@ func TestSessions_ReplacedStreamIsNotARevocation(t *testing.T) {
 	assert.NotErrorIs(t, cause, agentserver.ErrSessionRevoked,
 		"a reconnect that replaces the old stream must not look like a revocation")
 }
+
+// --- Per-session close token: a replaced handler must not close its replacement ---
+
+func TestSessions_CloseStream_StaleTokenKeepsReplacement(t *testing.T) {
+	sessions := agentserver.NewSessions(discardLogger(), &testBroadcaster{})
+	rec := &hookRecorder{}
+	sessions.SetLifecycleAlertHook(rec.record)
+
+	tok1 := sessions.Open("agent-A", func(error) {}, "addr1", nil, nil)
+	var secondCancelled bool
+	sessions.Open("agent-A", func(error) { secondCancelled = true }, "addr2", nil, nil)
+	before := rec.snapshot()
+
+	sessions.CloseStream("agent-A", tok1, "stream_ended")
+
+	assert.True(t, sessions.IsConnected("agent-A"), "the replacement session must stay open")
+	assert.False(t, secondCancelled, "a stale token must not cancel the replacement stream")
+	assert.Equal(t, before, rec.snapshot(), "a stale token must fire no lifecycle event")
+}
+
+func TestSessions_CloseStream_LiveTokenCloses(t *testing.T) {
+	broadcaster := &testBroadcaster{}
+	sessions := agentserver.NewSessions(discardLogger(), broadcaster)
+	rec := &hookRecorder{}
+	sessions.SetLifecycleAlertHook(rec.record)
+
+	var cancelled bool
+	tok := sessions.Open("agent-A", func(error) { cancelled = true }, "addr", nil, nil)
+
+	sessions.CloseStream("agent-A", tok, "stream_ended")
+
+	assert.False(t, sessions.IsConnected("agent-A"))
+	assert.True(t, cancelled, "the owning token must cancel its own stream")
+	assert.True(t, broadcaster.hasEvent("agent.disconnected"))
+	assert.Equal(t, []string{"agent-A//true", "agent-A/stream_ended/false"}, rec.snapshot())
+}
+
+func TestSessions_Close_IgnoresToken(t *testing.T) {
+	sessions := agentserver.NewSessions(discardLogger(), &testBroadcaster{})
+
+	sessions.Open("agent-A", func(error) {}, "addr1", nil, nil)
+	var secondCancelled bool
+	sessions.Open("agent-A", func(error) { secondCancelled = true }, "addr2", nil, nil)
+
+	sessions.Close("agent-A", "revoked")
+
+	assert.False(t, sessions.IsConnected("agent-A"), "Close tears down whichever session is current")
+	assert.True(t, secondCancelled, "Close is not tied to a token; it closes the live session")
+}
+
+func TestSessions_CloseStream_ZeroTokenIsNoop(t *testing.T) {
+	sessions := agentserver.NewSessions(discardLogger(), &testBroadcaster{})
+	rec := &hookRecorder{}
+	sessions.SetLifecycleAlertHook(rec.record)
+
+	sessions.Open("agent-A", func(error) {}, "addr", nil, nil)
+	before := rec.snapshot()
+
+	sessions.CloseStream("agent-A", agentserver.Token{}, "stream_ended")
+
+	assert.True(t, sessions.IsConnected("agent-A"))
+	assert.Equal(t, before, rec.snapshot())
+}
+
+// A session that reconnects while a stale sweep's DB query is already in
+// flight must not be reaped for a last_seen that predates it: the sweep's
+// staleAgents call here opens the replacement itself, simulating the race.
+func TestSessions_StaleWatcher_SkipsStreamOpenedDuringSweep(t *testing.T) {
+	sessions := agentserver.NewSessions(discardLogger(), &testBroadcaster{})
+	rec := &hookRecorder{}
+	sessions.SetLifecycleAlertHook(rec.record)
+
+	staleAgents := func(context.Context, time.Duration) ([]string, error) {
+		sessions.Open("agent-A", func(error) {}, "addr", nil, nil)
+		return []string{"agent-A"}, nil
+	}
+
+	sessions.StartStaleWatcher(t.Context(), 5*time.Millisecond, time.Minute, 0, staleAgents)
+
+	require.Eventually(t, func() bool { return sessions.IsConnected("agent-A") }, time.Second, 5*time.Millisecond)
+	time.Sleep(60 * time.Millisecond) // several more sweeps
+	assert.True(t, sessions.IsConnected("agent-A"), "a session opened during the sweep must not be reaped")
+	for _, call := range rec.snapshot() {
+		assert.NotContains(t, call, "/stale/false", "a session opened during the sweep must not be reaped as stale")
+	}
+}

--- a/internal/api/v1/containers_agent_test.go
+++ b/internal/api/v1/containers_agent_test.go
@@ -37,7 +37,7 @@ func (s *agentEnrichStore) InsertContainer(context.Context, *container.Container
 	return "", nil
 }
 func (s *agentEnrichStore) UpdateContainer(context.Context, *container.Container) error { return nil }
-func (s *agentEnrichStore) GetContainerByExternalID(context.Context, string) (*container.Container, error) {
+func (s *agentEnrichStore) GetContainerByExternalID(context.Context, string, string) (*container.Container, error) {
 	return nil, nil
 }
 func (s *agentEnrichStore) GetContainerByID(_ context.Context, id string) (*container.Container, error) {

--- a/internal/app/lifecycle.go
+++ b/internal/app/lifecycle.go
@@ -179,6 +179,7 @@ func (a *App) startEventStream(ctx context.Context) <-chan struct{} {
 
 			a.containerSvc.ProcessEvent(ctx, container.ContainerEvent{
 				Action:       evt.Action,
+				AgentID:      uid.LocalAgent,
 				ExternalID:   evt.ExternalID,
 				Name:         evt.Name,
 				ExitCode:     evt.ExitCode,

--- a/internal/certificate/service.go
+++ b/internal/certificate/service.go
@@ -416,7 +416,7 @@ func (s *Service) HandleContainerDestroy(ctx context.Context, externalID string)
 }
 
 func (s *Service) deleteLabelMonitors(ctx context.Context, externalID string, keep map[string]bool) {
-	monitors, err := s.store.ListMonitorsByExternalID(ctx, externalID)
+	monitors, err := s.store.ListMonitorsByExternalID(ctx, uid.LocalAgent, externalID)
 	if err != nil {
 		s.logger.Error("list label monitors for container", "error", err, "external_id", externalID)
 		return
@@ -497,15 +497,12 @@ func (s *Service) SyncAgentCerts(ctx context.Context, agentID, containerExternal
 // deleteAgentLabelMonitors removes this agent's label monitors for a container
 // that are no longer in `keep` (nil keep = remove all of them).
 func (s *Service) deleteAgentLabelMonitors(ctx context.Context, agentID, externalID string, keep map[string]bool) {
-	monitors, err := s.store.ListMonitorsByExternalID(ctx, externalID)
+	monitors, err := s.store.ListMonitorsByExternalID(ctx, agentID, externalID)
 	if err != nil {
 		s.logger.Error("list agent label monitors", "error", err, "external_id", externalID)
 		return
 	}
 	for _, m := range monitors {
-		if m.AgentID != agentID {
-			continue // only this agent's monitors
-		}
 		if keep != nil && keep[m.Hostname+":"+strconv.Itoa(m.Port)] {
 			continue
 		}

--- a/internal/certificate/service_test.go
+++ b/internal/certificate/service_test.go
@@ -287,6 +287,7 @@ func TestParseCertificateLabels_StripsSchemeAndPath(t *testing.T) {
 type mockCertStore struct {
 	monitors               map[string]*CertMonitor
 	standaloneCount        int
+	deleted                []string
 	getMonitorByHostPortFn func(ctx context.Context, hostname string, port int, serverName string) (*CertMonitor, error)
 }
 
@@ -336,7 +337,9 @@ func (m *mockCertStore) ListMonitors(_ context.Context, _ ListCertificatesOpts) 
 func (m *mockCertStore) UpdateMonitor(_ context.Context, _ *CertMonitor) error {
 	return nil
 }
-func (m *mockCertStore) DeleteMonitor(_ context.Context, _ string) error {
+func (m *mockCertStore) DeleteMonitor(_ context.Context, id string) error {
+	delete(m.monitors, id)
+	m.deleted = append(m.deleted, id)
 	return nil
 }
 func (m *mockCertStore) InsertCheckResult(_ context.Context, _ *CertCheckResult) (string, error) {
@@ -354,8 +357,14 @@ func (m *mockCertStore) InsertChainEntries(_ context.Context, _ []*CertChainEntr
 func (m *mockCertStore) GetChainEntries(_ context.Context, _ string) ([]*CertChainEntry, error) {
 	return nil, nil
 }
-func (m *mockCertStore) ListMonitorsByExternalID(_ context.Context, _ string) ([]*CertMonitor, error) {
-	return nil, nil
+func (m *mockCertStore) ListMonitorsByExternalID(_ context.Context, agentID, externalID string) ([]*CertMonitor, error) {
+	var out []*CertMonitor
+	for _, mon := range m.monitors {
+		if uid.Agent(mon.AgentID) == uid.Agent(agentID) && mon.ExternalID == externalID {
+			out = append(out, mon)
+		}
+	}
+	return out, nil
 }
 func (m *mockCertStore) ListDueScheduledMonitors(_ context.Context, _ time.Time) ([]*CertMonitor, error) {
 	return nil, nil
@@ -645,4 +654,27 @@ func TestProcessCheckResult_NoEventWhenStatusHolds(t *testing.T) {
 		}
 	}
 	assert.Zero(t, changed, "an unchanged status must not be announced again")
+}
+
+func TestDeleteLabelMonitors_LocalOnlyTouchesLocalAgent(t *testing.T) {
+	store := newMockCertStore()
+	svc := NewService(Deps{Store: store, Logger: noopLogger()})
+	ctx := context.Background()
+
+	const ext = "c-shared"
+	remote := &CertMonitor{
+		ID: uid.New(), Hostname: "remote.example", Port: 443,
+		ExternalID: ext, AgentID: "agent-b", Source: SourceLabel,
+	}
+	local := &CertMonitor{
+		ID: uid.New(), Hostname: "local.example", Port: 443,
+		ExternalID: ext, AgentID: uid.LocalAgent, Source: SourceLabel,
+	}
+	store.monitors[remote.ID] = remote
+	store.monitors[local.ID] = local
+
+	svc.HandleContainerDestroy(ctx, ext)
+
+	assert.Equal(t, []string{local.ID}, store.deleted,
+		"a local container destroy must not delete a remote agent's monitors")
 }

--- a/internal/certificate/store.go
+++ b/internal/certificate/store.go
@@ -39,7 +39,7 @@ type CertificateStore interface {
 	GetChainEntries(ctx context.Context, checkResultID string) ([]*CertChainEntry, error)
 
 	// Label-discovered monitors
-	ListMonitorsByExternalID(ctx context.Context, externalID string) ([]*CertMonitor, error)
+	ListMonitorsByExternalID(ctx context.Context, agentID, externalID string) ([]*CertMonitor, error)
 
 	// Scheduler
 	ListDueScheduledMonitors(ctx context.Context, now time.Time) ([]*CertMonitor, error)

--- a/internal/container/agent_event.go
+++ b/internal/container/agent_event.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/kolapsis/maintenant/internal/agentpb"
 	"github.com/kolapsis/maintenant/internal/event"
+	"github.com/kolapsis/maintenant/internal/uid"
 )
 
 // Docker label keys mirrored from internal/docker/discovery.go. Duplicated here
@@ -47,52 +48,64 @@ func (s *Service) HandleAgentEvent(ctx context.Context, agentID string, ev *agen
 		return nil
 	}
 
-	c, err := s.store.GetContainerByExternalID(ctx, externalID)
+	c, err := s.store.GetContainerByExternalID(ctx, uid.Agent(agentID), externalID)
 	if err != nil {
 		return fmt.Errorf("agent event: lookup %s: %w", shortID(externalID), err)
 	}
 
-	// First time we see this container: insert it directly. The local reconcile
-	// path only knows the server's own runtime, so agent containers must be
-	// created here or they never reach the database.
+	base := ContainerEvent{
+		AgentID:    agentID,
+		ExternalID: externalID,
+		Name:       ev.GetName(),
+		Timestamp:  agentEventTime(ev),
+		Labels:     ev.GetLabels(),
+	}
+
+	if ev.GetDestroyed() {
+		if c != nil {
+			base.Action = "destroy"
+			s.ProcessEvent(ctx, base)
+		}
+		return nil
+	}
+
 	if c == nil {
 		return s.insertAgentContainer(ctx, agentID, ev)
 	}
 
-	// Existing container: keep attribution and image fresh, then route the state
-	// change through the normal pipeline (handleStateChange updates existing rows
-	// correctly — the c == nil branch is never reached).
 	dirty := false
-	if c.AgentID != agentID {
-		c.AgentID = agentID
-		dirty = true
-	}
 	if img := ev.GetImage(); img != "" && img != c.Image {
 		c.Image = img
 		dirty = true
 	}
-	// The agent still sees it, so it is alive: resurrect a row archived while we
-	// had lost sight of the container.
+	if ev.GetHasHealthCheck() && !c.HasHealthCheck {
+		c.HasHealthCheck = true
+		dirty = true
+	}
 	if c.Archived {
 		c.Archived = false
 		c.ArchivedAt = nil
 		dirty = true
 	}
 	if dirty {
-		// Persist before ProcessEvent, which reloads the row from the store.
 		if err := s.store.UpdateContainer(ctx, c); err != nil {
 			return fmt.Errorf("agent event: update %s: %w", shortID(externalID), err)
 		}
 	}
 
-	s.ProcessEvent(ctx, ContainerEvent{
-		Action:     containerStateToAction(ev.GetState()),
-		ExternalID: externalID,
-		Name:       ev.GetName(),
-		ExitCode:   ev.GetStatusMessage(),
-		Timestamp:  agentEventTime(ev),
-		Labels:     ev.GetLabels(),
-	})
+	if hs := ev.GetHealthStatus(); hs != "" && (c.HealthStatus == nil || string(*c.HealthStatus) != hs) {
+		h := base
+		h.Action = "health_status"
+		h.HealthStatus = hs
+		s.ProcessEvent(ctx, h)
+	}
+
+	if action := containerStateToAction(ev.GetState()); action != "" {
+		st := base
+		st.Action = action
+		st.ExitCode = ev.GetStatusMessage()
+		s.ProcessEvent(ctx, st)
+	}
 	return nil
 }
 
@@ -100,12 +113,11 @@ func (s *Service) HandleAgentEvent(ctx context.Context, agentID string, ev *agen
 // every reported container is upserted (and un-archived), then any container we
 // still hold for this agent but which the snapshot omits is archived.
 //
-// This is the only mechanism that retires a remote container — agents do not
-// stream destroy events — and it is why an empty snapshot must be ignored: it
-// would mean "archive this agent's whole fleet" on a transient discovery error.
+// An empty snapshot only archives the agent's fleet when it is marked complete;
+// otherwise it means the agent could not enumerate its runtime.
 func (s *Service) HandleAgentInventory(ctx context.Context, agentID string, ev *agentpb.ContainerInventory) error {
 	reported := ev.GetContainers()
-	if len(reported) == 0 {
+	if len(reported) == 0 && !ev.GetComplete() {
 		return nil
 	}
 
@@ -133,7 +145,7 @@ func (s *Service) HandleAgentInventory(ctx context.Context, agentID string, ev *
 		if _, ok := live[sc.ExternalID]; ok {
 			continue
 		}
-		if err := s.store.ArchiveContainer(ctx, sc.ExternalID, now); err != nil {
+		if err := s.store.ArchiveContainer(ctx, sc.ID, now); err != nil {
 			s.logger.Error("agent inventory: archive", "external_id", shortID(sc.ExternalID), "error", err)
 			continue
 		}
@@ -161,6 +173,7 @@ func (s *Service) insertAgentContainer(ctx context.Context, agentID string, ev *
 
 	c := &Container{
 		ExternalID:         externalID,
+		HasHealthCheck:     ev.GetHasHealthCheck() || ev.GetHealthStatus() != "",
 		AgentID:            agentID,
 		Name:               ev.GetName(),
 		Image:              ev.GetImage(),
@@ -176,17 +189,14 @@ func (s *Service) insertAgentContainer(ctx context.Context, agentID string, ev *
 		FirstSeenAt:        now,
 		LastStateChangeAt:  now,
 	}
+	if hs := ev.GetHealthStatus(); hs != "" {
+		h := HealthStatus(hs)
+		c.HealthStatus = &h
+	}
 	applyAgentLabels(c, labels)
 
 	id, err := s.store.InsertContainer(ctx, c)
 	if err != nil {
-		// Likely a race with another event for the same external_id (UNIQUE
-		// constraint on containers.external_id). If the row now exists, treat
-		// the insert as a no-op; the follow-up event will carry the state.
-		if existing, gerr := s.store.GetContainerByExternalID(ctx, externalID); gerr == nil && existing != nil {
-			s.logger.Debug("agent event: insert raced, container already exists", "external_id", shortID(externalID))
-			return nil
-		}
 		return fmt.Errorf("agent event: insert %s: %w", shortID(externalID), err)
 	}
 	c.ID = id
@@ -288,6 +298,6 @@ func containerStateToAction(state agentpb.ContainerState) string {
 	case agentpb.ContainerState_CONTAINER_STATE_CREATED:
 		return "create"
 	default:
-		return "start"
+		return ""
 	}
 }

--- a/internal/container/agent_event_test.go
+++ b/internal/container/agent_event_test.go
@@ -78,7 +78,7 @@ func TestHandleAgentEvent_InsertsNewContainer(t *testing.T) {
 
 	require.NoError(t, svc.HandleAgentEvent(context.Background(), "agent-123", ev))
 
-	c, err := store.GetContainerByExternalID(context.Background(), id)
+	c, err := store.GetContainerByExternalID(context.Background(), "agent-123", id)
 	require.NoError(t, err)
 	require.NotNil(t, c)
 	assert.Equal(t, "agent-123", c.AgentID)
@@ -110,7 +110,7 @@ func TestHandleAgentEvent_InsertsNonRunningState(t *testing.T) {
 	}
 	require.NoError(t, svc.HandleAgentEvent(context.Background(), "agent-1", ev))
 
-	c, err := store.GetContainerByExternalID(context.Background(), id)
+	c, err := store.GetContainerByExternalID(context.Background(), "agent-1", id)
 	require.NoError(t, err)
 	require.NotNil(t, c, "exited container from agent must still be inserted")
 	assert.Equal(t, StateExited, c.State)
@@ -131,7 +131,7 @@ func TestHandleAgentEvent_CreatedStateNoInitialTransition(t *testing.T) {
 	}
 	require.NoError(t, svc.HandleAgentEvent(context.Background(), "agent-1", ev))
 
-	c, _ := store.GetContainerByExternalID(context.Background(), id)
+	c, _ := store.GetContainerByExternalID(context.Background(), "agent-1", id)
 	require.NotNil(t, c)
 	assert.Equal(t, StateCreated, c.State)
 	assert.Empty(t, store.transitionsFor(c.ID), "created state should not record an initial transition")
@@ -155,29 +155,34 @@ func TestHandleAgentEvent_UpdatesExistingState(t *testing.T) {
 	require.NoError(t, svc.HandleAgentEvent(context.Background(), agentID, ev))
 
 	assert.Equal(t, StateExited, store.storedState(id))
-	c, _ := store.GetContainerByExternalID(context.Background(), id)
+	c, _ := store.GetContainerByExternalID(context.Background(), agentID, id)
 	require.NotNil(t, c)
 	assert.Equal(t, agentID, c.AgentID)
 }
 
-func TestHandleAgentEvent_BackfillsAgentID(t *testing.T) {
+func TestHandleAgentEvent_SameExternalIDTwoAgents_NoTakeover(t *testing.T) {
 	store := newSvcStore()
 	svc := newTestService(store)
+	ctx := context.Background()
 
-	id := extID("orphan")
-	seed := makeTestContainer(id, StateRunning) // AgentID nil
+	id := extID("shared")
+	seed := makeTestContainer(id, StateRunning)
+	seed.AgentID = "agent-a"
 	store.seed(seed)
 
-	ev := &agentpb.ContainerEvent{
-		ContainerId: id,
-		Name:        "orphan",
-		State:       agentpb.ContainerState_CONTAINER_STATE_RUNNING,
-	}
-	require.NoError(t, svc.HandleAgentEvent(context.Background(), "agent-77", ev))
+	require.NoError(t, svc.HandleAgentEvent(ctx, "agent-b", &agentpb.ContainerEvent{
+		ContainerId: id, Name: "shared", State: agentpb.ContainerState_CONTAINER_STATE_EXITED,
+	}))
 
-	c, _ := store.GetContainerByExternalID(context.Background(), id)
-	require.NotNil(t, c)
-	assert.Equal(t, "agent-77", c.AgentID, "agent_id should be backfilled on existing row")
+	a, _ := store.GetContainerByExternalID(ctx, "agent-a", id)
+	require.NotNil(t, a)
+	assert.Equal(t, "agent-a", a.AgentID)
+	assert.Equal(t, StateRunning, a.State, "another agent's event must not move this row")
+
+	b, _ := store.GetContainerByExternalID(ctx, "agent-b", id)
+	require.NotNil(t, b, "the reporting agent gets its own row")
+	assert.Equal(t, "agent-b", b.AgentID)
+	assert.Equal(t, StateExited, b.State)
 }
 
 func TestHandleAgentEvent_UpdatesImageOnRedeploy(t *testing.T) {
@@ -199,7 +204,7 @@ func TestHandleAgentEvent_UpdatesImageOnRedeploy(t *testing.T) {
 	}
 	require.NoError(t, svc.HandleAgentEvent(context.Background(), agentID, ev))
 
-	c, _ := store.GetContainerByExternalID(context.Background(), id)
+	c, _ := store.GetContainerByExternalID(context.Background(), agentID, id)
 	require.NotNil(t, c)
 	assert.Equal(t, "app:v2", c.Image)
 }
@@ -214,7 +219,7 @@ func TestHandleAgentEvent_RuntimeResolver(t *testing.T) {
 		require.NoError(t, svc.HandleAgentEvent(context.Background(), "a", &agentpb.ContainerEvent{
 			ContainerId: id, Name: "swarmsvc", State: agentpb.ContainerState_CONTAINER_STATE_RUNNING,
 		}))
-		c, _ := store.GetContainerByExternalID(context.Background(), id)
+		c, _ := store.GetContainerByExternalID(context.Background(), "a", id)
 		require.NotNil(t, c)
 		assert.Equal(t, "swarm", c.RuntimeType)
 	})
@@ -228,7 +233,7 @@ func TestHandleAgentEvent_RuntimeResolver(t *testing.T) {
 		require.NoError(t, svc.HandleAgentEvent(context.Background(), "a", &agentpb.ContainerEvent{
 			ContainerId: id, Name: "errsvc", State: agentpb.ContainerState_CONTAINER_STATE_RUNNING,
 		}))
-		c, _ := store.GetContainerByExternalID(context.Background(), id)
+		c, _ := store.GetContainerByExternalID(context.Background(), "a", id)
 		require.NotNil(t, c)
 		assert.Equal(t, "docker", c.RuntimeType)
 	})
@@ -253,7 +258,7 @@ func TestHandleAgentEvent_AppliesMaintenantLabels(t *testing.T) {
 	}
 	require.NoError(t, svc.HandleAgentEvent(context.Background(), "a", ev))
 
-	c, _ := store.GetContainerByExternalID(context.Background(), id)
+	c, _ := store.GetContainerByExternalID(context.Background(), "a", id)
 	require.NotNil(t, c)
 	assert.True(t, c.IsIgnored)
 	assert.Equal(t, "infra", c.CustomGroup)
@@ -330,7 +335,7 @@ func TestHandleAgentEvent_PreservesImageWhenEventImageEmpty(t *testing.T) {
 	require.NoError(t, svc.HandleAgentEvent(ctx, agentID, &agentpb.ContainerEvent{
 		ContainerId: id, Name: "noimg", State: agentpb.ContainerState_CONTAINER_STATE_RUNNING,
 	}))
-	c, _ := store.GetContainerByExternalID(ctx, id)
+	c, _ := store.GetContainerByExternalID(ctx, agentID, id)
 	require.NotNil(t, c)
 	assert.Equal(t, "keep:me", c.Image)
 }
@@ -399,7 +404,7 @@ func TestHandleAgentEvent_ResurrectsArchivedContainer(t *testing.T) {
 	seed := makeTestContainer(id, StateRunning)
 	seed.AgentID = agentID
 	store.seed(seed)
-	require.NoError(t, store.ArchiveContainer(context.Background(), id, time.Now()))
+	require.NoError(t, store.ArchiveContainer(context.Background(), seed.ID, time.Now()))
 	require.True(t, store.isArchived(id))
 
 	ev := &agentpb.ContainerEvent{
@@ -410,7 +415,7 @@ func TestHandleAgentEvent_ResurrectsArchivedContainer(t *testing.T) {
 	require.NoError(t, svc.HandleAgentEvent(context.Background(), agentID, ev))
 
 	assert.False(t, store.isArchived(id), "a re-reported container must be un-archived")
-	c, _ := store.GetContainerByExternalID(context.Background(), id)
+	c, _ := store.GetContainerByExternalID(context.Background(), agentID, id)
 	require.NotNil(t, c)
 	assert.Nil(t, c.ArchivedAt, "archived_at must be cleared alongside the flag")
 }
@@ -459,7 +464,7 @@ func TestHandleAgentInventory_LeavesOtherAgentsAlone(t *testing.T) {
 	assert.False(t, store.isArchived(theirs), "another agent's containers must be untouched")
 }
 
-func TestHandleAgentInventory_EmptySnapshotArchivesNothing(t *testing.T) {
+func TestHandleAgentInventory_EmptyIncompleteSnapshotArchivesNothing(t *testing.T) {
 	// An empty inventory can only mean the agent failed to look; treating it as
 	// "this host is empty" would wipe the whole fleet.
 	store := newSvcStore()
@@ -473,7 +478,7 @@ func TestHandleAgentInventory_EmptySnapshotArchivesNothing(t *testing.T) {
 
 	require.NoError(t, svc.HandleAgentInventory(context.Background(), agentID, &agentpb.ContainerInventory{}))
 
-	assert.False(t, store.isArchived(id), "an empty snapshot must never archive anything")
+	assert.False(t, store.isArchived(id), "an incomplete empty snapshot must never archive anything")
 }
 
 func TestHandleAgentInventory_InsertsUnknownContainers(t *testing.T) {
@@ -487,8 +492,162 @@ func TestHandleAgentInventory_InsertsUnknownContainers(t *testing.T) {
 	}}
 	require.NoError(t, svc.HandleAgentInventory(context.Background(), agentID, inv))
 
-	c, _ := store.GetContainerByExternalID(context.Background(), id)
+	c, _ := store.GetContainerByExternalID(context.Background(), agentID, id)
 	require.NotNil(t, c, "an inventory entry we have never seen must be inserted")
 	assert.Equal(t, agentID, c.AgentID)
 	assert.Equal(t, StateRunning, c.State)
+}
+
+func TestHandleAgentEvent_HealthStatus_RecordsTransitionAndEvent(t *testing.T) {
+	store := newSvcStore()
+	var events []capturedEvent
+	svc := newTestService(store, captureEvents(&events))
+	ctx := context.Background()
+
+	agentID := "agent-h"
+	id := extID("healthy")
+	seed := makeTestContainer(id, StateRunning)
+	seed.AgentID = agentID
+	store.seed(seed)
+
+	require.NoError(t, svc.HandleAgentEvent(ctx, agentID, &agentpb.ContainerEvent{
+		ContainerId:    id,
+		Name:           "healthy",
+		State:          agentpb.ContainerState_CONTAINER_STATE_UNSPECIFIED,
+		HealthStatus:   "unhealthy",
+		HasHealthCheck: true,
+	}))
+
+	got := store.storedHealthStatus(id)
+	require.NotNil(t, got)
+	assert.Equal(t, HealthStatus("unhealthy"), *got)
+	assert.True(t, hasEvent(events, event.ContainerHealthChanged))
+	assert.False(t, hasEvent(events, event.ContainerStateChanged),
+		"an unspecified state must not be read as a state transition")
+
+	c, _ := store.GetContainerByExternalID(ctx, agentID, id)
+	require.NotNil(t, c)
+	assert.True(t, c.HasHealthCheck)
+	assert.Equal(t, StateRunning, c.State)
+}
+
+func TestHandleAgentEvent_InventoryEntrySeedsHealthAndHasHealthCheck(t *testing.T) {
+	store := newSvcStore()
+	svc := newTestService(store)
+	ctx := context.Background()
+
+	agentID := "agent-inv-h"
+	id := extID("seeded")
+	require.NoError(t, svc.HandleAgentInventory(ctx, agentID, &agentpb.ContainerInventory{
+		Complete: true,
+		Containers: []*agentpb.ContainerEvent{{
+			ContainerId:    id,
+			Name:           "seeded",
+			State:          agentpb.ContainerState_CONTAINER_STATE_RUNNING,
+			HealthStatus:   "starting",
+			HasHealthCheck: true,
+		}},
+	}))
+
+	c, _ := store.GetContainerByExternalID(ctx, agentID, id)
+	require.NotNil(t, c)
+	assert.True(t, c.HasHealthCheck)
+	require.NotNil(t, c.HealthStatus)
+	assert.Equal(t, HealthStatus("starting"), *c.HealthStatus)
+}
+
+func TestHandleAgentEvent_Destroyed_ArchivesOnlyThisAgentRow(t *testing.T) {
+	store := newSvcStore()
+	svc := newTestService(store)
+	ctx := context.Background()
+
+	id := extID("doomed")
+	mine := makeTestContainer(id, StateRunning)
+	mine.AgentID = "agent-a"
+	store.seed(mine)
+	theirs := makeTestContainer(id, StateRunning)
+	theirs.AgentID = "agent-b"
+	store.seed(theirs)
+
+	require.NoError(t, svc.HandleAgentEvent(ctx, "agent-a", &agentpb.ContainerEvent{
+		ContainerId: id,
+		Name:        "doomed",
+		State:       agentpb.ContainerState_CONTAINER_STATE_EXITED,
+		Destroyed:   true,
+	}))
+
+	a, _ := store.GetContainerByExternalID(ctx, "agent-a", id)
+	require.NotNil(t, a)
+	assert.True(t, a.Archived)
+	b, _ := store.GetContainerByExternalID(ctx, "agent-b", id)
+	require.NotNil(t, b)
+	assert.False(t, b.Archived)
+}
+
+func TestHandleAgentEvent_DestroyedUnknown_NoInsert(t *testing.T) {
+	store := newSvcStore()
+	svc := newTestService(store)
+	ctx := context.Background()
+
+	require.NoError(t, svc.HandleAgentEvent(ctx, "agent-a", &agentpb.ContainerEvent{
+		ContainerId: extID("ghost"),
+		Name:        "ghost",
+		State:       agentpb.ContainerState_CONTAINER_STATE_EXITED,
+		Destroyed:   true,
+	}))
+
+	got, err := store.ListContainers(ctx, ListContainersOpts{IncludeArchived: true, IncludeIgnored: true})
+	require.NoError(t, err)
+	assert.Empty(t, got, "a destroy for a container we never knew must insert nothing")
+}
+
+func TestHandleAgentEvent_UnknownHealthOnly_InsertsRunningWithHealth(t *testing.T) {
+	store := newSvcStore()
+	svc := newTestService(store)
+	ctx := context.Background()
+
+	agentID := "agent-a"
+	id := extID("newhealth")
+	require.NoError(t, svc.HandleAgentEvent(ctx, agentID, &agentpb.ContainerEvent{
+		ContainerId:  id,
+		Name:         "newhealth",
+		State:        agentpb.ContainerState_CONTAINER_STATE_UNSPECIFIED,
+		HealthStatus: "healthy",
+	}))
+
+	c, _ := store.GetContainerByExternalID(ctx, agentID, id)
+	require.NotNil(t, c)
+	assert.Equal(t, StateRunning, c.State)
+	assert.True(t, c.HasHealthCheck)
+	require.NotNil(t, c.HealthStatus)
+	assert.Equal(t, HealthStatus("healthy"), *c.HealthStatus)
+}
+
+func TestHandleAgentInventory_EmptyComplete_ArchivesFleet(t *testing.T) {
+	store := newSvcStore()
+	svc := newTestService(store)
+	ctx := context.Background()
+
+	agentID := "agent-gone"
+	id := extID("lastone")
+	seed := makeTestContainer(id, StateRunning)
+	seed.AgentID = agentID
+	store.seed(seed)
+
+	require.NoError(t, svc.HandleAgentInventory(ctx, agentID, &agentpb.ContainerInventory{Complete: true}))
+
+	assert.True(t, store.isArchived(id), "a complete empty snapshot means the host has no containers left")
+}
+
+func TestHandleAgentEvent_InsertErrorIsReturned(t *testing.T) {
+	store := newSvcStore()
+	store.errInsert = errors.New("boom")
+	svc := newTestService(store)
+
+	err := svc.HandleAgentEvent(context.Background(), "agent-a", &agentpb.ContainerEvent{
+		ContainerId: extID("failing"),
+		Name:        "failing",
+		State:       agentpb.ContainerState_CONTAINER_STATE_RUNNING,
+	})
+	require.Error(t, err)
 }

--- a/internal/container/service.go
+++ b/internal/container/service.go
@@ -30,6 +30,7 @@ type RuntimeDiscoverer interface {
 // This mirrors runtime.RuntimeEvent but lives in the container package to avoid import cycles.
 type ContainerEvent struct {
 	Action       string
+	AgentID      string
 	ExternalID   string
 	Name         string
 	ExitCode     string
@@ -127,7 +128,7 @@ func (s *Service) ProcessEvent(ctx context.Context, evt ContainerEvent) {
 	case "stop":
 		// Docker sends "die" before "stop". If the container exited cleanly (exit 0),
 		// the die handler already set StateCompleted — don't overwrite it with StateExited.
-		c, _ := s.store.GetContainerByExternalID(ctx, evt.ExternalID)
+		c, _ := s.lookup(ctx, evt)
 		if c != nil && c.State == StateCompleted {
 			return
 		}
@@ -151,14 +152,18 @@ func (s *Service) ProcessEvent(ctx context.Context, evt ContainerEvent) {
 	}
 }
 
+func (s *Service) lookup(ctx context.Context, evt ContainerEvent) (*Container, error) {
+	return s.store.GetContainerByExternalID(ctx, uid.Agent(evt.AgentID), evt.ExternalID)
+}
+
 func (s *Service) handleStateChange(ctx context.Context, evt ContainerEvent, newState ContainerState) {
-	c, err := s.store.GetContainerByExternalID(ctx, evt.ExternalID)
+	c, err := s.lookup(ctx, evt)
 	if err != nil {
 		s.logger.Error("get container for state change", "external_id", evt.ExternalID[:12], "error", err)
 		return
 	}
 	if c == nil {
-		if newState != StateRunning || s.discoverer == nil {
+		if newState != StateRunning || s.discoverer == nil || uid.Agent(evt.AgentID) != uid.LocalAgent {
 			s.logger.Debug("unknown container event, skipping", "external_id", evt.ExternalID[:12], "action", evt.Action)
 			return
 		}
@@ -250,7 +255,7 @@ func (s *Service) handleStateChange(ctx context.Context, evt ContainerEvent, new
 }
 
 func (s *Service) handleDestroy(ctx context.Context, evt ContainerEvent) {
-	c, err := s.store.GetContainerByExternalID(ctx, evt.ExternalID)
+	c, err := s.lookup(ctx, evt)
 	if err != nil {
 		s.logger.Error("get container for destroy", "external_id", evt.ExternalID[:12], "error", err)
 		return
@@ -261,7 +266,7 @@ func (s *Service) handleDestroy(ctx context.Context, evt ContainerEvent) {
 	}
 
 	now := evt.Timestamp
-	if err := s.store.ArchiveContainer(ctx, evt.ExternalID, now); err != nil {
+	if err := s.store.ArchiveContainer(ctx, c.ID, now); err != nil {
 		s.logger.Error("archive container", "external_id", evt.ExternalID[:12], "error", err)
 		return
 	}
@@ -275,7 +280,7 @@ func (s *Service) handleDestroy(ctx context.Context, evt ContainerEvent) {
 }
 
 func (s *Service) handleHealthChange(ctx context.Context, evt ContainerEvent) {
-	c, err := s.store.GetContainerByExternalID(ctx, evt.ExternalID)
+	c, err := s.lookup(ctx, evt)
 	if err != nil {
 		s.logger.Error("get container for health change", "external_id", evt.ExternalID[:12], "error", err)
 		return
@@ -327,9 +332,9 @@ func (s *Service) GetContainer(ctx context.Context, id string) (*Container, erro
 	return s.store.GetContainerByID(ctx, id)
 }
 
-// GetContainerByExternalID retrieves a container by its runtime-assigned external ID.
-func (s *Service) GetContainerByExternalID(ctx context.Context, externalID string) (*Container, error) {
-	return s.store.GetContainerByExternalID(ctx, externalID)
+// GetContainerByExternalID retrieves an agent's container by its runtime-assigned external ID.
+func (s *Service) GetContainerByExternalID(ctx context.Context, agentID, externalID string) (*Container, error) {
+	return s.store.GetContainerByExternalID(ctx, uid.Agent(agentID), externalID)
 }
 
 // DeleteContainer removes a container and its transitions from the database.
@@ -379,7 +384,7 @@ func (s *Service) Reconcile(ctx context.Context, discoverer RuntimeDiscoverer) e
 		dc, exists := currentByExternalID[sc.ExternalID]
 		if !exists {
 			// Container was removed while maintenant was offline — archive it
-			if err := s.store.ArchiveContainer(ctx, sc.ExternalID, now); err != nil {
+			if err := s.store.ArchiveContainer(ctx, sc.ID, now); err != nil {
 				s.logger.Error("reconcile archive", "external_id", sc.ExternalID, "error", err)
 			}
 			s.emitEvent(event.ContainerArchived, map[string]interface{}{

--- a/internal/container/service_test.go
+++ b/internal/container/service_test.go
@@ -32,22 +32,19 @@ import (
 
 type svcStore struct {
 	mu          sync.Mutex
-	containers  map[string]*Container // keyed by ExternalID
 	byID        map[string]*Container
 	transitions []*StateTransition
 
 	// injection points for error simulation
 	errGetByExternalID  error
+	errInsert           error
 	errUpdate           error
 	errInsertTransition error
 	errArchive          error
 }
 
 func newSvcStore() *svcStore {
-	return &svcStore{
-		containers: make(map[string]*Container),
-		byID:       make(map[string]*Container),
-	}
+	return &svcStore{byID: make(map[string]*Container)}
 }
 
 func (m *svcStore) seed(c *Container) {
@@ -58,17 +55,18 @@ func (m *svcStore) seed(c *Container) {
 		c.ID = uid.Container(c.AgentID, c.ExternalID)
 	}
 	clone := *c
-	m.containers[c.ExternalID] = &clone
 	m.byID[clone.ID] = &clone
 }
 
 func (m *svcStore) InsertContainer(_ context.Context, c *Container) (string, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	if m.errInsert != nil {
+		return "", m.errInsert
+	}
 	c.AgentID = uid.Agent(c.AgentID)
 	c.ID = uid.Container(c.AgentID, c.ExternalID)
 	clone := *c
-	m.containers[c.ExternalID] = &clone
 	m.byID[clone.ID] = &clone
 	return c.ID, nil
 }
@@ -80,23 +78,24 @@ func (m *svcStore) UpdateContainer(_ context.Context, c *Container) error {
 		return m.errUpdate
 	}
 	clone := *c
-	m.containers[c.ExternalID] = &clone
 	m.byID[c.ID] = &clone
 	return nil
 }
 
-func (m *svcStore) GetContainerByExternalID(_ context.Context, externalID string) (*Container, error) {
+func (m *svcStore) GetContainerByExternalID(_ context.Context, agentID, externalID string) (*Container, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.errGetByExternalID != nil {
 		return nil, m.errGetByExternalID
 	}
-	c, ok := m.containers[externalID]
-	if !ok {
-		return nil, nil
+	agentID = uid.Agent(agentID)
+	for _, c := range m.byID {
+		if c.AgentID == agentID && c.ExternalID == externalID {
+			clone := *c
+			return &clone, nil
+		}
 	}
-	clone := *c
-	return &clone, nil
+	return nil, nil
 }
 
 func (m *svcStore) GetContainerByID(_ context.Context, id string) (*Container, error) {
@@ -114,7 +113,7 @@ func (m *svcStore) ListContainers(_ context.Context, opts ListContainersOpts) ([
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	var result []*Container
-	for _, c := range m.containers {
+	for _, c := range m.byID {
 		if !opts.IncludeArchived && c.Archived {
 			continue
 		}
@@ -127,31 +126,27 @@ func (m *svcStore) ListContainers(_ context.Context, opts ListContainersOpts) ([
 	return result, nil
 }
 
-func (m *svcStore) ArchiveContainer(_ context.Context, externalID string, archivedAt time.Time) error {
+func (m *svcStore) ArchiveContainer(_ context.Context, id string, archivedAt time.Time) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.errArchive != nil {
 		return m.errArchive
 	}
-	c, ok := m.containers[externalID]
+	c, ok := m.byID[id]
 	if !ok {
 		return nil
 	}
 	c.Archived = true
 	c.ArchivedAt = &archivedAt
-	m.byID[c.ID].Archived = true
-	m.byID[c.ID].ArchivedAt = &archivedAt
 	return nil
 }
 
 func (m *svcStore) DeleteContainerByID(_ context.Context, id string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	c, ok := m.byID[id]
-	if !ok {
+	if _, ok := m.byID[id]; !ok {
 		return nil
 	}
-	delete(m.containers, c.ExternalID)
 	delete(m.byID, id)
 	return nil
 }
@@ -202,11 +197,12 @@ func (m *svcStore) DeleteArchivedContainersBefore(_ context.Context, _ time.Time
 func (m *svcStore) storedState(externalID string) ContainerState {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	c, ok := m.containers[externalID]
-	if !ok {
-		return ""
+	for _, c := range m.byID {
+		if c.ExternalID == externalID {
+			return c.State
+		}
 	}
-	return c.State
+	return ""
 }
 
 // transitionsFor returns all recorded transitions for a given container ID.
@@ -227,19 +223,24 @@ func (m *svcStore) transitionsFor(containerID string) []*StateTransition {
 func (m *svcStore) isArchived(externalID string) bool {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	c, ok := m.containers[externalID]
-	return ok && c.Archived
+	for _, c := range m.byID {
+		if c.ExternalID == externalID {
+			return c.Archived
+		}
+	}
+	return false
 }
 
 // storedHealthStatus retrieves the current health status pointer from the store.
 func (m *svcStore) storedHealthStatus(externalID string) *HealthStatus {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	c, ok := m.containers[externalID]
-	if !ok {
-		return nil
+	for _, c := range m.byID {
+		if c.ExternalID == externalID {
+			return c.HealthStatus
+		}
 	}
-	return c.HealthStatus
+	return nil
 }
 
 // ---------------------------------------------------------------------------
@@ -1033,4 +1034,44 @@ func TestService_ProcessEvent_ExitCodeStoredInTransition(t *testing.T) {
 	require.Len(t, transitions, 1)
 	require.NotNil(t, transitions[0].ExitCode)
 	assert.Equal(t, 42, *transitions[0].ExitCode)
+}
+
+func TestProcessEvent_RemoteEventNeverTriggersLocalReconcile(t *testing.T) {
+	store := newSvcStore()
+	discoverer := &mockDiscoverer{}
+	svc := newTestService(store, func(d *Deps) {
+		d.Discoverer = discoverer
+	})
+
+	evt := makeTestEvent("start", extID("remote"))
+	evt.AgentID = "agent-remote"
+	svc.ProcessEvent(context.Background(), evt)
+
+	assert.Equal(t, 0, discoverer.calls, "the local runtime must not be discovered for a remote agent's event")
+}
+
+func TestHandleDestroy_ArchivesByID(t *testing.T) {
+	store := newSvcStore()
+	svc := newTestService(store)
+
+	ext := extID("bykey")
+	mine := makeTestContainer(ext, StateRunning)
+	mine.AgentID = "agent-a"
+	store.seed(mine)
+
+	theirs := makeTestContainer(ext, StateRunning)
+	theirs.AgentID = "agent-b"
+	store.seed(theirs)
+
+	evt := makeTestEvent("destroy", ext)
+	evt.AgentID = "agent-a"
+	svc.ProcessEvent(context.Background(), evt)
+
+	gotA, _ := store.GetContainerByExternalID(context.Background(), "agent-a", ext)
+	require.NotNil(t, gotA)
+	assert.True(t, gotA.Archived)
+
+	gotB, _ := store.GetContainerByExternalID(context.Background(), "agent-b", ext)
+	require.NotNil(t, gotB)
+	assert.False(t, gotB.Archived, "destroy must archive only the reporting agent's row")
 }

--- a/internal/container/store.go
+++ b/internal/container/store.go
@@ -21,10 +21,10 @@ type ContainerStore interface {
 	// Container CRUD
 	InsertContainer(ctx context.Context, c *Container) (string, error)
 	UpdateContainer(ctx context.Context, c *Container) error
-	GetContainerByExternalID(ctx context.Context, externalID string) (*Container, error)
+	GetContainerByExternalID(ctx context.Context, agentID, externalID string) (*Container, error)
 	GetContainerByID(ctx context.Context, id string) (*Container, error)
 	ListContainers(ctx context.Context, opts ListContainersOpts) ([]*Container, error)
-	ArchiveContainer(ctx context.Context, externalID string, archivedAt time.Time) error
+	ArchiveContainer(ctx context.Context, id string, archivedAt time.Time) error
 	DeleteContainerByID(ctx context.Context, id string) error
 
 	// State transitions

--- a/internal/container/uptime_test.go
+++ b/internal/container/uptime_test.go
@@ -221,7 +221,7 @@ func (m *uptimeStore) InsertContainer(_ context.Context, _ *Container) (string, 
 	return "", nil
 }
 func (m *uptimeStore) UpdateContainer(_ context.Context, _ *Container) error { return nil }
-func (m *uptimeStore) GetContainerByExternalID(_ context.Context, _ string) (*Container, error) {
+func (m *uptimeStore) GetContainerByExternalID(_ context.Context, _, _ string) (*Container, error) {
 	return nil, nil
 }
 func (m *uptimeStore) GetContainerByID(_ context.Context, _ string) (*Container, error) {

--- a/internal/endpoint/service.go
+++ b/internal/endpoint/service.go
@@ -160,7 +160,7 @@ func (s *Service) SyncEndpoints(ctx context.Context, containerName, externalID s
 	}
 
 	// Get currently stored endpoints for this container
-	existing, err := s.store.ListEndpointsByExternalID(ctx, externalID)
+	existing, err := s.store.ListEndpointsByExternalID(ctx, uid.LocalAgent, externalID)
 	if err != nil {
 		s.logger.Error("list endpoints by external ID", "external_id", externalID, "error", err)
 		return
@@ -259,8 +259,7 @@ func (s *Service) SyncAgentEndpoints(ctx context.Context, agentID, containerName
 		})
 	}
 
-	// external_id is unique per container, so this scopes to this agent's container.
-	existing, err := s.store.ListEndpointsByExternalID(ctx, externalID)
+	existing, err := s.store.ListEndpointsByExternalID(ctx, agentID, externalID)
 	if err != nil {
 		s.logger.Error("list agent endpoints by external ID", "external_id", externalID, "error", err)
 		return
@@ -453,7 +452,7 @@ func (s *Service) ProcessCheckResult(ctx context.Context, endpointID string, res
 
 // HandleContainerStop pauses checks and sets endpoints to unknown for a stopped container.
 func (s *Service) HandleContainerStop(ctx context.Context, externalID string) {
-	endpoints, err := s.store.ListEndpointsByExternalID(ctx, externalID)
+	endpoints, err := s.store.ListEndpointsByExternalID(ctx, uid.LocalAgent, externalID)
 	if err != nil {
 		s.logger.Error("list endpoints for container stop", "external_id", externalID, "error", err)
 		return
@@ -486,7 +485,7 @@ func (s *Service) HandleContainerStart(ctx context.Context, containerName, exter
 
 // HandleContainerDestroy deactivates all endpoints for a destroyed container.
 func (s *Service) HandleContainerDestroy(ctx context.Context, externalID string) {
-	endpoints, err := s.store.ListEndpointsByExternalID(ctx, externalID)
+	endpoints, err := s.store.ListEndpointsByExternalID(ctx, uid.LocalAgent, externalID)
 	if err != nil {
 		s.logger.Error("list endpoints for container destroy", "external_id", externalID, "error", err)
 		return

--- a/internal/endpoint/service_test.go
+++ b/internal/endpoint/service_test.go
@@ -130,12 +130,12 @@ func (m *memStore) ListEndpoints(_ context.Context, opts ListEndpointsOpts) ([]*
 	return out, nil
 }
 
-func (m *memStore) ListEndpointsByExternalID(_ context.Context, externalID string) ([]*Endpoint, error) {
+func (m *memStore) ListEndpointsByExternalID(_ context.Context, agentID, externalID string) ([]*Endpoint, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	var out []*Endpoint
 	for _, ep := range m.endpoints {
-		if ep.ExternalID == externalID && ep.Active {
+		if uid.Agent(ep.AgentID) == uid.Agent(agentID) && ep.ExternalID == externalID && ep.Active {
 			c := m.cloneEp(ep)
 			out = append(out, c)
 		}
@@ -995,4 +995,25 @@ func TestService_Delete_AllowsStandalone(t *testing.T) {
 	ep, err := store.GetEndpointByID(ctx, id)
 	require.NoError(t, err)
 	require.Nil(t, ep)
+}
+
+func TestSyncAgentEndpoints_DoesNotTouchOtherAgentsEndpoints(t *testing.T) {
+	store := newMemStore()
+	svc := newService(store)
+	ctx := context.Background()
+
+	const ext = "c-shared"
+	theirs := seedEndpoint(t, store, &Endpoint{
+		AgentID: "agent-b", ContainerName: "app", LabelKey: "web",
+		ExternalID: ext, EndpointType: TypeHTTP, Target: "http://b/health",
+		Source: SourceLabel, Config: DefaultConfig(), Active: true,
+	})
+
+	// agent-a reports the same container with no endpoint labels at all.
+	svc.SyncAgentEndpoints(ctx, "agent-a", "app", ext, nil)
+
+	store.mu.Lock()
+	still := store.endpoints[theirs].Active
+	store.mu.Unlock()
+	assert.True(t, still, "another agent's endpoint must survive a label sync")
 }

--- a/internal/endpoint/store.go
+++ b/internal/endpoint/store.go
@@ -24,7 +24,7 @@ type EndpointStore interface {
 	GetActiveAgentEndpointByTarget(ctx context.Context, agentID, target string) (*Endpoint, error)
 	GetEndpointByID(ctx context.Context, id string) (*Endpoint, error)
 	ListEndpoints(ctx context.Context, opts ListEndpointsOpts) ([]*Endpoint, error)
-	ListEndpointsByExternalID(ctx context.Context, externalID string) ([]*Endpoint, error)
+	ListEndpointsByExternalID(ctx context.Context, agentID, externalID string) ([]*Endpoint, error)
 	CountStandaloneEndpoints(ctx context.Context) (int, error)
 	DeactivateEndpoint(ctx context.Context, id string) error
 	DeleteEndpoint(ctx context.Context, id string) error

--- a/internal/resource/agent_event.go
+++ b/internal/resource/agent_event.go
@@ -21,9 +21,6 @@ import (
 )
 
 // HandleAgentEvent records a resource sample pushed by a remote agent.
-// The container must already exist (verified via external_id lookup, so an
-// orphan FK is never written); its id is the deterministic uid.Container of the
-// reporting agent and the Docker external_id, identical to what the agent mints.
 func (s *Service) HandleAgentEvent(ctx context.Context, agentID string, ev *agentpb.ResourceSample) error {
 	containerExternalID := ev.GetContainerId()
 	if containerExternalID == "" {
@@ -41,13 +38,13 @@ func (s *Service) HandleAgentEvent(ctx context.Context, agentID string, ev *agen
 		return nil
 	}
 
-	c, err := s.containerSvc.GetContainerByExternalID(ctx, containerExternalID)
+	c, err := s.containerSvc.GetContainerByExternalID(ctx, agentID, containerExternalID)
 	if err != nil || c == nil {
 		return err
 	}
 
 	snap := &ResourceSnapshot{
-		ContainerID:     uid.Container(uid.Agent(agentID), containerExternalID),
+		ContainerID:     c.ID,
 		CPUPercent:      ev.GetCpuPercent(),
 		MemUsed:         clampInt64(ev.GetMemoryBytes()),
 		MemLimit:        clampInt64(ev.GetMemoryLimitBytes()),

--- a/internal/resource/agent_event_test.go
+++ b/internal/resource/agent_event_test.go
@@ -61,3 +61,34 @@ func TestHandleAgentEvent_SkipsWhenContainerUnknown(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, rstore.snapshots, "no snapshot when container not yet known")
 }
+
+func TestHandleAgentEvent_UsesRowIDNotDerivedID(t *testing.T) {
+	extID := "abc123def4567890"
+	// An inherited row: its primary key does not derive from its current agent.
+	c := &container.Container{ID: uid.New(), ExternalID: extID, AgentID: "agent-9", Name: "demo"}
+	require.NotEqual(t, uid.Container(uid.Agent("agent-9"), extID), c.ID)
+
+	rstore := newMockResourceStore()
+	svc := newTestService(rstore, buildContainerSvc(newMockContainerStore(c)), nil)
+
+	require.NoError(t, svc.HandleAgentEvent(context.Background(), "agent-9", &agentpb.ResourceSample{
+		ContainerId: extID, CpuPercent: 3,
+	}))
+	require.Len(t, rstore.snapshots, 1)
+	assert.Equal(t, c.ID, rstore.snapshots[0].ContainerID)
+}
+
+func TestHandleAgentEvent_IgnoresOtherAgentsContainer(t *testing.T) {
+	extID := "abc123def4567890"
+	c := &container.Container{
+		ID:         uid.Container(uid.Agent("agent-a"), extID),
+		ExternalID: extID, AgentID: "agent-a", Name: "demo",
+	}
+	rstore := newMockResourceStore()
+	svc := newTestService(rstore, buildContainerSvc(newMockContainerStore(c)), nil)
+
+	require.NoError(t, svc.HandleAgentEvent(context.Background(), "agent-b", &agentpb.ResourceSample{
+		ContainerId: extID, CpuPercent: 3,
+	}))
+	assert.Empty(t, rstore.snapshots, "a sample must never land on another agent's container")
+}

--- a/internal/resource/service_test.go
+++ b/internal/resource/service_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/kolapsis/maintenant/internal/container"
 	"github.com/kolapsis/maintenant/internal/event"
+	"github.com/kolapsis/maintenant/internal/uid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -121,20 +122,13 @@ func (m *mockResourceStore) DeleteDailyBefore(_ context.Context, _ time.Time, _ 
 // ---------------------------------------------------------------------------
 
 type mockContainerStore struct {
-	containers   map[string]*container.Container
-	byExternalID map[string]*container.Container
+	containers map[string]*container.Container
 }
 
 func newMockContainerStore(containers ...*container.Container) *mockContainerStore {
-	s := &mockContainerStore{
-		containers:   make(map[string]*container.Container),
-		byExternalID: make(map[string]*container.Container),
-	}
+	s := &mockContainerStore{containers: make(map[string]*container.Container)}
 	for _, c := range containers {
 		s.containers[c.ID] = c
-		if c.ExternalID != "" {
-			s.byExternalID[c.ExternalID] = c
-		}
 	}
 	return s
 }
@@ -155,9 +149,11 @@ func (m *mockContainerStore) InsertContainer(_ context.Context, _ *container.Con
 func (m *mockContainerStore) UpdateContainer(_ context.Context, _ *container.Container) error {
 	return nil
 }
-func (m *mockContainerStore) GetContainerByExternalID(_ context.Context, externalID string) (*container.Container, error) {
-	if c, ok := m.byExternalID[externalID]; ok {
-		return c, nil
+func (m *mockContainerStore) GetContainerByExternalID(_ context.Context, agentID, externalID string) (*container.Container, error) {
+	for _, c := range m.containers {
+		if uid.Agent(c.AgentID) == uid.Agent(agentID) && c.ExternalID == externalID {
+			return c, nil
+		}
 	}
 	return nil, nil
 }

--- a/internal/store/certificates.go
+++ b/internal/store/certificates.go
@@ -393,10 +393,10 @@ func (s *CertificateStore) ListDueScheduledMonitors(ctx context.Context, now tim
 
 // --- Label-discovered monitors ---
 
-func (s *CertificateStore) ListMonitorsByExternalID(ctx context.Context, externalID string) ([]*certificate.CertMonitor, error) {
+func (s *CertificateStore) ListMonitorsByExternalID(ctx context.Context, agentID, externalID string) ([]*certificate.CertMonitor, error) {
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT `+certMonitorColumns+` FROM cert_monitors WHERE external_id=? AND source='label'`,
-		externalID)
+		`SELECT `+certMonitorColumns+` FROM cert_monitors WHERE agent_id=? AND external_id=? AND source='label'`,
+		uid.Agent(agentID), externalID)
 	if err != nil {
 		return nil, fmt.Errorf("list monitors by external_id: %w", err)
 	}

--- a/internal/store/containers.go
+++ b/internal/store/containers.go
@@ -57,6 +57,7 @@ func (s *ContainerStore) InsertContainer(ctx context.Context, c *container.Conta
 			is_ignored=excluded.is_ignored, alert_severity=excluded.alert_severity,
 			restart_threshold=excluded.restart_threshold, alert_channels=excluded.alert_channels,
 			archived=excluded.archived, last_state_change_at=excluded.last_state_change_at,
+			agent_id=excluded.agent_id,
 			runtime_type=excluded.runtime_type, error_detail=excluded.error_detail,
 			controller_kind=excluded.controller_kind, namespace=excluded.namespace,
 			pod_count=excluded.pod_count, ready_count=excluded.ready_count,
@@ -107,9 +108,9 @@ func (s *ContainerStore) UpdateContainer(ctx context.Context, c *container.Conta
 	return nil
 }
 
-func (s *ContainerStore) GetContainerByExternalID(ctx context.Context, externalID string) (*container.Container, error) {
+func (s *ContainerStore) GetContainerByExternalID(ctx context.Context, agentID, externalID string) (*container.Container, error) {
 	return s.scanContainer(s.db.QueryRowContext(ctx,
-		`SELECT `+containerColumns+` FROM containers WHERE external_id=?`, externalID))
+		`SELECT `+containerColumns+` FROM containers WHERE agent_id=? AND external_id=?`, uid.Agent(agentID), externalID))
 }
 
 func (s *ContainerStore) GetContainerByID(ctx context.Context, id string) (*container.Container, error) {
@@ -161,13 +162,13 @@ func (s *ContainerStore) ListContainers(ctx context.Context, opts container.List
 	return containers, rows.Err()
 }
 
-func (s *ContainerStore) ArchiveContainer(ctx context.Context, externalID string, archivedAt time.Time) error {
+func (s *ContainerStore) ArchiveContainer(ctx context.Context, id string, archivedAt time.Time) error {
 	_, err := s.writer.Exec(ctx,
-		`UPDATE containers SET archived=1, archived_at=? WHERE external_id=? AND archived=0`,
-		archivedAt.Unix(), externalID,
+		`UPDATE containers SET archived=1, archived_at=? WHERE id=? AND archived=0`,
+		archivedAt.Unix(), id,
 	)
 	if err != nil {
-		return fmt.Errorf("archive container %s: %w", externalID, err)
+		return fmt.Errorf("archive container %s: %w", id, err)
 	}
 	return nil
 }

--- a/internal/store/containers_agent_test.go
+++ b/internal/store/containers_agent_test.go
@@ -65,9 +65,134 @@ func TestUpdateContainer_PersistsAgentID(t *testing.T) {
 	c.Image = "img:v2"
 	require.NoError(t, cstore.UpdateContainer(ctx, c))
 
-	got, err := cstore.GetContainerByExternalID(ctx, "ext-agent-1")
+	got, err := cstore.GetContainerByExternalID(ctx, agentID, "ext-agent-1")
 	require.NoError(t, err)
 	require.NotNil(t, got)
 	assert.Equal(t, agentID, got.AgentID, "agent_id must survive UpdateContainer")
 	assert.Equal(t, "img:v2", got.Image)
+}
+
+func seedAgent(t *testing.T, db *DB, agentID string) {
+	t.Helper()
+	require.NoError(t, NewAgentStore(db).Insert(context.Background(), &agent.Agent{
+		AgentID:         agentID,
+		PublicKey:       make([]byte, 32),
+		Hostname:        agentID,
+		Label:           agentID,
+		OSArch:          "linux/amd64",
+		AgentVersion:    "dev",
+		DetectedRuntime: "docker",
+		Status:          "active",
+		CreatedAt:       time.Now(),
+	}))
+}
+
+func agentContainer(agentID, externalID string) *container.Container {
+	now := time.Now()
+	return &container.Container{
+		ExternalID:        externalID,
+		AgentID:           agentID,
+		Name:              externalID,
+		Image:             "img:v1",
+		State:             container.StateRunning,
+		AlertSeverity:     container.SeverityWarning,
+		RestartThreshold:  3,
+		RuntimeType:       "docker",
+		FirstSeenAt:       now,
+		LastStateChangeAt: now,
+	}
+}
+
+func TestContainerStore_GetByExternalID_ScopedByAgent(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	cstore := NewContainerStore(db)
+	seedAgent(t, db, "agent-a")
+	seedAgent(t, db, "agent-b")
+
+	const ext = "ext-shared"
+	idA, err := cstore.InsertContainer(ctx, agentContainer("agent-a", ext))
+	require.NoError(t, err)
+	idB, err := cstore.InsertContainer(ctx, agentContainer("agent-b", ext))
+	require.NoError(t, err)
+	require.NotEqual(t, idA, idB)
+
+	gotA, err := cstore.GetContainerByExternalID(ctx, "agent-a", ext)
+	require.NoError(t, err)
+	require.NotNil(t, gotA)
+	assert.Equal(t, idA, gotA.ID)
+
+	gotB, err := cstore.GetContainerByExternalID(ctx, "agent-b", ext)
+	require.NoError(t, err)
+	require.NotNil(t, gotB)
+	assert.Equal(t, idB, gotB.ID)
+
+	none, err := cstore.GetContainerByExternalID(ctx, "agent-a", "ext-unknown")
+	require.NoError(t, err)
+	assert.Nil(t, none)
+}
+
+func TestContainerStore_ArchiveByID_LeavesSibling(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	cstore := NewContainerStore(db)
+	seedAgent(t, db, "agent-a")
+	seedAgent(t, db, "agent-b")
+
+	const ext = "ext-shared"
+	idA, err := cstore.InsertContainer(ctx, agentContainer("agent-a", ext))
+	require.NoError(t, err)
+	_, err = cstore.InsertContainer(ctx, agentContainer("agent-b", ext))
+	require.NoError(t, err)
+
+	require.NoError(t, cstore.ArchiveContainer(ctx, idA, time.Now()))
+
+	gotA, err := cstore.GetContainerByExternalID(ctx, "agent-a", ext)
+	require.NoError(t, err)
+	require.NotNil(t, gotA)
+	assert.True(t, gotA.Archived)
+
+	gotB, err := cstore.GetContainerByExternalID(ctx, "agent-b", ext)
+	require.NoError(t, err)
+	require.NotNil(t, gotB)
+	assert.False(t, gotB.Archived, "archiving by id must not touch the other agent's row")
+}
+
+func TestContainerStore_Upsert_ReclaimsAgentID(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	cstore := NewContainerStore(db)
+	seedAgent(t, db, "agent-a")
+	seedAgent(t, db, "agent-b")
+
+	const ext = "ext-inherited"
+	idA, err := cstore.InsertContainer(ctx, agentContainer("agent-a", ext))
+	require.NoError(t, err)
+
+	// The takeover bug left A's row carrying B's agent_id.
+	stolen := agentContainer("agent-b", ext)
+	stolen.ID = idA
+	require.NoError(t, cstore.UpdateContainer(ctx, stolen))
+	got, err := cstore.GetContainerByExternalID(ctx, "agent-b", ext)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, idA, got.ID)
+
+	// A's next report reclaims its own row...
+	reclaimed, err := cstore.InsertContainer(ctx, agentContainer("agent-a", ext))
+	require.NoError(t, err)
+	assert.Equal(t, idA, reclaimed)
+	gotA, err := cstore.GetContainerByExternalID(ctx, "agent-a", ext)
+	require.NoError(t, err)
+	require.NotNil(t, gotA)
+	assert.Equal(t, idA, gotA.ID)
+
+	// ...and B's next report gets a row of its own.
+	idB, err := cstore.InsertContainer(ctx, agentContainer("agent-b", ext))
+	require.NoError(t, err)
+	assert.NotEqual(t, idA, idB)
+	gotB, err := cstore.GetContainerByExternalID(ctx, "agent-b", ext)
+	require.NoError(t, err)
+	require.NotNil(t, gotB)
+	assert.Equal(t, idB, gotB.ID)
 }

--- a/internal/store/endpoints.go
+++ b/internal/store/endpoints.go
@@ -152,10 +152,10 @@ func (s *EndpointStore) ListEndpoints(ctx context.Context, opts endpoint.ListEnd
 	return endpoints, rows.Err()
 }
 
-func (s *EndpointStore) ListEndpointsByExternalID(ctx context.Context, externalID string) ([]*endpoint.Endpoint, error) {
+func (s *EndpointStore) ListEndpointsByExternalID(ctx context.Context, agentID, externalID string) ([]*endpoint.Endpoint, error) {
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT `+endpointColumns+` FROM endpoints WHERE external_id=? AND active=1 ORDER BY label_key`,
-		externalID)
+		`SELECT `+endpointColumns+` FROM endpoints WHERE agent_id=? AND external_id=? AND active=1 ORDER BY label_key`,
+		uid.Agent(agentID), externalID)
 	if err != nil {
 		return nil, fmt.Errorf("list endpoints by external_id: %w", err)
 	}

--- a/internal/store/updates_orphan_test.go
+++ b/internal/store/updates_orphan_test.go
@@ -44,7 +44,7 @@ func seedScannedContainer(t *testing.T, cs *ContainerStore, externalID, name str
 	require.NoError(t, err)
 
 	if archivedAt != nil {
-		require.NoError(t, cs.ArchiveContainer(ctx, externalID, *archivedAt))
+		require.NoError(t, cs.ArchiveContainer(ctx, id, *archivedAt))
 	}
 	return id
 }

--- a/proto/ingest.proto
+++ b/proto/ingest.proto
@@ -238,6 +238,11 @@ message ContainerEvent {
   string status_message = 6;
   google.protobuf.Timestamp started_at = 7;
   map<string, string> labels = 8;
+  // Docker healthcheck state ("healthy", "unhealthy", "starting"); empty when the container has no healthcheck.
+  string health_status = 9;
+  bool has_health_check = 10;
+  // Set when the container was removed from the host; state is then EXITED so an older server treats it as a stop.
+  bool destroyed = 11;
 }
 
 // A full snapshot of every container the agent's runtime knows about, sent on
@@ -247,11 +252,13 @@ message ContainerEvent {
 // archived rather than deleted — containers carry history (transitions,
 // uptime, CVEs) that must outlive their removal.
 //
-// An inventory with no entries is never sent and never acted upon: the agent
-// skips it when discovery fails, so an empty snapshot could only mean "I could
-// not look", which the protocol cannot distinguish from "this host is empty".
+// `complete` disambiguates an empty snapshot: true means discovery succeeded
+// and the host genuinely has no containers, false means discovery failed and
+// the inventory must not be acted upon.
 message ContainerInventory {
   repeated ContainerEvent containers = 1;
+  // True when discovery succeeded; an empty complete snapshot is authoritative and retires every container of the agent.
+  bool complete = 2;
 }
 
 enum ContainerState {


### PR DESCRIPTION
The store identifies a container by `(agent_id, external_id)`: the primary key
is derived from both and the unique constraint covers the pair. The service
resolved one by `external_id` alone. Two hosts running the same image therefore
shared a row at random, and the agent path went further: it rewrote `agent_id`
on whatever row it found, so an enrolled agent could take over another host's
container by naming its external id, leaving a row whose key no longer matched
its own derivation.

Scope every lookup by agent, archive by primary key, and carry the agent id on
the domain event so the local runtime and a remote agent travel the same path
without sharing an identity. The upsert now reclaims `agent_id`, so a row left
behind by the old behaviour heals on the next report rather than needing a
migration.

Three defects lived on that same path and are fixed with it:

- **Remote healthchecks never reached the server.** The protocol carried no
  health field, so the agent dropped `health_status` events before sending them
  and a remote container stayed `running` while it turned unhealthy. Health now
  travels with the event and routes through the local pipeline.
- **The last container removed from a host was never archived.** An empty
  inventory could not be told apart from a failed discovery, and destroy events
  were not streamed at all. Inventories now carry `complete`; destroy travels as
  an exited state an older server still understands.
- **Reconnecting an agent could disconnect it.** `Close` removed whatever
  session was registered for that agent, so the replaced handler's deferred
  close killed the stream that had just replaced it. `Open` returns a token and
  `CloseStream` only closes the session it names.

The protocol changes are additive in both directions: an agent and a server on
different versions keep the behaviour they had.

Found by an external security audit of `2c6654c` (findings S-02, Q-01, Q-05,
Q-06).
