### PR TITLE
fix(security): report the vulnerability posture the analysis actually earned

### DIFF
--- a/frontend/src/components/PostureCategoryBreakdown.vue
+++ b/frontend/src/components/PostureCategoryBreakdown.vue
@@ -36,6 +36,12 @@ function categoryLabel(name: string): string {
   }
   return labels[name] || name
 }
+
+function unavailableLabel(cat: CategoryScore): string {
+  if (cat.evaluation === 'unsupported') return 'Not covered'
+  if (cat.evaluation === 'not_evaluated' || cat.evaluation === 'error') return 'Not evaluated'
+  return 'Not applicable'
+}
 </script>
 
 <template>
@@ -77,8 +83,13 @@ function categoryLabel(name: string): string {
       </template>
 
       <template v-else>
-        <div class="py-2 text-xs text-mnt-muted italic">
-          Not applicable
+        <div class="py-2">
+          <span
+            class="inline-flex items-center rounded-full border border-mnt-default px-2 py-0.5 text-[10px] font-bold text-mnt-muted"
+          >
+            {{ unavailableLabel(cat) }}
+          </span>
+          <p v-if="cat.summary" class="mt-1.5 text-[10px] text-mnt-muted">{{ cat.summary }}</p>
         </div>
       </template>
     </div>

--- a/frontend/src/services/postureApi.ts
+++ b/frontend/src/services/postureApi.ts
@@ -20,6 +20,7 @@ export interface CategoryScore {
   applicable: boolean
   issue_count: number
   summary: string
+  evaluation?: string
 }
 
 export interface ContainerRisk {

--- a/internal/app/adapters.go
+++ b/internal/app/adapters.go
@@ -68,6 +68,22 @@ func (a *CVEPostureAdapter) ListCVEsForContainer(ctx context.Context, containerE
 	return result, nil
 }
 
+// CVEEvaluationPostureAdapter adapts the update store for CVE evaluation state.
+type CVEEvaluationPostureAdapter struct {
+	Store update.UpdateStore
+}
+
+func (a *CVEEvaluationPostureAdapter) GetCVEEvaluation(ctx context.Context, containerExternalID string) (*security.CVEEvaluationInfo, error) {
+	eval, err := a.Store.GetCVEEvaluation(ctx, containerExternalID)
+	if err != nil {
+		return nil, fmt.Errorf("get cve evaluation: %w", err)
+	}
+	if eval == nil {
+		return nil, nil
+	}
+	return &security.CVEEvaluationInfo{Status: string(eval.Status)}, nil
+}
+
 // UpdatePostureAdapter adapts the update store for update/image-age scoring.
 type UpdatePostureAdapter struct {
 	Store update.UpdateStore

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -500,12 +500,13 @@ func New(cfg Config, logger *slog.Logger) (*App, error) {
 	// --- Security posture scoring ---
 	ackStore := store.NewAcknowledgmentStore(db)
 	a.scorer = security.NewScorer(security.ScorerDeps{
-		Certs:     &CertPostureAdapter{CertSvc: a.certSvc},
-		CVEs:      &CVEPostureAdapter{Store: updateStore},
-		Updates:   &UpdatePostureAdapter{Store: updateStore},
-		Security:  a.securitySvc,
-		Acks:      ackStore,
-		Threshold: cfg.SecurityScoreThreshold,
+		Certs:          &CertPostureAdapter{CertSvc: a.certSvc},
+		CVEs:           &CVEPostureAdapter{Store: updateStore},
+		CVEEvaluations: &CVEEvaluationPostureAdapter{Store: updateStore},
+		Updates:        &UpdatePostureAdapter{Store: updateStore},
+		Security:       a.securitySvc,
+		Acks:           ackStore,
+		Threshold:      cfg.SecurityScoreThreshold,
 	})
 
 	if cfg.SecurityScoreThreshold > 0 {

--- a/internal/mcp/tools_security.go
+++ b/internal/mcp/tools_security.go
@@ -31,7 +31,7 @@ func registerSecurityTools(server *gomcp.Server, svc *Services) {
 
 	gomcp.AddTool(server, &gomcp.Tool{
 		Name:        "list_cve",
-		Description: "List active CVE vulnerabilities detected in container images, optionally filtered by container or minimum severity." + requires(extension.CapCVEEnrichment),
+		Description: "List active CVE vulnerabilities detected in container images, optionally filtered by container or minimum severity. For a single container the response carries the CVE evaluation state: an empty list only means \"no known CVEs\" when the state is \"evaluated\"." + requires(extension.CapCVEEnrichment),
 		Annotations: &gomcp.ToolAnnotations{ReadOnlyHint: true},
 	}, listCVEHandler(svc))
 
@@ -65,6 +65,30 @@ type listRiskScoresInput struct {
 
 type getSecurityPostureInput struct {
 	ContainerID string `json:"container_id,omitempty" jsonschema:"Internal container ID; omit for the global infrastructure posture"`
+}
+
+// containerCVEList carries a container's CVEs alongside the state of its last
+// analysis, so an empty list is never mistaken for a clean bill of health.
+type containerCVEList struct {
+	ContainerID string                 `json:"container_id"`
+	Evaluation  string                 `json:"evaluation"`
+	CVEs        []*update.ContainerCVE `json:"cves"`
+}
+
+func evaluationState(e *update.CVEEvaluation) string {
+	if e == nil {
+		return security.EvaluationNotEvaluated
+	}
+	switch e.Status {
+	case update.CVEEvaluated:
+		return security.EvaluationEvaluated
+	case update.CVEUnsupported:
+		return security.EvaluationUnsupported
+	case update.CVEEvaluationError:
+		return security.EvaluationError
+	default:
+		return security.EvaluationNotEvaluated
+	}
 }
 
 // --- Handlers ---
@@ -107,7 +131,15 @@ func listCVEHandler(svc *Services) gomcp.ToolHandlerFor[listCVEInput, any] {
 			if err != nil {
 				return nil, nil, fmt.Errorf("failed to list container CVEs: %w", err)
 			}
-			return jsonResult(cves)
+			eval, err := svc.UpdateStore.GetCVEEvaluation(ctx, input.ContainerID)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to get CVE evaluation: %w", err)
+			}
+			return jsonResult(containerCVEList{
+				ContainerID: input.ContainerID,
+				Evaluation:  evaluationState(eval),
+				CVEs:        cves,
+			})
 		}
 		cves, err := svc.UpdateStore.ListAllActiveCVEs(ctx, update.ListCVEsOpts{Severity: input.Severity})
 		if err != nil {

--- a/internal/mcp/tools_security_test.go
+++ b/internal/mcp/tools_security_test.go
@@ -14,10 +14,14 @@ package mcp
 import (
 	"context"
 	"log/slog"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/kolapsis/maintenant/internal/extension"
 	"github.com/kolapsis/maintenant/internal/security"
+	"github.com/kolapsis/maintenant/internal/store"
+	"github.com/kolapsis/maintenant/internal/update"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -69,4 +73,45 @@ func TestGetSecurityPosture_CE_EditionRequired(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, result.IsError)
 	assert.Contains(t, textFromContent(t, result.Content), "edition_required")
+}
+
+func newTestUpdateStore(t *testing.T) update.UpdateStore {
+	t.Helper()
+	db, err := store.Open(filepath.Join(t.TempDir(), "test.db"), slog.Default())
+	require.NoError(t, err)
+	require.NoError(t, store.Migrate(context.Background(), db, slog.Default()))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	db.StartWriter(ctx)
+	t.Cleanup(func() {
+		cancel()
+		_ = db.Close()
+	})
+	return store.NewUpdateStore(db)
+}
+
+func TestListCVE_Container_NotEvaluated(t *testing.T) {
+	withEdition(t, extension.Pro)
+	svc := &Services{UpdateStore: newTestUpdateStore(t), Logger: slog.Default(), Version: "test"}
+
+	result, _, err := listCVEHandler(svc)(context.Background(), nil, listCVEInput{ContainerID: "c-1"})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, textFromContent(t, result.Content), `"evaluation":"not_evaluated"`)
+}
+
+func TestListCVE_Container_Evaluated(t *testing.T) {
+	withEdition(t, extension.Pro)
+	us := newTestUpdateStore(t)
+	require.NoError(t, us.UpsertCVEEvaluation(context.Background(), &update.CVEEvaluation{
+		ContainerID: "c-1",
+		Status:      update.CVEEvaluated,
+		EvaluatedAt: time.Now(),
+	}))
+	svc := &Services{UpdateStore: us, Logger: slog.Default(), Version: "test"}
+
+	result, _, err := listCVEHandler(svc)(context.Background(), nil, listCVEInput{ContainerID: "c-1"})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, textFromContent(t, result.Content), `"evaluation":"evaluated"`)
 }

--- a/internal/security/posture.go
+++ b/internal/security/posture.go
@@ -33,6 +33,7 @@ type CategoryScore struct {
 	Applicable bool   `json:"applicable"`
 	IssueCount int    `json:"issue_count"`
 	Summary    string `json:"summary"`
+	Evaluation string `json:"evaluation,omitempty"`
 }
 
 // InfrastructurePosture is the top-level aggregation across all containers.

--- a/internal/security/scorer.go
+++ b/internal/security/scorer.go
@@ -48,6 +48,16 @@ type CVEReader interface {
 	ListCVEsForContainer(ctx context.Context, containerExternalID string) ([]CVEInfo, error)
 }
 
+// CVEEvaluationInfo reports whether a container went through CVE analysis.
+type CVEEvaluationInfo struct {
+	Status string // "evaluated", "unsupported", "error"
+}
+
+// CVEEvaluationReader reports the CVE analysis state of a container.
+type CVEEvaluationReader interface {
+	GetCVEEvaluation(ctx context.Context, containerExternalID string) (*CVEEvaluationInfo, error)
+}
+
 // UpdateReader provides update and image age data for a container.
 type UpdateReader interface {
 	ListUpdatesForContainer(ctx context.Context, containerExternalID string) ([]UpdateInfo, error)
@@ -71,6 +81,14 @@ const (
 	CategoryImageAge        = "image_age"
 )
 
+// Category evaluation states, reported by CategoryScore.Evaluation.
+const (
+	EvaluationEvaluated    = "evaluated"
+	EvaluationUnsupported  = "unsupported"
+	EvaluationNotEvaluated = "not_evaluated"
+	EvaluationError        = "error"
+)
+
 // Category weights (must sum to 100).
 const (
 	WeightCVEs            = 30
@@ -89,6 +107,7 @@ type cachedScore struct {
 type ScorerDeps struct {
 	Certs                CertificateReader    // optional — nil skips TLS scoring
 	CVEs                 CVEReader            // optional — nil skips CVE scoring
+	CVEEvaluations       CVEEvaluationReader  // optional — nil makes every CVE category "not evaluated"
 	Updates              UpdateReader         // optional — nil skips update scoring
 	Security             *Service             // optional — nil skips network exposure scoring
 	Acks                 AcknowledgmentStore  // required
@@ -101,6 +120,7 @@ type ScorerDeps struct {
 type Scorer struct {
 	certs   CertificateReader
 	cves    CVEReader
+	cveEval CVEEvaluationReader
 	updates UpdateReader
 	sec     *Service
 	acks    AcknowledgmentStore
@@ -122,6 +142,7 @@ func NewScorer(d ScorerDeps) *Scorer {
 	return &Scorer{
 		certs:          d.Certs,
 		cves:           d.CVEs,
+		cveEval:        d.CVEEvaluations,
 		updates:        d.Updates,
 		sec:            d.Security,
 		acks:           d.Acks,
@@ -163,6 +184,7 @@ func (s *Scorer) computeContainerScore(ctx context.Context, containerID string, 
 		applicable bool
 		issueCount int
 		summary    string
+		evaluation string
 	}
 
 	categories := make([]categoryResult, 0, 5)
@@ -185,20 +207,31 @@ func (s *Scorer) computeContainerScore(ctx context.Context, containerID string, 
 	// --- CVEs ---
 	cveResult := categoryResult{name: CategoryCVEs, weight: WeightCVEs}
 	if s.cves != nil {
-		cves, err := s.cves.ListCVEsForContainer(ctx, containerExternalID)
+		state, err := s.cveEvaluationState(ctx, containerExternalID)
 		if err != nil {
-			return nil, fmt.Errorf("scoring cves for container %s: %w", containerID, err)
+			return nil, fmt.Errorf("reading cve evaluation for container %s: %w", containerID, err)
 		}
-		if len(cves) > 0 {
-			// Filter out acknowledged CVEs
-			filtered := filterAcknowledgedCVEs(ctx, cves, containerExternalID, s.acks)
+		cveResult.evaluation = state
+
+		switch state {
+		case EvaluationEvaluated:
+			cves, err := s.cves.ListCVEsForContainer(ctx, containerExternalID)
+			if err != nil {
+				return nil, fmt.Errorf("scoring cves for container %s: %w", containerID, err)
+			}
 			cveResult.applicable = true
-			cveResult.subScore, cveResult.issueCount, cveResult.summary = scoreCVEs(filtered, len(cves)-len(filtered))
-		} else {
-			// No CVEs means this category applies and scores perfectly
-			cveResult.applicable = true
-			cveResult.subScore = 100
-			cveResult.summary = "no known CVEs"
+			if len(cves) > 0 {
+				filtered := filterAcknowledgedCVEs(ctx, cves, containerExternalID, s.acks)
+				cveResult.subScore, cveResult.issueCount, cveResult.summary = scoreCVEs(filtered, len(cves)-len(filtered))
+			} else {
+				cveResult.subScore = 100
+				cveResult.summary = "no known CVEs"
+			}
+		case EvaluationUnsupported:
+			cveResult.summary = "image not covered by the vulnerability data source"
+		default:
+			cveResult.summary = "not evaluated"
+			isPartial = true
 		}
 	}
 	categories = append(categories, cveResult)
@@ -290,8 +323,9 @@ func (s *Scorer) computeContainerScore(ctx context.Context, containerID string, 
 			Applicable: c.applicable,
 			IssueCount: c.issueCount,
 			Summary:    c.summary,
+			Evaluation: c.evaluation,
 		}
-		if !c.applicable {
+		if !c.applicable && c.summary == "" {
 			categoryScores[i].Summary = "not applicable"
 		}
 	}
@@ -306,6 +340,27 @@ func (s *Scorer) computeContainerScore(ctx context.Context, containerID string, 
 		ComputedAt:      time.Now(),
 		IsPartial:       isPartial,
 	}, nil
+}
+
+// cveEvaluationState reports how the container's last CVE analysis went; a
+// missing reader or a missing row both mean it was never analysed.
+func (s *Scorer) cveEvaluationState(ctx context.Context, containerExternalID string) (string, error) {
+	if s.cveEval == nil {
+		return EvaluationNotEvaluated, nil
+	}
+	eval, err := s.cveEval.GetCVEEvaluation(ctx, containerExternalID)
+	if err != nil {
+		return "", err
+	}
+	if eval == nil {
+		return EvaluationNotEvaluated, nil
+	}
+	switch eval.Status {
+	case EvaluationEvaluated, EvaluationUnsupported, EvaluationError:
+		return eval.Status, nil
+	default:
+		return EvaluationNotEvaluated, nil
+	}
 }
 
 // ContainerInfo holds minimal container data for infrastructure scoring.

--- a/internal/security/scorer_test.go
+++ b/internal/security/scorer_test.go
@@ -39,6 +39,18 @@ func (m *mockCVEReader) ListCVEsForContainer(_ context.Context, containerExterna
 	return m.cves[containerExternalID], nil
 }
 
+type mockCVEEvalReader struct {
+	states map[string]string
+}
+
+func (m *mockCVEEvalReader) GetCVEEvaluation(_ context.Context, containerExternalID string) (*CVEEvaluationInfo, error) {
+	state, ok := m.states[containerExternalID]
+	if !ok {
+		return nil, nil
+	}
+	return &CVEEvaluationInfo{Status: state}, nil
+}
+
 type mockUpdateReader struct {
 	updates map[string][]UpdateInfo
 }
@@ -321,8 +333,9 @@ func TestScorerScoreContainer(t *testing.T) {
 		Updates: &mockUpdateReader{updates: map[string][]UpdateInfo{
 			"ext-1": {{UpdateType: "minor", PublishedAt: timePtr(time.Now().Add(-15 * 24 * time.Hour))}},
 		}},
-		Security: secSvc,
-		Acks:     &mockAckStore{},
+		CVEEvaluations: &mockCVEEvalReader{states: map[string]string{"ext-1": EvaluationEvaluated}},
+		Security:       secSvc,
+		Acks:           &mockAckStore{},
 	})
 
 	score, err := scorer.ScoreContainer(ctx, "c1", "ext-1", "test-container")
@@ -467,4 +480,122 @@ func TestScorerWithSecurityServiceNoInsights(t *testing.T) {
 
 func timePtr(t time.Time) *time.Time {
 	return &t
+}
+
+func cveCategory(t *testing.T, score *SecurityScore) *CategoryScore {
+	t.Helper()
+	for i := range score.Categories {
+		if score.Categories[i].Name == CategoryCVEs {
+			return &score.Categories[i]
+		}
+	}
+	t.Fatal("cve category missing")
+	return nil
+}
+
+func TestScorerCVENeverEvaluated(t *testing.T) {
+	ctx := context.Background()
+	secSvc := newTestService()
+
+	scorer := NewScorer(ScorerDeps{
+		CVEs:           &mockCVEReader{cves: map[string][]CVEInfo{}},
+		CVEEvaluations: &mockCVEEvalReader{},
+		Security:       secSvc,
+		Acks:           &mockAckStore{},
+	})
+
+	score, err := scorer.ScoreContainer(ctx, "c1", "ext-1", "test")
+	require.NoError(t, err)
+	require.NotNil(t, score)
+
+	cat := cveCategory(t, score)
+	assert.False(t, cat.Applicable)
+	assert.Equal(t, EvaluationNotEvaluated, cat.Evaluation)
+	assert.Equal(t, "not evaluated", cat.Summary)
+	assert.True(t, score.IsPartial)
+}
+
+func TestScorerCVEEvaluatedWithNoFindings(t *testing.T) {
+	ctx := context.Background()
+	secSvc := newTestService()
+
+	scorer := NewScorer(ScorerDeps{
+		CVEs:           &mockCVEReader{cves: map[string][]CVEInfo{}},
+		CVEEvaluations: &mockCVEEvalReader{states: map[string]string{"ext-1": EvaluationEvaluated}},
+		Security:       secSvc,
+		Acks:           &mockAckStore{},
+	})
+
+	score, err := scorer.ScoreContainer(ctx, "c1", "ext-1", "test")
+	require.NoError(t, err)
+	require.NotNil(t, score)
+
+	cat := cveCategory(t, score)
+	assert.True(t, cat.Applicable)
+	assert.Equal(t, 100, cat.SubScore)
+	assert.Equal(t, "no known CVEs", cat.Summary)
+	assert.False(t, score.IsPartial)
+}
+
+func TestScorerCVEUnsupportedImage(t *testing.T) {
+	ctx := context.Background()
+	secSvc := newTestService()
+
+	scorer := NewScorer(ScorerDeps{
+		CVEs:           &mockCVEReader{cves: map[string][]CVEInfo{}},
+		CVEEvaluations: &mockCVEEvalReader{states: map[string]string{"ext-1": EvaluationUnsupported}},
+		Security:       secSvc,
+		Acks:           &mockAckStore{},
+	})
+
+	score, err := scorer.ScoreContainer(ctx, "c1", "ext-1", "test")
+	require.NoError(t, err)
+	require.NotNil(t, score)
+
+	cat := cveCategory(t, score)
+	assert.False(t, cat.Applicable)
+	assert.Equal(t, EvaluationUnsupported, cat.Evaluation)
+	assert.NotEqual(t, "not applicable", cat.Summary)
+	assert.False(t, score.IsPartial)
+}
+
+func TestScorerCVEEvaluatedWithFindings(t *testing.T) {
+	ctx := context.Background()
+	secSvc := newTestService()
+
+	scorer := NewScorer(ScorerDeps{
+		CVEs: &mockCVEReader{cves: map[string][]CVEInfo{
+			"ext-1": {{CVEID: "CVE-2025-001", Severity: "critical"}},
+		}},
+		CVEEvaluations: &mockCVEEvalReader{states: map[string]string{"ext-1": EvaluationEvaluated}},
+		Security:       secSvc,
+		Acks:           &mockAckStore{},
+	})
+
+	score, err := scorer.ScoreContainer(ctx, "c1", "ext-1", "test")
+	require.NoError(t, err)
+	require.NotNil(t, score)
+
+	cat := cveCategory(t, score)
+	assert.True(t, cat.Applicable)
+	assert.Equal(t, 1, cat.IssueCount)
+	assert.Less(t, cat.SubScore, 100)
+	assert.False(t, score.IsPartial)
+}
+
+func TestScoreInfrastructurePartialWhenCVENotEvaluated(t *testing.T) {
+	ctx := context.Background()
+	secSvc := newTestService()
+
+	scorer := NewScorer(ScorerDeps{
+		CVEs:           &mockCVEReader{cves: map[string][]CVEInfo{}},
+		CVEEvaluations: &mockCVEEvalReader{},
+		Security:       secSvc,
+		Acks:           &mockAckStore{},
+	})
+
+	posture, err := scorer.ScoreInfrastructure(ctx, []ContainerInfo{{ID: "c1", ExternalID: "ext-1", Name: "a"}})
+	require.NoError(t, err)
+	require.NotNil(t, posture)
+	assert.True(t, posture.IsPartial)
 }

--- a/internal/store/cve_evaluations_test.go
+++ b/internal/store/cve_evaluations_test.go
@@ -1,0 +1,117 @@
+// Copyright 2026 Benjamin Touchard (Kolapsis)
+//
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+// or a commercial license. You may not use this file except in compliance
+// with one of these licenses.
+//
+// AGPL-3.0: https://www.gnu.org/licenses/agpl-3.0.html
+// Commercial: See COMMERCIAL-LICENSE.md
+//
+// Source: https://github.com/kolapsis/maintenant
+
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kolapsis/maintenant/internal/update"
+)
+
+func TestCVEEvaluation_UpsertThenGet(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	us := NewUpdateStore(db)
+
+	evaluatedAt := time.Now().Truncate(time.Second)
+	err := us.UpsertCVEEvaluation(ctx, &update.CVEEvaluation{
+		ContainerID:    "c1",
+		Status:         update.CVEEvaluated,
+		EvaluatedAt:    evaluatedAt,
+		Ecosystem:      "Debian",
+		PackageName:    "openssl",
+		PackageVersion: "1.1.1",
+	})
+	require.NoError(t, err)
+
+	got, err := us.GetCVEEvaluation(ctx, "c1")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "c1", got.ContainerID)
+	assert.Equal(t, update.CVEEvaluated, got.Status)
+	assert.True(t, evaluatedAt.Equal(got.EvaluatedAt))
+	assert.Equal(t, "Debian", got.Ecosystem)
+	assert.Equal(t, "openssl", got.PackageName)
+	assert.Equal(t, "1.1.1", got.PackageVersion)
+	assert.Empty(t, got.Error)
+}
+
+func TestCVEEvaluation_UpsertReplaces(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	us := NewUpdateStore(db)
+
+	first := time.Now().Add(-time.Hour).Truncate(time.Second)
+	require.NoError(t, us.UpsertCVEEvaluation(ctx, &update.CVEEvaluation{
+		ContainerID: "c1",
+		Status:      update.CVEEvaluated,
+		EvaluatedAt: first,
+		Ecosystem:   "Debian",
+		PackageName: "openssl",
+	}))
+
+	second := time.Now().Truncate(time.Second)
+	require.NoError(t, us.UpsertCVEEvaluation(ctx, &update.CVEEvaluation{
+		ContainerID: "c1",
+		Status:      update.CVEEvaluationError,
+		EvaluatedAt: second,
+		Error:       "osv.dev: connection refused",
+	}))
+
+	got, err := us.GetCVEEvaluation(ctx, "c1")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, update.CVEEvaluationError, got.Status)
+	assert.True(t, second.Equal(got.EvaluatedAt))
+	assert.Equal(t, "osv.dev: connection refused", got.Error)
+
+	rows, err := db.Reader().QueryContext(ctx, "SELECT COUNT(*) FROM cve_evaluations WHERE container_id = ?", "c1")
+	require.NoError(t, err)
+	defer func() { _ = rows.Close() }()
+	require.True(t, rows.Next())
+	var count int
+	require.NoError(t, rows.Scan(&count))
+	assert.Equal(t, 1, count, "the second upsert must replace, not add a row")
+}
+
+func TestCVEEvaluation_GetMissingIsNil(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	us := NewUpdateStore(db)
+
+	got, err := us.GetCVEEvaluation(ctx, "does-not-exist")
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+func TestCVEEvaluation_DeleteRemoves(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	us := NewUpdateStore(db)
+
+	require.NoError(t, us.UpsertCVEEvaluation(ctx, &update.CVEEvaluation{
+		ContainerID: "c1",
+		Status:      update.CVEUnsupported,
+		EvaluatedAt: time.Now(),
+	}))
+
+	require.NoError(t, us.DeleteCVEEvaluation(ctx, "c1"))
+
+	got, err := us.GetCVEEvaluation(ctx, "c1")
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}

--- a/internal/store/migrations/postgres/31_cve_evaluations.down.sql
+++ b/internal/store/migrations/postgres/31_cve_evaluations.down.sql
@@ -1,0 +1,2 @@
+-- Migration rollback is intentionally a no-op per the project convention
+-- (see 20_cert_ocsp.down.sql, 25_cert_sni.down.sql).

--- a/internal/store/migrations/postgres/31_cve_evaluations.up.sql
+++ b/internal/store/migrations/postgres/31_cve_evaluations.up.sql
@@ -1,0 +1,14 @@
+-- Tracks whether a container has actually been through CVE analysis, and how
+-- it went. Without this a container never analysed and a container analysed
+-- with zero findings both read as "no known CVEs": the scorer needs to tell
+-- them apart.
+CREATE TABLE cve_evaluations (
+    container_id    TEXT PRIMARY KEY NOT NULL,
+    status           TEXT NOT NULL,
+    evaluated_at     BIGINT NOT NULL,
+    ecosystem        TEXT,
+    package_name     TEXT,
+    package_version  TEXT,
+    error            TEXT
+);
+CREATE INDEX idx_cve_evaluations_status ON cve_evaluations(status);

--- a/internal/store/migrations/sqlite/31_cve_evaluations.down.sql
+++ b/internal/store/migrations/sqlite/31_cve_evaluations.down.sql
@@ -1,0 +1,2 @@
+-- Migration rollback is intentionally a no-op per the project convention
+-- (see 20_cert_ocsp.down.sql, 25_cert_sni.down.sql).

--- a/internal/store/migrations/sqlite/31_cve_evaluations.up.sql
+++ b/internal/store/migrations/sqlite/31_cve_evaluations.up.sql
@@ -1,0 +1,14 @@
+-- Tracks whether a container has actually been through CVE analysis, and how
+-- it went. Without this a container never analysed and a container analysed
+-- with zero findings both read as "no known CVEs": the scorer needs to tell
+-- them apart.
+CREATE TABLE cve_evaluations (
+    container_id    TEXT PRIMARY KEY NOT NULL,
+    status           TEXT NOT NULL,
+    evaluated_at     BIGINT NOT NULL,
+    ecosystem        TEXT,
+    package_name     TEXT,
+    package_version  TEXT,
+    error            TEXT
+);
+CREATE INDEX idx_cve_evaluations_status ON cve_evaluations(status);

--- a/internal/store/migrations_postgres_test.go
+++ b/internal/store/migrations_postgres_test.go
@@ -116,6 +116,7 @@ func TestMigratePostgres_ConcurrentCatchUp(t *testing.T) {
 	for _, undo := range []string{
 		"DROP TABLE instances", // 29
 		"ALTER TABLE notification_channels DROP COLUMN secret, DROP COLUMN config", // 30
+		"DROP TABLE cve_evaluations", // 31
 	} {
 		_, err = db.ReadDB().Exec(undo)
 		require.NoError(t, err, undo)

--- a/internal/store/transform.go
+++ b/internal/store/transform.go
@@ -148,9 +148,10 @@ func runConversion(ctx context.Context, conn *sql.Conn) error {
 	// Drop any pre-existing agents/enrollment_tokens from the never-deployed
 	// agent migrations (22-23) so the new schema can recreate them cleanly. No-op
 	// on production databases (migrations 1-21 never created these tables).
-	// instances was created empty by migration 29 moments ago (it is not a
-	// legacy table), and uuid_schema recreates it below.
-	for _, t := range []string{"agents", "enrollment_tokens", "instances"} {
+	// instances and cve_evaluations were created empty by later migrations
+	// moments ago (neither is a legacy table), and uuid_schema recreates
+	// them below.
+	for _, t := range []string{"agents", "enrollment_tokens", "instances", "cve_evaluations"} {
 		if err := exec("drop unreleased "+t, fmt.Sprintf("DROP TABLE IF EXISTS %q", t)); err != nil {
 			return err
 		}

--- a/internal/store/updates.go
+++ b/internal/store/updates.go
@@ -536,6 +536,66 @@ func (s *UpdateStore) GetCVESummaryCounts(ctx context.Context) (map[string]int, 
 	return counts, rows.Err()
 }
 
+// --- CVE evaluations ---
+
+func (s *UpdateStore) UpsertCVEEvaluation(ctx context.Context, e *update.CVEEvaluation) error {
+	_, err := s.writer.Exec(ctx,
+		`INSERT INTO cve_evaluations (container_id, status, evaluated_at, ecosystem, package_name, package_version, error)
+		VALUES (?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(container_id) DO UPDATE SET
+			status = excluded.status, evaluated_at = excluded.evaluated_at,
+			ecosystem = excluded.ecosystem, package_name = excluded.package_name,
+			package_version = excluded.package_version, error = excluded.error`,
+		e.ContainerID, string(e.Status), e.EvaluatedAt.Unix(), e.Ecosystem, e.PackageName, e.PackageVersion, e.Error,
+	)
+	if err != nil {
+		return fmt.Errorf("upsert cve evaluation: %w", err)
+	}
+	return nil
+}
+
+func (s *UpdateStore) GetCVEEvaluation(ctx context.Context, containerID string) (*update.CVEEvaluation, error) {
+	var e update.CVEEvaluation
+	var status string
+	var evaluatedAt int64
+	var ecosystem, packageName, packageVersion, evalErr sql.NullString
+
+	err := s.db.QueryRowContext(ctx,
+		`SELECT container_id, status, evaluated_at, ecosystem, package_name, package_version, error
+		FROM cve_evaluations WHERE container_id = ?`, containerID).
+		Scan(&e.ContainerID, &status, &evaluatedAt, &ecosystem, &packageName, &packageVersion, &evalErr)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get cve evaluation: %w", err)
+	}
+
+	e.Status = update.CVEEvaluationStatus(status)
+	e.EvaluatedAt = time.Unix(evaluatedAt, 0)
+	if ecosystem.Valid {
+		e.Ecosystem = ecosystem.String
+	}
+	if packageName.Valid {
+		e.PackageName = packageName.String
+	}
+	if packageVersion.Valid {
+		e.PackageVersion = packageVersion.String
+	}
+	if evalErr.Valid {
+		e.Error = evalErr.String
+	}
+	return &e, nil
+}
+
+func (s *UpdateStore) DeleteCVEEvaluation(ctx context.Context, containerID string) error {
+	_, err := s.writer.Exec(ctx, `DELETE FROM cve_evaluations WHERE container_id = ?`, containerID)
+	if err != nil {
+		return fmt.Errorf("delete cve evaluation: %w", err)
+	}
+	return nil
+}
+
 // --- Version pins ---
 
 func (s *UpdateStore) InsertVersionPin(ctx context.Context, p *update.VersionPin) (string, error) {

--- a/internal/store/uuid_schema.sql
+++ b/internal/store/uuid_schema.sql
@@ -682,6 +682,17 @@ CREATE INDEX idx_container_cves_container_id ON container_cves(container_id);
 CREATE INDEX idx_container_cves_severity ON container_cves(severity);
 CREATE UNIQUE INDEX uq_container_cves ON container_cves(container_id, cve_id);
 
+CREATE TABLE cve_evaluations (
+    container_id    TEXT PRIMARY KEY NOT NULL,
+    status           TEXT NOT NULL,
+    evaluated_at     BIGINT NOT NULL,
+    ecosystem        TEXT,
+    package_name     TEXT,
+    package_version  TEXT,
+    error            TEXT
+);
+CREATE INDEX idx_cve_evaluations_status ON cve_evaluations(status);
+
 CREATE TABLE version_pins (
     id            TEXT PRIMARY KEY NOT NULL,
     container_id  TEXT NOT NULL,

--- a/internal/update/cve.go
+++ b/internal/update/cve.go
@@ -15,38 +15,48 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 )
 
-const osvBatchURL = "https://api.osv.dev/v1/querybatch"
+const (
+	osvBaseURL    = "https://api.osv.dev"
+	maxOSVPages   = 10
+	cveCacheTTL   = 24 * time.Hour
+	cveSummaryMax = 512
+)
 
 // CVEClient queries OSV.dev for known vulnerabilities.
 type CVEClient struct {
-	store  UpdateStore
-	client *http.Client
-	logger *slog.Logger
-	delay  time.Duration
+	store   UpdateStore
+	client  *http.Client
+	logger  *slog.Logger
+	delay   time.Duration
+	baseURL string
 }
 
 // NewCVEClient creates a CVE lookup client.
 func NewCVEClient(store UpdateStore, logger *slog.Logger) *CVEClient {
 	return &CVEClient{
-		store:  store,
-		client: &http.Client{Timeout: 30 * time.Second},
-		logger: logger,
-		delay:  500 * time.Millisecond,
+		store:   store,
+		client:  &http.Client{Timeout: 30 * time.Second},
+		logger:  logger,
+		delay:   500 * time.Millisecond,
+		baseURL: osvBaseURL,
 	}
 }
 
 // osvQuery is a single query in the OSV batch request.
 type osvQuery struct {
-	Package osvPackage `json:"package"`
-	Version string     `json:"version,omitempty"`
+	Package   osvPackage `json:"package"`
+	Version   string     `json:"version,omitempty"`
+	PageToken string     `json:"page_token,omitempty"`
 }
 
 type osvPackage struct {
@@ -59,20 +69,30 @@ type osvBatchRequest struct {
 	Queries []osvQuery `json:"queries"`
 }
 
-// osvBatchResponse is the batch response.
+// osvBatchResponse is the batch response: ids only, no vulnerability detail.
 type osvBatchResponse struct {
-	Results []osvResult `json:"results"`
+	Results []osvBatchResult `json:"results"`
 }
 
-type osvResult struct {
-	Vulns []osvVuln `json:"vulns"`
+type osvBatchResult struct {
+	Vulns         []osvBatchVuln `json:"vulns"`
+	NextPageToken string         `json:"next_page_token"`
 }
 
-type osvVuln struct {
-	ID       string        `json:"id"`
-	Summary  string        `json:"summary"`
-	Severity []osvSeverity `json:"severity"`
-	Affected []osvAffected `json:"affected"`
+type osvBatchVuln struct {
+	ID       string `json:"id"`
+	Modified string `json:"modified"`
+}
+
+// osvVulnRecord is the full vulnerability record from GET /v1/vulns/{id}.
+type osvVulnRecord struct {
+	ID         string         `json:"id"`
+	Summary    string         `json:"summary"`
+	Details    string         `json:"details"`
+	Severity   []osvSeverity  `json:"severity"`
+	Affected   []osvAffected  `json:"affected"`
+	References []osvReference `json:"references"`
+	Aliases    []string       `json:"aliases"`
 }
 
 type osvSeverity struct {
@@ -96,6 +116,11 @@ type osvEvent struct {
 	Fixed      string `json:"fixed,omitempty"`
 }
 
+type osvReference struct {
+	Type string `json:"type"`
+	URL  string `json:"url"`
+}
+
 // ImageCVEQuery holds parameters for querying CVEs for an image.
 type ImageCVEQuery struct {
 	ContainerID string
@@ -104,7 +129,8 @@ type ImageCVEQuery struct {
 	Version     string
 }
 
-// QueryCVEs queries OSV.dev for a batch of images and returns CVEs.
+// QueryCVEs queries OSV.dev for a batch of images and returns CVEs, hydrating
+// each vulnerability id returned by the batch endpoint with its full record.
 func (c *CVEClient) QueryCVEs(ctx context.Context, queries []ImageCVEQuery) (map[string][]*CVECacheEntry, error) {
 	results := make(map[string][]*CVECacheEntry)
 
@@ -130,7 +156,6 @@ func (c *CVEClient) QueryCVEs(ctx context.Context, queries []ImageCVEQuery) (map
 		return results, nil
 	}
 
-	// Build OSV batch request
 	osvQueries := make([]osvQuery, len(uncached))
 	for i, q := range uncached {
 		osvQueries[i] = osvQuery{
@@ -139,135 +164,228 @@ func (c *CVEClient) QueryCVEs(ctx context.Context, queries []ImageCVEQuery) (map
 		}
 	}
 
-	body, err := json.Marshal(osvBatchRequest{Queries: osvQueries})
+	batchResp, err := c.postBatch(ctx, osvQueries)
 	if err != nil {
-		return results, fmt.Errorf("marshal osv request: %w", err)
+		return results, err
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, osvBatchURL, bytes.NewReader(body))
-	if err != nil {
-		return results, fmt.Errorf("create osv request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := c.client.Do(req)
-	if err != nil {
-		return results, fmt.Errorf("osv request: %w", err)
-	}
-	defer func(Body io.ReadCloser) {
-		_ = Body.Close()
-	}(resp.Body)
-
-	if resp.StatusCode != http.StatusOK {
-		return results, fmt.Errorf("osv returned status %d", resp.StatusCode)
-	}
-
-	var batchResp osvBatchResponse
-	if err := json.NewDecoder(resp.Body).Decode(&batchResp); err != nil {
-		return results, fmt.Errorf("decode osv response: %w", err)
-	}
-
-	// Process results
-	now := time.Now()
-	expires := now.Add(24 * time.Hour)
-
-	for i, result := range batchResp.Results {
-		if i >= len(uncached) {
+	vulnIDs := make([][]string, len(uncached))
+	for i := range uncached {
+		if i >= len(batchResp.Results) {
 			break
 		}
-		q := uncached[i]
-		var entries []*CVECacheEntry
-
-		for _, vuln := range result.Vulns {
-			severity, score := parseSeverity(vuln)
-			fixedIn := extractFixedIn(vuln)
-
-			entry := CVECacheEntry{
-				Ecosystem:      q.Ecosystem,
-				PackageName:    q.PackageName,
-				PackageVersion: q.Version,
-				CVEID:          vuln.ID,
-				CVSSScore:      score,
-				Severity:       severity,
-				Summary:        truncate(vuln.Summary, 512),
-				FixedIn:        fixedIn,
-				FetchedAt:      now,
-				ExpiresAt:      expires,
-			}
-
-			if _, err := c.store.InsertCVECacheEntry(ctx, &entry); err != nil {
-				c.logger.Warn("cve: failed to cache entry", "cve", vuln.ID, "error", err)
-			}
-
-			entries = append(entries, &entry)
+		ids, err := c.paginateResult(ctx, osvQueries[i], batchResp.Results[i])
+		if err != nil {
+			return results, err
 		}
+		vulnIDs[i] = ids
+	}
 
+	records := c.hydrateVulns(ctx, vulnIDs)
+
+	now := time.Now()
+	expires := now.Add(cveCacheTTL)
+
+	for i, q := range uncached {
+		var entries []*CVECacheEntry
+		for _, id := range vulnIDs[i] {
+			rec, ok := records[id]
+			if !ok {
+				continue
+			}
+			entry := c.buildCVECacheEntry(q, rec, now, expires)
+			if _, err := c.store.InsertCVECacheEntry(ctx, entry); err != nil {
+				c.logger.Warn("cve: failed to cache entry", "cve", entry.CVEID, "error", err)
+			}
+			entries = append(entries, entry)
+		}
 		results[q.ContainerID] = entries
 	}
 
 	return results, nil
 }
 
-func parseSeverity(vuln osvVuln) (CVESeverity, float64) {
-	for _, s := range vuln.Severity {
-		if s.Type == "CVSS_V3" {
-			score := parseCVSSScore(s.Score)
-			if score >= 9.0 {
-				return CVESeverityCritical, score
+// paginateResult follows next_page_token for a single query's batch result,
+// re-issuing the batch with only that query until the token is exhausted.
+func (c *CVEClient) paginateResult(ctx context.Context, q osvQuery, first osvBatchResult) ([]string, error) {
+	ids := idsFromVulns(first.Vulns)
+	token := first.NextPageToken
+	page := 1
+
+	for token != "" {
+		if page >= maxOSVPages {
+			c.logger.Warn("cve: osv pagination cap reached", "package", q.Package.Name, "ecosystem", q.Package.Ecosystem)
+			break
+		}
+
+		select {
+		case <-ctx.Done():
+			return ids, ctx.Err()
+		case <-time.After(c.delay):
+		}
+
+		pageQuery := q
+		pageQuery.PageToken = token
+		resp, err := c.postBatch(ctx, []osvQuery{pageQuery})
+		if err != nil {
+			return ids, err
+		}
+		page++
+		if len(resp.Results) == 0 {
+			break
+		}
+		ids = append(ids, idsFromVulns(resp.Results[0].Vulns)...)
+		token = resp.Results[0].NextPageToken
+	}
+
+	return ids, nil
+}
+
+func (c *CVEClient) postBatch(ctx context.Context, queries []osvQuery) (osvBatchResponse, error) {
+	body, err := json.Marshal(osvBatchRequest{Queries: queries})
+	if err != nil {
+		return osvBatchResponse{}, fmt.Errorf("marshal osv request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/v1/querybatch", bytes.NewReader(body))
+	if err != nil {
+		return osvBatchResponse{}, fmt.Errorf("create osv request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return osvBatchResponse{}, fmt.Errorf("osv request: %w", err)
+	}
+	defer func(Body io.ReadCloser) {
+		_ = Body.Close()
+	}(resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		return osvBatchResponse{}, fmt.Errorf("osv returned status %d", resp.StatusCode)
+	}
+
+	var batchResp osvBatchResponse
+	if err := json.NewDecoder(resp.Body).Decode(&batchResp); err != nil {
+		return osvBatchResponse{}, fmt.Errorf("decode osv response: %w", err)
+	}
+	return batchResp, nil
+}
+
+// hydrateVulns fetches each distinct vuln id once, memoising across queries.
+// A fetch failure for one id is logged and skipped, never fails the run.
+func (c *CVEClient) hydrateVulns(ctx context.Context, perQueryIDs [][]string) map[string]*osvVulnRecord {
+	records := make(map[string]*osvVulnRecord)
+	seen := make(map[string]bool)
+	fetched := false
+
+	for _, ids := range perQueryIDs {
+		for _, id := range ids {
+			if seen[id] {
+				continue
 			}
-			if score >= 7.0 {
-				return CVESeverityHigh, score
+			seen[id] = true
+
+			if fetched {
+				select {
+				case <-ctx.Done():
+					return records
+				case <-time.After(c.delay):
+				}
 			}
-			if score >= 4.0 {
-				return CVESeverityMedium, score
+			fetched = true
+
+			rec, err := c.fetchVuln(ctx, id)
+			if err != nil {
+				c.logger.Warn("cve: failed to fetch vuln", "id", id, "error", err)
+				continue
 			}
-			return CVESeverityLow, score
+			records[id] = rec
 		}
 	}
-	// Default based on OSV ID prefix
-	if strings.HasPrefix(vuln.ID, "CVE-") {
-		return CVESeverityMedium, 5.0
-	}
-	return CVESeverityLow, 0
+
+	return records
 }
 
-// parseCVSSScore extracts the base score from a CVSS v3 vector string.
-func parseCVSSScore(vector string) float64 {
-	// CVSS vectors look like: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
-	// We use a simplified scoring based on the attack vector components.
-	if vector == "" {
-		return 0
+func (c *CVEClient) fetchVuln(ctx context.Context, id string) (*osvVulnRecord, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/v1/vulns/"+url.PathEscape(id), nil)
+	if err != nil {
+		return nil, fmt.Errorf("create osv vuln request: %w", err)
 	}
 
-	score := 5.0 // base
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("osv vuln request: %w", err)
+	}
+	defer func(Body io.ReadCloser) {
+		_ = Body.Close()
+	}(resp.Body)
 
-	if strings.Contains(vector, "AV:N") {
-		score += 1.5
-	}
-	if strings.Contains(vector, "AC:L") {
-		score += 0.5
-	}
-	if strings.Contains(vector, "PR:N") {
-		score += 0.5
-	}
-	if strings.Contains(vector, "C:H") {
-		score += 1.0
-	}
-	if strings.Contains(vector, "I:H") {
-		score += 0.5
-	}
-	if strings.Contains(vector, "A:H") {
-		score += 0.5
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("osv vuln %s returned status %d", id, resp.StatusCode)
 	}
 
-	if score > 10.0 {
-		score = 10.0
+	var rec osvVulnRecord
+	if err := json.NewDecoder(resp.Body).Decode(&rec); err != nil {
+		return nil, fmt.Errorf("decode osv vuln %s: %w", id, err)
 	}
-	return score
+	return &rec, nil
 }
 
-func extractFixedIn(vuln osvVuln) string {
-	for _, a := range vuln.Affected {
+func (c *CVEClient) buildCVECacheEntry(q ImageCVEQuery, rec *osvVulnRecord, now, expires time.Time) *CVECacheEntry {
+	entry := &CVECacheEntry{
+		Ecosystem:      q.Ecosystem,
+		PackageName:    q.PackageName,
+		PackageVersion: q.Version,
+		CVEID:          rec.ID,
+		Summary:        summaryFor(rec),
+		FixedIn:        fixedInFor(q, rec),
+		Severity:       CVESeverityUnknown,
+		FetchedAt:      now,
+		ExpiresAt:      expires,
+	}
+
+	if vector, ok := cvssV3Vector(rec); ok {
+		entry.CVSSVector = vector
+		if metrics, err := ParseCVSSv3(vector); err == nil {
+			entry.CVSSScore = metrics.BaseScore()
+			entry.Severity = SeverityForScore(entry.CVSSScore)
+		} else if !errors.Is(err, ErrInvalidCVSS) {
+			c.logger.Warn("cve: unexpected cvss parse error", "cve", rec.ID, "error", err)
+		}
+	}
+
+	if len(rec.References) > 0 {
+		if b, err := json.Marshal(rec.References); err == nil {
+			entry.ReferencesJSON = string(b)
+		}
+	}
+
+	return entry
+}
+
+func idsFromVulns(vulns []osvBatchVuln) []string {
+	ids := make([]string, len(vulns))
+	for i, v := range vulns {
+		ids[i] = v.ID
+	}
+	return ids
+}
+
+func cvssV3Vector(rec *osvVulnRecord) (string, bool) {
+	for _, s := range rec.Severity {
+		if s.Type == "CVSS_V3" {
+			return s.Score, true
+		}
+	}
+	return "", false
+}
+
+func fixedInFor(q ImageCVEQuery, rec *osvVulnRecord) string {
+	for _, a := range rec.Affected {
+		if a.Package.Ecosystem != q.Ecosystem || !strings.EqualFold(a.Package.Name, q.PackageName) {
+			continue
+		}
 		for _, r := range a.Ranges {
 			for _, e := range r.Events {
 				if e.Fixed != "" {
@@ -277,6 +395,13 @@ func extractFixedIn(vuln osvVuln) string {
 		}
 	}
 	return ""
+}
+
+func summaryFor(rec *osvVulnRecord) string {
+	if rec.Summary != "" {
+		return rec.Summary
+	}
+	return truncate(rec.Details, cveSummaryMax)
 }
 
 func truncate(s string, maxLen int) string {

--- a/internal/update/cve_test.go
+++ b/internal/update/cve_test.go
@@ -1,0 +1,370 @@
+// Copyright 2026 Benjamin Touchard (kOlapsis)
+//
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+// or a commercial license. You may not use this file except in compliance
+// with one of these licenses.
+//
+// AGPL-3.0: https://www.gnu.org/licenses/agpl-3.0.html
+// Commercial: See COMMERCIAL-LICENSE.md
+//
+// Source: https://github.com/kolapsis/maintenant
+
+package update
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- stubs ---
+
+// cveStubStore is a stubStore that gives controllable CVE cache behavior;
+// every other UpdateStore method is the stubStore no-op default.
+type cveStubStore struct {
+	stubStore
+	mu            sync.Mutex
+	fresh         map[string]bool
+	cachedEntries map[string][]*CVECacheEntry
+	inserted      []*CVECacheEntry
+}
+
+func cveCacheKey(ecosystem, packageName, packageVersion string) string {
+	return ecosystem + "|" + packageName + "|" + packageVersion
+}
+
+func (s *cveStubStore) IsCVECacheFresh(_ context.Context, ecosystem, packageName, packageVersion string) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.fresh[cveCacheKey(ecosystem, packageName, packageVersion)], nil
+}
+
+func (s *cveStubStore) GetCVECacheEntries(_ context.Context, ecosystem, packageName, packageVersion string) ([]*CVECacheEntry, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.cachedEntries[cveCacheKey(ecosystem, packageName, packageVersion)], nil
+}
+
+func (s *cveStubStore) InsertCVECacheEntry(_ context.Context, e *CVECacheEntry) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.inserted = append(s.inserted, e)
+	return "cache-id", nil
+}
+
+// requestLog records the OSV requests a test server received, safe for
+// concurrent use since httptest handlers run on their own goroutine.
+type requestLog struct {
+	mu    sync.Mutex
+	batch []osvBatchRequest
+	vulns []string
+}
+
+func (l *requestLog) recordBatch(r osvBatchRequest) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.batch = append(l.batch, r)
+}
+
+func (l *requestLog) recordVuln(id string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.vulns = append(l.vulns, id)
+}
+
+func (l *requestLog) batchCount() int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return len(l.batch)
+}
+
+func (l *requestLog) batchAt(i int) osvBatchRequest {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.batch[i]
+}
+
+func (l *requestLog) vulnCount(id string) int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	n := 0
+	for _, v := range l.vulns {
+		if v == id {
+			n++
+		}
+	}
+	return n
+}
+
+func (l *requestLog) totalVulnRequests() int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return len(l.vulns)
+}
+
+func newTestCVEClient(store UpdateStore, serverURL string) *CVEClient {
+	c := NewCVEClient(store, testLogger())
+	c.baseURL = serverURL
+	c.delay = 0
+	return c
+}
+
+func writeJSON(t *testing.T, w http.ResponseWriter, v any) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	assert.NoError(t, json.NewEncoder(w).Encode(v))
+}
+
+// --- tests ---
+
+func TestQueryCVEs_HydratesFromVulnsEndpoint(t *testing.T) {
+	log := &requestLog{}
+	vulnRecords := map[string]osvVulnRecord{
+		"CVE-2024-0001": {
+			ID:      "CVE-2024-0001",
+			Summary: "OpenSSL vulnerable to buffer overflow",
+			Severity: []osvSeverity{
+				{Type: "CVSS_V3", Score: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"},
+			},
+			Affected: []osvAffected{
+				{
+					Package: osvPackage{Ecosystem: "Debian", Name: "openssl"},
+					Ranges: []osvRange{
+						{Type: "ECOSYSTEM", Events: []osvEvent{{Introduced: "0"}, {Fixed: "1.2.3"}}},
+					},
+				},
+			},
+		},
+		"GHSA-xxxx": {
+			ID:      "GHSA-xxxx",
+			Summary: "Unscored advisory",
+		},
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/querybatch", func(w http.ResponseWriter, r *http.Request) {
+		var req osvBatchRequest
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		log.recordBatch(req)
+		writeJSON(t, w, osvBatchResponse{
+			Results: []osvBatchResult{
+				{Vulns: []osvBatchVuln{{ID: "CVE-2024-0001"}, {ID: "GHSA-xxxx"}}},
+			},
+		})
+	})
+	mux.HandleFunc("/v1/vulns/", func(w http.ResponseWriter, r *http.Request) {
+		id := strings.TrimPrefix(r.URL.Path, "/v1/vulns/")
+		log.recordVuln(id)
+		rec, ok := vulnRecords[id]
+		assert.True(t, ok, "unexpected vuln id %q", id)
+		writeJSON(t, w, rec)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	client := newTestCVEClient(&cveStubStore{}, server.URL)
+
+	result, err := client.QueryCVEs(context.Background(), []ImageCVEQuery{
+		{ContainerID: "c1", PackageName: "openssl", Ecosystem: "Debian", Version: "1.1.1"},
+	})
+	require.NoError(t, err)
+
+	entries := result["c1"]
+	require.Len(t, entries, 2)
+
+	byID := make(map[string]*CVECacheEntry, len(entries))
+	for _, e := range entries {
+		byID[e.CVEID] = e
+	}
+
+	critical := byID["CVE-2024-0001"]
+	require.NotNil(t, critical)
+	assert.Equal(t, "OpenSSL vulnerable to buffer overflow", critical.Summary)
+	assert.Equal(t, CVESeverityCritical, critical.Severity)
+	assert.InDelta(t, 9.8, critical.CVSSScore, 0.001)
+	assert.Equal(t, "1.2.3", critical.FixedIn)
+
+	unscored := byID["GHSA-xxxx"]
+	require.NotNil(t, unscored)
+	assert.Equal(t, CVESeverityUnknown, unscored.Severity)
+	assert.Equal(t, float64(0), unscored.CVSSScore)
+}
+
+func TestQueryCVEs_BatchResponseCarriesNoDetails(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/querybatch", func(w http.ResponseWriter, r *http.Request) {
+		// Deliberately malformed per the OSV contract: a real querybatch
+		// response never carries summary/severity, only id and modified.
+		_, _ = w.Write([]byte(`{"results":[{"vulns":[{"id":"CVE-2024-0002","summary":"WRONG, MUST BE IGNORED","severity":[{"type":"CVSS_V3","score":"CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N"}]}]}]}`))
+	})
+	mux.HandleFunc("/v1/vulns/", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(t, w, osvVulnRecord{
+			ID:      "CVE-2024-0002",
+			Summary: "Real summary from the vulns endpoint",
+		})
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	client := newTestCVEClient(&cveStubStore{}, server.URL)
+
+	result, err := client.QueryCVEs(context.Background(), []ImageCVEQuery{
+		{ContainerID: "c1", PackageName: "curl", Ecosystem: "Debian", Version: "7.0"},
+	})
+	require.NoError(t, err)
+
+	entries := result["c1"]
+	require.Len(t, entries, 1)
+	assert.Equal(t, "Real summary from the vulns endpoint", entries[0].Summary)
+	assert.Equal(t, CVESeverityUnknown, entries[0].Severity)
+}
+
+func TestQueryCVEs_Paginates(t *testing.T) {
+	log := &requestLog{}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/querybatch", func(w http.ResponseWriter, r *http.Request) {
+		var req osvBatchRequest
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		log.recordBatch(req)
+
+		if len(req.Queries) == 1 && req.Queries[0].PageToken == "tok1" {
+			writeJSON(t, w, osvBatchResponse{
+				Results: []osvBatchResult{{Vulns: []osvBatchVuln{{ID: "CVE-B"}}}},
+			})
+			return
+		}
+		writeJSON(t, w, osvBatchResponse{
+			Results: []osvBatchResult{{Vulns: []osvBatchVuln{{ID: "CVE-A"}}, NextPageToken: "tok1"}},
+		})
+	})
+	mux.HandleFunc("/v1/vulns/", func(w http.ResponseWriter, r *http.Request) {
+		id := strings.TrimPrefix(r.URL.Path, "/v1/vulns/")
+		log.recordVuln(id)
+		writeJSON(t, w, osvVulnRecord{ID: id, Summary: "summary for " + id})
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	client := newTestCVEClient(&cveStubStore{}, server.URL)
+
+	result, err := client.QueryCVEs(context.Background(), []ImageCVEQuery{
+		{ContainerID: "c1", PackageName: "libfoo", Ecosystem: "Debian", Version: "2.0"},
+	})
+	require.NoError(t, err)
+
+	entries := result["c1"]
+	require.Len(t, entries, 2)
+
+	ids := map[string]bool{}
+	for _, e := range entries {
+		ids[e.CVEID] = true
+	}
+	assert.True(t, ids["CVE-A"])
+	assert.True(t, ids["CVE-B"])
+
+	require.Equal(t, 2, log.batchCount())
+	assert.Equal(t, "tok1", log.batchAt(1).Queries[0].PageToken)
+}
+
+func TestQueryCVEs_MemoisesVulnFetchAcrossQueries(t *testing.T) {
+	log := &requestLog{}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/querybatch", func(w http.ResponseWriter, r *http.Request) {
+		var req osvBatchRequest
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		log.recordBatch(req)
+
+		results := make([]osvBatchResult, len(req.Queries))
+		for i := range req.Queries {
+			results[i] = osvBatchResult{Vulns: []osvBatchVuln{{ID: "CVE-SHARED"}}}
+		}
+		writeJSON(t, w, osvBatchResponse{Results: results})
+	})
+	mux.HandleFunc("/v1/vulns/", func(w http.ResponseWriter, r *http.Request) {
+		id := strings.TrimPrefix(r.URL.Path, "/v1/vulns/")
+		log.recordVuln(id)
+		writeJSON(t, w, osvVulnRecord{ID: id, Summary: "shared vuln"})
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	client := newTestCVEClient(&cveStubStore{}, server.URL)
+
+	result, err := client.QueryCVEs(context.Background(), []ImageCVEQuery{
+		{ContainerID: "c1", PackageName: "libfoo", Ecosystem: "Debian", Version: "1.0"},
+		{ContainerID: "c2", PackageName: "libfoo", Ecosystem: "Debian", Version: "1.1"},
+	})
+	require.NoError(t, err)
+
+	require.Len(t, result["c1"], 1)
+	require.Len(t, result["c2"], 1)
+	assert.Equal(t, "CVE-SHARED", result["c1"][0].CVEID)
+	assert.Equal(t, "CVE-SHARED", result["c2"][0].CVEID)
+
+	assert.Equal(t, 1, log.vulnCount("CVE-SHARED"))
+	assert.Equal(t, 1, log.totalVulnRequests())
+}
+
+func TestQueryCVEs_VulnFetchFailureSkipsOnlyThatID(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/querybatch", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(t, w, osvBatchResponse{
+			Results: []osvBatchResult{{Vulns: []osvBatchVuln{{ID: "CVE-A"}, {ID: "CVE-B"}}}},
+		})
+	})
+	mux.HandleFunc("/v1/vulns/CVE-A", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	mux.HandleFunc("/v1/vulns/CVE-B", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(t, w, osvVulnRecord{ID: "CVE-B", Summary: "fine"})
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	client := newTestCVEClient(&cveStubStore{}, server.URL)
+
+	result, err := client.QueryCVEs(context.Background(), []ImageCVEQuery{
+		{ContainerID: "c1", PackageName: "libfoo", Ecosystem: "Debian", Version: "1.0"},
+	})
+	require.NoError(t, err)
+
+	entries := result["c1"]
+	require.Len(t, entries, 1)
+	assert.Equal(t, "CVE-B", entries[0].CVEID)
+}
+
+func TestQueryCVEs_UsesFreshCacheWithoutNetwork(t *testing.T) {
+	requests := 0
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	cached := []*CVECacheEntry{{CVEID: "CVE-CACHED", Severity: CVESeverityHigh}}
+	store := &cveStubStore{
+		fresh:         map[string]bool{cveCacheKey("Debian", "openssl", "1.1.1"): true},
+		cachedEntries: map[string][]*CVECacheEntry{cveCacheKey("Debian", "openssl", "1.1.1"): cached},
+	}
+	client := newTestCVEClient(store, server.URL)
+
+	result, err := client.QueryCVEs(context.Background(), []ImageCVEQuery{
+		{ContainerID: "c1", PackageName: "openssl", Ecosystem: "Debian", Version: "1.1.1"},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, cached, result["c1"])
+	assert.Equal(t, 0, requests)
+	assert.Empty(t, store.inserted)
+}

--- a/internal/update/cvss.go
+++ b/internal/update/cvss.go
@@ -1,0 +1,228 @@
+// Copyright 2026 Benjamin Touchard (kOlapsis)
+//
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+// or a commercial license. You may not use this file except in compliance
+// with one of these licenses.
+//
+// AGPL-3.0: https://www.gnu.org/licenses/agpl-3.0.html
+// Commercial: See COMMERCIAL-LICENSE.md
+//
+// Source: https://github.com/kolapsis/maintenant
+
+package update
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"strings"
+)
+
+// ErrInvalidCVSS reports a malformed or incomplete CVSS v3.x base vector.
+var ErrInvalidCVSS = errors.New("invalid CVSS v3 vector")
+
+// CVSSMetrics is a parsed CVSS v3.0/v3.1 base vector.
+type CVSSMetrics struct {
+	Version string
+	AV      string
+	AC      string
+	PR      string
+	UI      string
+	S       string
+	C       string
+	I       string
+	A       string
+}
+
+var cvssBaseValues = map[string]map[string]struct{}{
+	"AV": {"N": {}, "A": {}, "L": {}, "P": {}},
+	"AC": {"L": {}, "H": {}},
+	"PR": {"N": {}, "L": {}, "H": {}},
+	"UI": {"N": {}, "R": {}},
+	"S":  {"U": {}, "C": {}},
+	"C":  {"N": {}, "L": {}, "H": {}},
+	"I":  {"N": {}, "L": {}, "H": {}},
+	"A":  {"N": {}, "L": {}, "H": {}},
+}
+
+var cvssTemporalKeys = map[string]struct{}{
+	"E": {}, "RL": {}, "RC": {}, "CR": {}, "IR": {}, "AR": {},
+	"MAV": {}, "MAC": {}, "MPR": {}, "MUI": {}, "MS": {}, "MC": {}, "MI": {}, "MA": {},
+}
+
+// ParseCVSSv3 parses a "CVSS:3.x/AV:../AC:../PR:../UI:../S:../C:../I:../A:.." base vector.
+func ParseCVSSv3(vector string) (CVSSMetrics, error) {
+	parts := strings.Split(vector, "/")
+	if len(parts) < 1 {
+		return CVSSMetrics{}, fmt.Errorf("%w: empty vector", ErrInvalidCVSS)
+	}
+
+	var version string
+	switch parts[0] {
+	case "CVSS:3.0":
+		version = "3.0"
+	case "CVSS:3.1":
+		version = "3.1"
+	default:
+		return CVSSMetrics{}, fmt.Errorf("%w: unsupported prefix %q", ErrInvalidCVSS, parts[0])
+	}
+
+	m := CVSSMetrics{Version: version}
+	seen := make(map[string]bool, 8)
+
+	for _, part := range parts[1:] {
+		kv := strings.SplitN(part, ":", 2)
+		if len(kv) != 2 {
+			return CVSSMetrics{}, fmt.Errorf("%w: malformed metric %q", ErrInvalidCVSS, part)
+		}
+		key, value := kv[0], kv[1]
+
+		if _, ok := cvssTemporalKeys[key]; ok {
+			continue
+		}
+
+		allowed, ok := cvssBaseValues[key]
+		if !ok {
+			return CVSSMetrics{}, fmt.Errorf("%w: unknown metric %q", ErrInvalidCVSS, key)
+		}
+		if _, ok := allowed[value]; !ok {
+			return CVSSMetrics{}, fmt.Errorf("%w: invalid value %q for metric %q", ErrInvalidCVSS, value, key)
+		}
+		if seen[key] {
+			return CVSSMetrics{}, fmt.Errorf("%w: duplicate metric %q", ErrInvalidCVSS, key)
+		}
+		seen[key] = true
+
+		switch key {
+		case "AV":
+			m.AV = value
+		case "AC":
+			m.AC = value
+		case "PR":
+			m.PR = value
+		case "UI":
+			m.UI = value
+		case "S":
+			m.S = value
+		case "C":
+			m.C = value
+		case "I":
+			m.I = value
+		case "A":
+			m.A = value
+		}
+	}
+
+	for key := range cvssBaseValues {
+		if !seen[key] {
+			return CVSSMetrics{}, fmt.Errorf("%w: missing metric %q", ErrInvalidCVSS, key)
+		}
+	}
+
+	return m, nil
+}
+
+func cvssCIAValue(v string) float64 {
+	switch v {
+	case "H":
+		return 0.56
+	case "L":
+		return 0.22
+	default:
+		return 0
+	}
+}
+
+func cvssAVValue(v string) float64 {
+	switch v {
+	case "N":
+		return 0.85
+	case "A":
+		return 0.62
+	case "L":
+		return 0.55
+	default:
+		return 0.2
+	}
+}
+
+func cvssACValue(v string) float64 {
+	if v == "L" {
+		return 0.77
+	}
+	return 0.44
+}
+
+func cvssPRValue(v, scope string) float64 {
+	if scope == "C" {
+		switch v {
+		case "N":
+			return 0.85
+		case "L":
+			return 0.68
+		default:
+			return 0.5
+		}
+	}
+	switch v {
+	case "N":
+		return 0.85
+	case "L":
+		return 0.62
+	default:
+		return 0.27
+	}
+}
+
+func cvssUIValue(v string) float64 {
+	if v == "N" {
+		return 0.85
+	}
+	return 0.62
+}
+
+func cvssRoundup(input float64) float64 {
+	intInput := int(math.Round(input * 100000))
+	if intInput%10000 == 0 {
+		return float64(intInput) / 100000.0
+	}
+	return float64(intInput/10000+1) / 10.0
+}
+
+// BaseScore computes the CVSS base score of the metrics using the v3.1 formulas
+// (the v3.0 spec differs only in Roundup precision, not the score itself).
+func (m CVSSMetrics) BaseScore() float64 {
+	iss := 1 - (1-cvssCIAValue(m.C))*(1-cvssCIAValue(m.I))*(1-cvssCIAValue(m.A))
+
+	var impact float64
+	if m.S == "C" {
+		impact = 7.52*(iss-0.029) - 3.25*math.Pow(iss-0.02, 15)
+	} else {
+		impact = 6.42 * iss
+	}
+
+	if impact <= 0 {
+		return 0
+	}
+
+	exploitability := 8.22 * cvssAVValue(m.AV) * cvssACValue(m.AC) * cvssPRValue(m.PR, m.S) * cvssUIValue(m.UI)
+
+	if m.S == "C" {
+		return cvssRoundup(math.Min(1.08*(impact+exploitability), 10))
+	}
+	return cvssRoundup(math.Min(impact+exploitability, 10))
+}
+
+// SeverityForScore maps a CVSS base score to its qualitative severity rating.
+func SeverityForScore(score float64) CVESeverity {
+	if score >= 9.0 {
+		return CVESeverityCritical
+	}
+	if score >= 7.0 {
+		return CVESeverityHigh
+	}
+	if score >= 4.0 {
+		return CVESeverityMedium
+	}
+	return CVESeverityLow
+}

--- a/internal/update/cvss_test.go
+++ b/internal/update/cvss_test.go
@@ -1,0 +1,111 @@
+// Copyright 2026 Benjamin Touchard (kOlapsis)
+//
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+// or a commercial license. You may not use this file except in compliance
+// with one of these licenses.
+//
+// AGPL-3.0: https://www.gnu.org/licenses/agpl-3.0.html
+// Commercial: See COMMERCIAL-LICENSE.md
+//
+// Source: https://github.com/kolapsis/maintenant
+
+package update
+
+import (
+	"errors"
+	"math"
+	"testing"
+)
+
+func TestParseCVSSv3BaseScore(t *testing.T) {
+	tests := []struct {
+		name   string
+		vector string
+		want   float64
+	}{
+		{"none", "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N", 0.0},
+		{"critical unchanged", "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H", 9.8},
+		{"critical changed", "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H", 10.0},
+		{"high AC", "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H", 8.1},
+		{"medium changed", "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:L/I:L/A:N", 6.4},
+		{"local high", "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H", 7.8},
+		{"user interaction", "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H", 6.5},
+		{"physical low", "CVSS:3.1/AV:P/AC:H/PR:H/UI:R/S:U/C:L/I:N/A:N", 1.6},
+		{"adjacent", "CVSS:3.1/AV:A/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H", 6.5},
+		{"v3.0 critical", "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H", 9.8},
+		{"with temporal metrics", "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/E:P/RL:O/RC:C", 9.8},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, err := ParseCVSSv3(tt.vector)
+			if err != nil {
+				t.Fatalf("ParseCVSSv3(%q) returned error: %v", tt.vector, err)
+			}
+			got := m.BaseScore()
+			if math.Abs(got-tt.want) > 1e-9 {
+				t.Errorf("BaseScore() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseCVSSv3ACNotConfusedWithC(t *testing.T) {
+	m, err := ParseCVSSv3("CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H")
+	if err != nil {
+		t.Fatalf("ParseCVSSv3 returned error: %v", err)
+	}
+	if m.AC != "H" {
+		t.Errorf("AC = %q, want %q", m.AC, "H")
+	}
+	if m.C != "H" {
+		t.Errorf("C = %q, want %q", m.C, "H")
+	}
+	if got := m.BaseScore(); math.Abs(got-8.1) > 1e-9 {
+		t.Errorf("BaseScore() = %v, want %v", got, 8.1)
+	}
+}
+
+func TestParseCVSSv3Invalid(t *testing.T) {
+	tests := []struct {
+		name   string
+		vector string
+	}{
+		{"empty", ""},
+		{"unsupported version", "CVSS:2.0/AV:N/AC:L/Au:N/C:N/I:N/A:N"},
+		{"missing metric", "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N"},
+		{"duplicate metric", "CVSS:3.1/AV:N/AV:A/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N"},
+		{"unknown value", "CVSS:3.1/AV:X/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N"},
+		{"garbage", "not a cvss vector"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParseCVSSv3(tt.vector)
+			if !errors.Is(err, ErrInvalidCVSS) {
+				t.Errorf("ParseCVSSv3(%q) error = %v, want errors.Is(err, ErrInvalidCVSS)", tt.vector, err)
+			}
+		})
+	}
+}
+
+func TestSeverityForScore(t *testing.T) {
+	tests := []struct {
+		score float64
+		want  CVESeverity
+	}{
+		{8.9, CVESeverityHigh},
+		{9.0, CVESeverityCritical},
+		{6.9, CVESeverityMedium},
+		{7.0, CVESeverityHigh},
+		{3.9, CVESeverityLow},
+		{4.0, CVESeverityMedium},
+	}
+
+	for _, tt := range tests {
+		got := SeverityForScore(tt.score)
+		if got != tt.want {
+			t.Errorf("SeverityForScore(%v) = %v, want %v", tt.score, got, tt.want)
+		}
+	}
+}

--- a/internal/update/enricher.go
+++ b/internal/update/enricher.go
@@ -17,6 +17,8 @@ import (
 	"time"
 )
 
+const maxEvaluationErrorLen = 200
+
 // ProEnricher enriches scan results with CVE data, changelog info, and risk scores.
 type ProEnricher struct {
 	store     UpdateStore
@@ -39,25 +41,21 @@ func NewProEnricher(store UpdateStore, cve *CVEClient, changelog *ChangelogResol
 	}
 }
 
-// Enrich runs CVE lookup, changelog resolution, and risk scoring for each update result.
+// Enrich runs a CVE pass for every scanned container, then resolves the
+// changelog and risk score of those that actually have an update pending.
 func (e *ProEnricher) Enrich(ctx context.Context, results []UpdateResult) error {
 	for i := range results {
-		if !results[i].HasUpdate {
-			continue
-		}
-
 		r := &results[i]
-		e.logger.Debug("enriching update",
+		e.logger.Debug("enriching container",
 			"container", r.ContainerName, "image", r.Image,
-			"current", r.CurrentTag, "latest", r.LatestTag)
+			"current", r.CurrentTag, "latest", r.LatestTag, "has_update", r.HasUpdate)
 
-		// 1. Changelog resolution
-		e.enrichChangelog(ctx, r)
-
-		// 2. CVE lookup
 		cves := e.enrichCVEs(ctx, r)
 
-		// 3. Risk scoring
+		if !r.HasUpdate {
+			continue
+		}
+		e.enrichChangelog(ctx, r)
 		e.enrichRisk(ctx, r, cves)
 	}
 
@@ -102,28 +100,32 @@ func (e *ProEnricher) enrichCVEs(ctx context.Context, r *UpdateResult) []*Contai
 		return nil
 	}
 
-	var query *ImageCVEQuery
-	if e.ecosystem != nil {
-		result := e.ecosystem.Resolve(ctx, r.Image, r.CurrentTag, r.CurrentDigest, nil)
-		if result != nil {
-			query = &ImageCVEQuery{
-				PackageName: result.PackageName,
-				Ecosystem:   result.Ecosystem,
-				Version:     r.CurrentTag,
-			}
-		}
-	}
+	query := e.resolveCVEQuery(ctx, r)
 	if query == nil {
 		e.logger.Debug("cve: no ecosystem mapping", "container", r.ContainerName, "image", r.Image)
+		e.recordEvaluation(ctx, r, &CVEEvaluation{Status: CVEUnsupported})
 		return nil
 	}
-	query.ContainerID = r.ContainerID
 
 	cveResults, err := e.cve.QueryCVEs(ctx, []ImageCVEQuery{*query})
 	if err != nil {
 		e.logger.Warn("cve: query failed", "container", r.ContainerName, "error", err)
+		e.recordEvaluation(ctx, r, &CVEEvaluation{
+			Status:         CVEEvaluationError,
+			Ecosystem:      query.Ecosystem,
+			PackageName:    query.PackageName,
+			PackageVersion: query.Version,
+			Error:          shortError(err),
+		})
 		return nil
 	}
+
+	e.recordEvaluation(ctx, r, &CVEEvaluation{
+		Status:         CVEEvaluated,
+		Ecosystem:      query.Ecosystem,
+		PackageName:    query.PackageName,
+		PackageVersion: query.Version,
+	})
 
 	entries := cveResults[r.ContainerID]
 	if len(entries) == 0 {
@@ -134,7 +136,6 @@ func (e *ProEnricher) enrichCVEs(ctx context.Context, r *UpdateResult) []*Contai
 	e.logger.Info("cve: vulnerabilities found",
 		"container", r.ContainerName, "count", len(entries))
 
-	// Persist as ContainerCVE records
 	var cves []*ContainerCVE
 	now := time.Now()
 	for _, entry := range entries {
@@ -155,6 +156,38 @@ func (e *ProEnricher) enrichCVEs(ctx context.Context, r *UpdateResult) []*Contai
 	}
 
 	return cves
+}
+
+func (e *ProEnricher) resolveCVEQuery(ctx context.Context, r *UpdateResult) *ImageCVEQuery {
+	if e.ecosystem == nil {
+		return nil
+	}
+	resolved := e.ecosystem.Resolve(ctx, r.Image, r.CurrentTag, r.CurrentDigest, nil)
+	if resolved == nil {
+		return nil
+	}
+	return &ImageCVEQuery{
+		ContainerID: r.ContainerID,
+		PackageName: resolved.PackageName,
+		Ecosystem:   resolved.Ecosystem,
+		Version:     r.CurrentTag,
+	}
+}
+
+func (e *ProEnricher) recordEvaluation(ctx context.Context, r *UpdateResult, eval *CVEEvaluation) {
+	eval.ContainerID = r.ContainerID
+	eval.EvaluatedAt = time.Now()
+	if err := e.store.UpsertCVEEvaluation(ctx, eval); err != nil {
+		e.logger.Warn("cve: failed to persist evaluation", "container", r.ContainerName, "error", err)
+	}
+}
+
+func shortError(err error) string {
+	msg := err.Error()
+	if len(msg) > maxEvaluationErrorLen {
+		return msg[:maxEvaluationErrorLen]
+	}
+	return msg
 }
 
 func (e *ProEnricher) enrichRisk(ctx context.Context, r *UpdateResult, cves []*ContainerCVE) {

--- a/internal/update/enricher_test.go
+++ b/internal/update/enricher_test.go
@@ -1,0 +1,220 @@
+// Copyright 2026 Benjamin Touchard (Kolapsis)
+//
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+// or a commercial license. You may not use this file except in compliance
+// with one of these licenses.
+//
+// AGPL-3.0: https://www.gnu.org/licenses/agpl-3.0.html
+// Commercial: See COMMERCIAL-LICENSE.md
+//
+// Source: https://github.com/kolapsis/maintenant
+
+package update
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// enricherStubStore records what the enricher persists and always resolves a
+// pending update, so changelog and risk enrichment can actually run.
+type enricherStubStore struct {
+	stubStore
+	mu          sync.Mutex
+	imageUpdate *ImageUpdate
+	evaluations map[string]*CVEEvaluation
+	cves        []*ContainerCVE
+	riskRecords []*RiskScoreRecord
+}
+
+func newEnricherStubStore() *enricherStubStore {
+	return &enricherStubStore{
+		imageUpdate: &ImageUpdate{ID: "u1", ContainerID: "c1", UpdateType: UpdateTypeMinor},
+		evaluations: make(map[string]*CVEEvaluation),
+	}
+}
+
+func (s *enricherStubStore) GetImageUpdateByContainer(_ context.Context, containerID string) (*ImageUpdate, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.imageUpdate == nil || s.imageUpdate.ContainerID != containerID {
+		return nil, nil
+	}
+	return s.imageUpdate, nil
+}
+
+func (s *enricherStubStore) UpsertCVEEvaluation(_ context.Context, e *CVEEvaluation) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.evaluations[e.ContainerID] = e
+	return nil
+}
+
+func (s *enricherStubStore) UpsertContainerCVE(_ context.Context, c *ContainerCVE) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.cves = append(s.cves, c)
+	return nil
+}
+
+func (s *enricherStubStore) InsertRiskScoreRecord(_ context.Context, r *RiskScoreRecord) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.riskRecords = append(s.riskRecords, r)
+	return "risk-1", nil
+}
+
+func (s *enricherStubStore) evaluation(containerID string) *CVEEvaluation {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.evaluations[containerID]
+}
+
+func (s *enricherStubStore) storedCVEs() []*ContainerCVE {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]*ContainerCVE(nil), s.cves...)
+}
+
+func (s *enricherStubStore) storedRiskRecords() []*RiskScoreRecord {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]*RiskScoreRecord(nil), s.riskRecords...)
+}
+
+// osvTestServer serves one vulnerability for every batch query.
+func osvTestServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/querybatch", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(t, w, osvBatchResponse{
+			Results: []osvBatchResult{{Vulns: []osvBatchVuln{{ID: "CVE-2024-9999"}}}},
+		})
+	})
+	mux.HandleFunc("/v1/vulns/", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(t, w, osvVulnRecord{
+			ID:      strings.TrimPrefix(r.URL.Path, "/v1/vulns/"),
+			Summary: "test advisory",
+			Severity: []osvSeverity{
+				{Type: "CVSS_V3", Score: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"},
+			},
+		})
+	})
+	return httptest.NewServer(mux)
+}
+
+func newTestEnricher(store UpdateStore, cve *CVEClient) *ProEnricher {
+	return NewProEnricher(store, cve, nil, NewRiskEngine(), NewEcosystemResolver(nil, testLogger()), testLogger())
+}
+
+func TestEnrichScansContainerWithoutUpdate(t *testing.T) {
+	server := osvTestServer(t)
+	defer server.Close()
+
+	store := newEnricherStubStore()
+	enricher := newTestEnricher(store, newTestCVEClient(store, server.URL))
+
+	results := []UpdateResult{{
+		ContainerID:   "c1",
+		ContainerName: "web",
+		Image:         "nginx",
+		CurrentTag:    "1.27.0",
+		HasUpdate:     false,
+	}}
+	require.NoError(t, enricher.Enrich(context.Background(), results))
+
+	eval := store.evaluation("c1")
+	require.NotNil(t, eval, "an up-to-date container must still be evaluated")
+	assert.Equal(t, CVEEvaluated, eval.Status)
+	assert.Equal(t, "Debian:12", eval.Ecosystem)
+	assert.Equal(t, "nginx", eval.PackageName)
+	assert.Equal(t, "1.27.0", eval.PackageVersion)
+
+	require.Len(t, store.storedCVEs(), 1)
+	assert.Empty(t, store.storedRiskRecords(), "risk scoring describes an update that does not exist")
+	assert.Empty(t, results[0].ChangelogURL)
+}
+
+func TestEnrichRunsChangelogAndRiskOnlyWithUpdate(t *testing.T) {
+	server := osvTestServer(t)
+	defer server.Close()
+
+	store := newEnricherStubStore()
+	enricher := newTestEnricher(store, newTestCVEClient(store, server.URL))
+
+	results := []UpdateResult{{
+		ContainerID:   "c1",
+		ContainerName: "web",
+		Image:         "nginx",
+		CurrentTag:    "1.27.0",
+		LatestTag:     "1.28.0",
+		UpdateType:    UpdateTypeMinor,
+		HasUpdate:     true,
+	}}
+	require.NoError(t, enricher.Enrich(context.Background(), results))
+
+	require.NotNil(t, store.evaluation("c1"))
+	assert.Len(t, store.storedRiskRecords(), 1)
+}
+
+func TestEnrichRecordsUnsupportedWithoutEcosystem(t *testing.T) {
+	server := osvTestServer(t)
+	defer server.Close()
+
+	store := newEnricherStubStore()
+	enricher := newTestEnricher(store, newTestCVEClient(store, server.URL))
+
+	results := []UpdateResult{{
+		ContainerID:   "c1",
+		ContainerName: "tiny",
+		Image:         "scratch",
+		CurrentTag:    "latest",
+	}}
+	require.NoError(t, enricher.Enrich(context.Background(), results))
+
+	eval := store.evaluation("c1")
+	require.NotNil(t, eval)
+	assert.Equal(t, CVEUnsupported, eval.Status)
+	assert.Empty(t, eval.Ecosystem)
+	assert.Empty(t, store.storedCVEs())
+}
+
+func TestEnrichRecordsErrorOnQueryFailure(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	store := newEnricherStubStore()
+	enricher := newTestEnricher(store, newTestCVEClient(store, server.URL))
+
+	results := []UpdateResult{{
+		ContainerID:   "c1",
+		ContainerName: "web",
+		Image:         "nginx",
+		CurrentTag:    "1.27.0",
+	}}
+	require.NoError(t, enricher.Enrich(context.Background(), results))
+
+	eval := store.evaluation("c1")
+	require.NotNil(t, eval)
+	assert.Equal(t, CVEEvaluationError, eval.Status)
+	assert.NotEmpty(t, eval.Error)
+	assert.Empty(t, store.storedCVEs(), "a failed query must not invent a clean bill of health")
+}
+
+func TestShortErrorTruncates(t *testing.T) {
+	msg := shortError(&stringError{s: strings.Repeat("x", maxEvaluationErrorLen+50)})
+	assert.Len(t, msg, maxEvaluationErrorLen)
+}
+
+type stringError struct{ s string }
+
+func (e *stringError) Error() string { return e.s }

--- a/internal/update/model.go
+++ b/internal/update/model.go
@@ -180,6 +180,7 @@ const (
 	CVESeverityHigh     CVESeverity = "high"
 	CVESeverityMedium   CVESeverity = "medium"
 	CVESeverityLow      CVESeverity = "low"
+	CVESeverityUnknown  CVESeverity = "unknown"
 )
 
 // CVECacheEntry caches CVE lookup results from OSV.dev.
@@ -216,6 +217,27 @@ type ContainerCVE struct {
 type ListCVEsOpts struct {
 	Severity    string
 	ContainerID string
+}
+
+// CVEEvaluationStatus records the outcome of a container's CVE analysis.
+type CVEEvaluationStatus string
+
+const (
+	CVEEvaluated       CVEEvaluationStatus = "evaluated"
+	CVEUnsupported     CVEEvaluationStatus = "unsupported"
+	CVEEvaluationError CVEEvaluationStatus = "error"
+)
+
+// CVEEvaluation records that a container went through CVE analysis, and how
+// it went, so an unevaluated container is never mistaken for a clean one.
+type CVEEvaluation struct {
+	ContainerID    string              `json:"container_id"`
+	Status         CVEEvaluationStatus `json:"status"`
+	EvaluatedAt    time.Time           `json:"evaluated_at"`
+	Ecosystem      string              `json:"ecosystem,omitempty"`
+	PackageName    string              `json:"package_name,omitempty"`
+	PackageVersion string              `json:"package_version,omitempty"`
+	Error          string              `json:"error,omitempty"`
 }
 
 // RiskScoreRecord stores historical risk scores for trend tracking.

--- a/internal/update/scanner_test.go
+++ b/internal/update/scanner_test.go
@@ -109,6 +109,11 @@ func (s *stubStore) DeleteContainerCVEs(_ context.Context, _ string) error    { 
 func (s *stubStore) GetCVESummaryCounts(_ context.Context) (map[string]int, error) {
 	return nil, nil
 }
+func (s *stubStore) UpsertCVEEvaluation(_ context.Context, _ *CVEEvaluation) error { return nil }
+func (s *stubStore) GetCVEEvaluation(_ context.Context, _ string) (*CVEEvaluation, error) {
+	return nil, nil
+}
+func (s *stubStore) DeleteCVEEvaluation(_ context.Context, _ string) error           { return nil }
 func (s *stubStore) UpsertDigestBaseline(_ context.Context, _ *DigestBaseline) error { return nil }
 func (s *stubStore) GetDigestBaseline(_ context.Context, _ string) (*DigestBaseline, error) {
 	return s.baseline, nil

--- a/internal/update/service.go
+++ b/internal/update/service.go
@@ -422,9 +422,10 @@ func (s *Service) runScan(ctx context.Context) {
 		s.emitEvent(event.UpdateDetected, eventData)
 	}
 
-	// Enrichment pipeline (no-op in CE, runs CVE/changelog/risk in Pro)
-	if updatesFound > 0 {
-		s.logger.Info("starting enrichment pipeline", "updates", updatesFound)
+	// Enrichment pipeline (no-op in CE, runs CVE/changelog/risk in Pro).
+	// Gated on results, not updates: a container on its latest tag still needs a CVE pass.
+	if len(results) > 0 {
+		s.logger.Info("starting enrichment pipeline", "containers", len(results), "updates", updatesFound)
 		if err := s.enricher.Enrich(ctx, results); err != nil {
 			s.logger.Warn("update enrichment failed", "error", err)
 		}

--- a/internal/update/store.go
+++ b/internal/update/store.go
@@ -60,6 +60,11 @@ type UpdateStore interface {
 	DeleteContainerCVEs(ctx context.Context, containerID string) error
 	GetCVESummaryCounts(ctx context.Context) (map[string]int, error)
 
+	// CVE evaluations
+	UpsertCVEEvaluation(ctx context.Context, e *CVEEvaluation) error
+	GetCVEEvaluation(ctx context.Context, containerID string) (*CVEEvaluation, error)
+	DeleteCVEEvaluation(ctx context.Context, containerID string) error
+
 	// Digest baselines (non-semver tags)
 	UpsertDigestBaseline(ctx context.Context, b *DigestBaseline) error
 	GetDigestBaseline(ctx context.Context, containerID string) (*DigestBaseline, error)


### PR DESCRIPTION
The OSV client queried `/v1/querybatch` and read `summary`, `severity` and
`affected` out of the answer. That endpoint returns identifiers and nothing
else, so every field came back empty and the severity fell to a default keyed
on the identifier prefix: **every CVE was stored Medium/5.0 and every GHSA
Low/0**, whatever the advisory actually said. The record is now fetched from
`/v1/vulns/{id}` — paginated, memoised, cached — and the severity comes from it,
or stays unknown.

The score presented as CVSS was a sum of bonuses matched by substring on the
vector. It gave **7.5 to a vector with no impact at all**, and added a point for
`AC:H` because that string contains `C:H` — a high attack complexity, which
lowers a real score, raised this one. The v3.1 base score is now computed from
the specification and pinned to a table of published vectors.

Enrichment ran only for a container with a pending image update, and the posture
score gave the CVE category a perfect 100 whenever no row existed for a
container. Together they handed an unearned clean bill of health to every
container on its latest tag. Analysis now runs for whichever container has a
resolvable package, and what it concluded is persisted: `evaluated`,
`unsupported` or `error`. The category scores only when it was evaluated, says
so when the image is not covered by the data source, and marks the score partial
when the analysis never ran or failed — `IsPartial` existed and was never once
set to true.

Migration **31** adds `cve_evaluations` on both engines. The API, the MCP tools
and the posture view carry the state, so nothing downstream has to infer a
verdict from an empty list.

Found by an external security audit of `2c6654c` (findings Q-02, Q-03).
