### PR TITLE
fix(mcp-oauth): consume authorization codes and refresh tokens atomically

### DIFF
--- a/internal/mcp/oauth/server_test.go
+++ b/internal/mcp/oauth/server_test.go
@@ -15,12 +15,18 @@ type fakeStore struct {
 	stored *MCPAuthCode
 }
 
-func (f *fakeStore) StoreCode(_ context.Context, code *MCPAuthCode) error { f.stored = code; return nil }
+func (f *fakeStore) StoreCode(_ context.Context, code *MCPAuthCode) error {
+	f.stored = code
+	return nil
+}
 func (f *fakeStore) ConsumeCode(context.Context, string) (*MCPAuthCode, error) {
 	return nil, nil
 }
-func (f *fakeStore) StoreToken(context.Context, *MCPOAuthToken) error      { return nil }
+func (f *fakeStore) StoreToken(context.Context, *MCPOAuthToken) error { return nil }
 func (f *fakeStore) GetToken(context.Context, string) (*MCPOAuthToken, error) {
+	return nil, nil
+}
+func (f *fakeStore) ConsumeRefreshToken(context.Context, string) (*MCPOAuthToken, error) {
 	return nil, nil
 }
 func (f *fakeStore) RevokeToken(context.Context, string) error    { return nil }

--- a/internal/mcp/oauth/store.go
+++ b/internal/mcp/oauth/store.go
@@ -2,7 +2,17 @@ package oauth
 
 import (
 	"context"
+	"errors"
 	"time"
+)
+
+var (
+	ErrCodeNotFound = errors.New("authorization code not found")
+	ErrCodeUsed     = errors.New("authorization code already used")
+	ErrCodeExpired  = errors.New("authorization code expired")
+
+	ErrTokenNotFound = errors.New("token not found")
+	ErrTokenRevoked  = errors.New("token revoked")
 )
 
 // MCPAuthCode represents an OAuth authorization code stored in the database.
@@ -39,6 +49,7 @@ type MCPOAuthStore interface {
 	// Tokens
 	StoreToken(ctx context.Context, token *MCPOAuthToken) error
 	GetToken(ctx context.Context, tokenHash string) (*MCPOAuthToken, error)
+	ConsumeRefreshToken(ctx context.Context, tokenHash string) (*MCPOAuthToken, error)
 	RevokeToken(ctx context.Context, tokenHash string) error
 	RevokeFamily(ctx context.Context, familyID string) error
 

--- a/internal/mcp/oauth/token.go
+++ b/internal/mcp/oauth/token.go
@@ -2,6 +2,7 @@ package oauth
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"time"
 
@@ -42,7 +43,8 @@ func (s *OAuthServer) handleAuthorizationCode(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	// Consume authorization code (marks as used atomically)
+	// Consume the authorization code: the store marks it used atomically, so
+	// only one concurrent exchange of the same code can ever succeed.
 	codeHash := HashToken(code)
 	authCode, err := s.store.ConsumeCode(r.Context(), codeHash)
 	if err != nil {
@@ -89,41 +91,34 @@ func (s *OAuthServer) handleRefreshToken(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	// Look up the refresh token
+	// Consume the refresh token: the store revokes it atomically, so only one
+	// concurrent refresh of the same token can ever rotate it.
 	tokenHash := HashToken(refreshTokenRaw)
-	storedToken, err := s.store.GetToken(r.Context(), tokenHash)
+	storedToken, err := s.store.ConsumeRefreshToken(r.Context(), tokenHash)
 	if err != nil {
-		s.logger.Warn("refresh with unknown token", "error", err)
-		tokenError(w, http.StatusBadRequest, "invalid_grant", "invalid refresh token")
-		return
-	}
-
-	// Check token type
-	if storedToken.TokenType != "refresh" {
-		tokenError(w, http.StatusBadRequest, "invalid_grant", "not a refresh token")
-		return
-	}
-
-	// Replay detection: if already revoked, revoke the entire family
-	if storedToken.Revoked {
-		s.logger.Warn("refresh token replay detected, revoking family",
-			"family_id", storedToken.FamilyID, "client_id", clientID)
-		if err := s.store.RevokeFamily(r.Context(), storedToken.FamilyID); err != nil {
-			s.logger.Error("failed to revoke token family", "error", err)
+		switch {
+		case errors.Is(err, ErrTokenRevoked):
+			// Replay: this token was already consumed once. Revoke the whole
+			// family, since a stolen refresh token is now in play.
+			s.logger.Warn("refresh token replay detected, revoking family",
+				"family_id", storedToken.FamilyID, "client_id", clientID)
+			if err := s.store.RevokeFamily(r.Context(), storedToken.FamilyID); err != nil {
+				s.logger.Error("failed to revoke token family", "error", err)
+			}
+			tokenError(w, http.StatusBadRequest, "invalid_grant", "refresh token already used")
+		case errors.Is(err, ErrTokenNotFound):
+			s.logger.Warn("refresh with unknown token")
+			tokenError(w, http.StatusBadRequest, "invalid_grant", "invalid refresh token")
+		default:
+			s.logger.Error("failed to consume refresh token", "error", err)
+			tokenError(w, http.StatusInternalServerError, "server_error", "internal error")
 		}
-		tokenError(w, http.StatusBadRequest, "invalid_grant", "refresh token already used")
 		return
 	}
 
-	// Check expiration
 	if time.Now().After(storedToken.ExpiresAt) {
 		tokenError(w, http.StatusBadRequest, "invalid_grant", "refresh token expired")
 		return
-	}
-
-	// Revoke old refresh token (rotation)
-	if err := s.store.RevokeToken(r.Context(), tokenHash); err != nil {
-		s.logger.Error("failed to revoke old refresh token", "error", err)
 	}
 
 	s.logger.Info("refresh token rotated", "client_id", clientID, "family_id", storedToken.FamilyID)

--- a/internal/mcp/oauth/token_test.go
+++ b/internal/mcp/oauth/token_test.go
@@ -1,0 +1,139 @@
+package oauth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// fakeRefreshStore is a configurable MCPOAuthStore used to drive the refresh
+// grant through its store-error and replay branches without a database.
+type fakeRefreshStore struct {
+	consumeToken *MCPOAuthToken
+	consumeErr   error
+
+	revokedFamilies []string
+	revokeFamilyErr error
+
+	storedTokens []*MCPOAuthToken
+}
+
+func (f *fakeRefreshStore) StoreCode(context.Context, *MCPAuthCode) error { return nil }
+func (f *fakeRefreshStore) ConsumeCode(context.Context, string) (*MCPAuthCode, error) {
+	return nil, nil
+}
+func (f *fakeRefreshStore) StoreToken(_ context.Context, token *MCPOAuthToken) error {
+	f.storedTokens = append(f.storedTokens, token)
+	return nil
+}
+func (f *fakeRefreshStore) GetToken(context.Context, string) (*MCPOAuthToken, error) {
+	return nil, nil
+}
+func (f *fakeRefreshStore) ConsumeRefreshToken(context.Context, string) (*MCPOAuthToken, error) {
+	return f.consumeToken, f.consumeErr
+}
+func (f *fakeRefreshStore) RevokeToken(context.Context, string) error { return nil }
+func (f *fakeRefreshStore) RevokeFamily(_ context.Context, familyID string) error {
+	f.revokedFamilies = append(f.revokedFamilies, familyID)
+	return f.revokeFamilyErr
+}
+func (f *fakeRefreshStore) DeleteExpired(context.Context) (int64, error) { return 0, nil }
+
+func newTestServerWithStore(store MCPOAuthStore) *OAuthServer {
+	return NewOAuthServer(Config{
+		ClientID:            "maintenant-mcp",
+		ClientSecret:        "secret",
+		IssuerURL:           "https://now.kolapsis.com",
+		AllowedRedirectURIs: "https://claude.ai/api/mcp/auth_callback",
+	}, store, slog.New(slog.NewTextHandler(io.Discard, nil)))
+}
+
+func doRefreshRequest(t *testing.T, s *OAuthServer, refreshToken string) (*httptest.ResponseRecorder, map[string]string) {
+	t.Helper()
+	form := url.Values{
+		"grant_type":    {"refresh_token"},
+		"refresh_token": {refreshToken},
+		"client_id":     {"maintenant-mcp"},
+		"client_secret": {"secret"},
+	}
+	req := httptest.NewRequest(http.MethodPost, "/oauth/token", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+	s.HandleToken(rec, req)
+
+	var body map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response body: %v", err)
+	}
+	return rec, body
+}
+
+func TestHandleRefreshToken_ReplayRevokesFamilyAndRejects(t *testing.T) {
+	store := &fakeRefreshStore{
+		consumeErr:   ErrTokenRevoked,
+		consumeToken: &MCPOAuthToken{FamilyID: "family-1"},
+	}
+	s := newTestServerWithStore(store)
+
+	rec, body := doRefreshRequest(t, s, "stolen-refresh-token")
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+	if body["error"] != "invalid_grant" {
+		t.Errorf("error = %q, want invalid_grant", body["error"])
+	}
+	if len(store.revokedFamilies) != 1 || store.revokedFamilies[0] != "family-1" {
+		t.Errorf("revoked families = %v, want [family-1]", store.revokedFamilies)
+	}
+	if len(store.storedTokens) != 0 {
+		t.Errorf("stored tokens = %d, want 0: replay must not issue a new pair", len(store.storedTokens))
+	}
+}
+
+func TestHandleRefreshToken_UnknownTokenRejectedWithoutRevoke(t *testing.T) {
+	store := &fakeRefreshStore{consumeErr: ErrTokenNotFound}
+	s := newTestServerWithStore(store)
+
+	rec, body := doRefreshRequest(t, s, "never-issued")
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+	if body["error"] != "invalid_grant" {
+		t.Errorf("error = %q, want invalid_grant", body["error"])
+	}
+	if len(store.revokedFamilies) != 0 {
+		t.Errorf("revoked families = %v, want none", store.revokedFamilies)
+	}
+	if len(store.storedTokens) != 0 {
+		t.Errorf("stored tokens = %d, want 0", len(store.storedTokens))
+	}
+}
+
+func TestHandleRefreshToken_StoreErrorDuringConsumeIssuesNoPair(t *testing.T) {
+	store := &fakeRefreshStore{consumeErr: errors.New("database exploded")}
+	s := newTestServerWithStore(store)
+
+	rec, body := doRefreshRequest(t, s, "any-token")
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusInternalServerError)
+	}
+	if body["error"] != "server_error" {
+		t.Errorf("error = %q, want server_error", body["error"])
+	}
+	if len(store.revokedFamilies) != 0 {
+		t.Errorf("revoked families = %v, want none", store.revokedFamilies)
+	}
+	if len(store.storedTokens) != 0 {
+		t.Errorf("stored tokens = %d, want 0: a failed consume must not issue a pair", len(store.storedTokens))
+	}
+}

--- a/internal/store/mcp_oauth.go
+++ b/internal/store/mcp_oauth.go
@@ -37,7 +37,39 @@ func (s *MCPOAuthStoreImpl) StoreCode(ctx context.Context, code *oauth.MCPAuthCo
 	return nil
 }
 
+// ConsumeCode atomically marks an authorization code used, so that only one
+// caller among concurrent exchanges of the same code can ever succeed.
 func (s *MCPOAuthStoreImpl) ConsumeCode(ctx context.Context, codeHash string) (*oauth.MCPAuthCode, error) {
+	now := time.Now().Unix()
+	result, err := s.writer.Exec(ctx,
+		`UPDATE mcp_oauth_codes SET used = 1 WHERE code_hash = ? AND used = 0 AND expires_at > ?`,
+		codeHash, now)
+	if err != nil {
+		return nil, fmt.Errorf("consume mcp oauth code: %w", err)
+	}
+	if result.RowsAffected != 1 {
+		return nil, s.diagnoseCodeFailure(ctx, codeHash, now)
+	}
+	return s.readCode(ctx, codeHash)
+}
+
+func (s *MCPOAuthStoreImpl) diagnoseCodeFailure(ctx context.Context, codeHash string, now int64) error {
+	code, err := s.readCode(ctx, codeHash)
+	if err != nil {
+		return err
+	}
+	if code.Used {
+		return oauth.ErrCodeUsed
+	}
+	if code.ExpiresAt.Unix() <= now {
+		return oauth.ErrCodeExpired
+	}
+	// Row exists, unused and unexpired, yet the conditional UPDATE affected no
+	// row: a concurrent caller won the race between it and this diagnosis.
+	return oauth.ErrCodeUsed
+}
+
+func (s *MCPOAuthStoreImpl) readCode(ctx context.Context, codeHash string) (*oauth.MCPAuthCode, error) {
 	row := s.db.QueryRowContext(ctx,
 		`SELECT code_hash, client_id, redirect_uri, code_challenge, code_challenge_method, scope, expires_at, used, created_at
 		 FROM mcp_oauth_codes WHERE code_hash = ?`, codeHash)
@@ -49,7 +81,7 @@ func (s *MCPOAuthStoreImpl) ConsumeCode(ctx context.Context, codeHash string) (*
 		&code.CodeChallenge, &code.CodeChallengeMethod,
 		&code.Scope, &expiresAt, &used, &createdAt)
 	if errors.Is(err, sql.ErrNoRows) {
-		return nil, fmt.Errorf("authorization code not found")
+		return nil, oauth.ErrCodeNotFound
 	}
 	if err != nil {
 		return nil, fmt.Errorf("query mcp oauth code: %w", err)
@@ -58,22 +90,6 @@ func (s *MCPOAuthStoreImpl) ConsumeCode(ctx context.Context, codeHash string) (*
 	code.ExpiresAt = time.Unix(expiresAt, 0)
 	code.CreatedAt = time.Unix(createdAt, 0)
 	code.Used = used != 0
-
-	if code.Used {
-		return nil, fmt.Errorf("authorization code already used")
-	}
-	if time.Now().After(code.ExpiresAt) {
-		return nil, fmt.Errorf("authorization code expired")
-	}
-
-	// Mark as used
-	_, err = s.writer.Exec(ctx,
-		`UPDATE mcp_oauth_codes SET used = 1 WHERE code_hash = ?`, codeHash)
-	if err != nil {
-		return nil, fmt.Errorf("consume mcp oauth code: %w", err)
-	}
-
-	code.Used = true
 	return &code, nil
 }
 
@@ -91,6 +107,42 @@ func (s *MCPOAuthStoreImpl) StoreToken(ctx context.Context, token *oauth.MCPOAut
 }
 
 func (s *MCPOAuthStoreImpl) GetToken(ctx context.Context, tokenHash string) (*oauth.MCPOAuthToken, error) {
+	return s.readToken(ctx, tokenHash)
+}
+
+// ConsumeRefreshToken atomically revokes a refresh token, so that only one
+// caller among concurrent refreshes of the same token can ever rotate it.
+func (s *MCPOAuthStoreImpl) ConsumeRefreshToken(ctx context.Context, tokenHash string) (*oauth.MCPOAuthToken, error) {
+	result, err := s.writer.Exec(ctx,
+		`UPDATE mcp_oauth_tokens SET revoked = 1 WHERE token_hash = ? AND token_type = 'refresh' AND revoked = 0`,
+		tokenHash)
+	if err != nil {
+		return nil, fmt.Errorf("consume mcp oauth refresh token: %w", err)
+	}
+	if result.RowsAffected != 1 {
+		return s.diagnoseTokenFailure(ctx, tokenHash)
+	}
+	return s.readToken(ctx, tokenHash)
+}
+
+// diagnoseTokenFailure explains why the conditional UPDATE affected no row.
+// For ErrTokenRevoked it also returns the current row, since the caller needs
+// its FamilyID to revoke the whole family on a replay.
+func (s *MCPOAuthStoreImpl) diagnoseTokenFailure(ctx context.Context, tokenHash string) (*oauth.MCPOAuthToken, error) {
+	token, err := s.readToken(ctx, tokenHash)
+	if err != nil {
+		return nil, err
+	}
+	if token.TokenType != "refresh" {
+		return nil, oauth.ErrTokenNotFound
+	}
+	// The row exists as a refresh token yet wasn't revoked by us: it is
+	// either already revoked, or a concurrent caller just won the race
+	// between it and this diagnosis. Either way, it is spent.
+	return token, oauth.ErrTokenRevoked
+}
+
+func (s *MCPOAuthStoreImpl) readToken(ctx context.Context, tokenHash string) (*oauth.MCPOAuthToken, error) {
 	row := s.db.QueryRowContext(ctx,
 		`SELECT token_hash, token_type, client_id, scope, expires_at, revoked, family_id, created_at
 		 FROM mcp_oauth_tokens WHERE token_hash = ?`, tokenHash)
@@ -101,7 +153,7 @@ func (s *MCPOAuthStoreImpl) GetToken(ctx context.Context, tokenHash string) (*oa
 	err := row.Scan(&token.TokenHash, &token.TokenType, &token.ClientID,
 		&token.Scope, &expiresAt, &revoked, &token.FamilyID, &createdAt)
 	if errors.Is(err, sql.ErrNoRows) {
-		return nil, fmt.Errorf("token not found")
+		return nil, oauth.ErrTokenNotFound
 	}
 	if err != nil {
 		return nil, fmt.Errorf("query mcp oauth token: %w", err)

--- a/internal/store/mcp_oauth_test.go
+++ b/internal/store/mcp_oauth_test.go
@@ -1,0 +1,277 @@
+package store
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/kolapsis/maintenant/internal/mcp/oauth"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConsumeCode_ConcurrentExchangesYieldExactlyOneWinner(t *testing.T) {
+	db := openTestDB(t)
+	s := NewMCPOAuthStore(db)
+	ctx := context.Background()
+
+	now := time.Now()
+	code := &oauth.MCPAuthCode{
+		CodeHash:            "concurrent-code-hash",
+		ClientID:            "client",
+		RedirectURI:         "https://example.com/cb",
+		CodeChallenge:       "challenge",
+		CodeChallengeMethod: "S256",
+		Scope:               "mcp",
+		ExpiresAt:           now.Add(10 * time.Minute),
+		CreatedAt:           now,
+	}
+	require.NoError(t, s.StoreCode(ctx, code))
+
+	const n = 16
+	var ready sync.WaitGroup
+	ready.Add(n)
+	release := make(chan struct{})
+	var wg sync.WaitGroup
+	errs := make([]error, n)
+
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			ready.Done()
+			<-release
+			_, err := s.ConsumeCode(ctx, code.CodeHash)
+			errs[i] = err
+		}(i)
+	}
+	ready.Wait()
+	close(release)
+	wg.Wait()
+
+	successes, failures := 0, 0
+	for _, err := range errs {
+		if err == nil {
+			successes++
+			continue
+		}
+		failures++
+		require.ErrorIs(t, err, oauth.ErrCodeUsed)
+	}
+	require.Equal(t, 1, successes, "exactly one caller must win the race")
+	require.Equal(t, n-1, failures)
+}
+
+func TestConsumeCode_ExpiredIsRefused(t *testing.T) {
+	db := openTestDB(t)
+	s := NewMCPOAuthStore(db)
+	ctx := context.Background()
+
+	now := time.Now()
+	code := &oauth.MCPAuthCode{
+		CodeHash:            "expired-code-hash",
+		ClientID:            "client",
+		RedirectURI:         "https://example.com/cb",
+		CodeChallenge:       "challenge",
+		CodeChallengeMethod: "S256",
+		ExpiresAt:           now.Add(-time.Minute),
+		CreatedAt:           now.Add(-11 * time.Minute),
+	}
+	require.NoError(t, s.StoreCode(ctx, code))
+
+	_, err := s.ConsumeCode(ctx, code.CodeHash)
+	require.ErrorIs(t, err, oauth.ErrCodeExpired)
+}
+
+func TestConsumeCode_UnknownIsRefused(t *testing.T) {
+	db := openTestDB(t)
+	s := NewMCPOAuthStore(db)
+	ctx := context.Background()
+
+	_, err := s.ConsumeCode(ctx, "never-issued")
+	require.ErrorIs(t, err, oauth.ErrCodeNotFound)
+}
+
+func TestConsumeCode_UsedIsRefused(t *testing.T) {
+	db := openTestDB(t)
+	s := NewMCPOAuthStore(db)
+	ctx := context.Background()
+
+	now := time.Now()
+	code := &oauth.MCPAuthCode{
+		CodeHash:            "single-use-code-hash",
+		ClientID:            "client",
+		RedirectURI:         "https://example.com/cb",
+		CodeChallenge:       "challenge",
+		CodeChallengeMethod: "S256",
+		ExpiresAt:           now.Add(10 * time.Minute),
+		CreatedAt:           now,
+	}
+	require.NoError(t, s.StoreCode(ctx, code))
+
+	_, err := s.ConsumeCode(ctx, code.CodeHash)
+	require.NoError(t, err)
+
+	_, err = s.ConsumeCode(ctx, code.CodeHash)
+	require.ErrorIs(t, err, oauth.ErrCodeUsed)
+}
+
+func TestConsumeCode_ReturnsTheStoredFields(t *testing.T) {
+	db := openTestDB(t)
+	s := NewMCPOAuthStore(db)
+	ctx := context.Background()
+
+	now := time.Now()
+	code := &oauth.MCPAuthCode{
+		CodeHash:            "roundtrip-code-hash",
+		ClientID:            "maintenant-mcp",
+		RedirectURI:         "https://claude.ai/api/mcp/auth_callback",
+		CodeChallenge:       "challenge-value",
+		CodeChallengeMethod: "S256",
+		Scope:               "mcp:read mcp:write",
+		ExpiresAt:           now.Add(10 * time.Minute),
+		CreatedAt:           now,
+	}
+	require.NoError(t, s.StoreCode(ctx, code))
+
+	got, err := s.ConsumeCode(ctx, code.CodeHash)
+	require.NoError(t, err)
+	require.Equal(t, code.CodeHash, got.CodeHash)
+	require.Equal(t, code.ClientID, got.ClientID)
+	require.Equal(t, code.RedirectURI, got.RedirectURI)
+	require.Equal(t, code.CodeChallenge, got.CodeChallenge)
+	require.Equal(t, code.CodeChallengeMethod, got.CodeChallengeMethod)
+	require.Equal(t, code.Scope, got.Scope)
+	require.True(t, got.Used)
+}
+
+func TestConsumeRefreshToken_ConcurrentRefreshesYieldExactlyOneWinner(t *testing.T) {
+	db := openTestDB(t)
+	s := NewMCPOAuthStore(db)
+	ctx := context.Background()
+
+	now := time.Now()
+	token := &oauth.MCPOAuthToken{
+		TokenHash: "concurrent-refresh-hash",
+		TokenType: "refresh",
+		ClientID:  "client",
+		Scope:     "mcp",
+		ExpiresAt: now.Add(time.Hour),
+		FamilyID:  "family-concurrent",
+		CreatedAt: now,
+	}
+	require.NoError(t, s.StoreToken(ctx, token))
+
+	const n = 16
+	var ready sync.WaitGroup
+	ready.Add(n)
+	release := make(chan struct{})
+	var wg sync.WaitGroup
+	errs := make([]error, n)
+
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			ready.Done()
+			<-release
+			_, err := s.ConsumeRefreshToken(ctx, token.TokenHash)
+			errs[i] = err
+		}(i)
+	}
+	ready.Wait()
+	close(release)
+	wg.Wait()
+
+	successes, failures := 0, 0
+	for _, err := range errs {
+		if err == nil {
+			successes++
+			continue
+		}
+		failures++
+		require.ErrorIs(t, err, oauth.ErrTokenRevoked)
+	}
+	require.Equal(t, 1, successes, "exactly one caller must win the race")
+	require.Equal(t, n-1, failures)
+}
+
+func TestConsumeRefreshToken_UnknownIsRefused(t *testing.T) {
+	db := openTestDB(t)
+	s := NewMCPOAuthStore(db)
+	ctx := context.Background()
+
+	_, err := s.ConsumeRefreshToken(ctx, "never-issued")
+	require.ErrorIs(t, err, oauth.ErrTokenNotFound)
+}
+
+func TestConsumeRefreshToken_WrongTypeIsRefused(t *testing.T) {
+	db := openTestDB(t)
+	s := NewMCPOAuthStore(db)
+	ctx := context.Background()
+
+	now := time.Now()
+	access := &oauth.MCPOAuthToken{
+		TokenHash: "access-not-refresh-hash",
+		TokenType: "access",
+		ClientID:  "client",
+		ExpiresAt: now.Add(time.Hour),
+		FamilyID:  "family-access",
+		CreatedAt: now,
+	}
+	require.NoError(t, s.StoreToken(ctx, access))
+
+	_, err := s.ConsumeRefreshToken(ctx, access.TokenHash)
+	require.ErrorIs(t, err, oauth.ErrTokenNotFound)
+}
+
+func TestConsumeRefreshToken_RevokedIsRefusedAndCarriesFamilyID(t *testing.T) {
+	db := openTestDB(t)
+	s := NewMCPOAuthStore(db)
+	ctx := context.Background()
+
+	now := time.Now()
+	token := &oauth.MCPOAuthToken{
+		TokenHash: "replayed-refresh-hash",
+		TokenType: "refresh",
+		ClientID:  "client",
+		ExpiresAt: now.Add(time.Hour),
+		FamilyID:  "family-replay",
+		CreatedAt: now,
+	}
+	require.NoError(t, s.StoreToken(ctx, token))
+
+	_, err := s.ConsumeRefreshToken(ctx, token.TokenHash)
+	require.NoError(t, err)
+
+	got, err := s.ConsumeRefreshToken(ctx, token.TokenHash)
+	require.ErrorIs(t, err, oauth.ErrTokenRevoked)
+	require.NotNil(t, got, "the caller needs the row back to revoke the token family")
+	require.Equal(t, token.FamilyID, got.FamilyID)
+}
+
+func TestConsumeRefreshToken_ReturnsTheStoredFields(t *testing.T) {
+	db := openTestDB(t)
+	s := NewMCPOAuthStore(db)
+	ctx := context.Background()
+
+	now := time.Now()
+	token := &oauth.MCPOAuthToken{
+		TokenHash: "roundtrip-refresh-hash",
+		TokenType: "refresh",
+		ClientID:  "maintenant-mcp",
+		Scope:     "mcp:read mcp:write",
+		ExpiresAt: now.Add(time.Hour),
+		FamilyID:  "family-roundtrip",
+		CreatedAt: now,
+	}
+	require.NoError(t, s.StoreToken(ctx, token))
+
+	got, err := s.ConsumeRefreshToken(ctx, token.TokenHash)
+	require.NoError(t, err)
+	require.Equal(t, token.TokenHash, got.TokenHash)
+	require.Equal(t, token.ClientID, got.ClientID)
+	require.Equal(t, token.Scope, got.Scope)
+	require.Equal(t, token.FamilyID, got.FamilyID)
+	require.True(t, got.Revoked)
+}


### PR DESCRIPTION
Consuming an authorization code read the row through the reader, checked the
`used` flag in Go, then wrote `UPDATE … SET used = 1 WHERE code_hash = ?` — no
condition on `used`, no look at how many rows it touched. That read sits outside
the writer's serialization on SQLite and goes straight to the pool on
PostgreSQL, so two exchanges of the same code both saw an unused row and both
succeeded. A comment claimed the code was marked used atomically; it was not.

Refresh rotation had the same shape, and one more problem: when revoking the old
token failed, the error was logged and a new pair was issued anyway, leaving the
token that was supposed to be spent still valid.

Both are now a single conditional write whose affected-row count decides the
outcome, and a failed write is diagnosed into a typed error so the caller can
tell an unknown code from a spent or an expired one. A refresh issues nothing
until the old token is actually consumed; replaying one still revokes its whole
family.

The client secret and PKCE were required before and are required now: what this
restores is the single-use guarantee, not authentication.

Tested with sixteen goroutines released together on one code and on one refresh
token — exactly one winner — on SQLite and on PostgreSQL.

Found by an external security audit of `2c6654c` (finding S-04); the same defect
was noted as #14 in the July audit and left open.
