### PR TITLE
fix(http): stop trusting the caller for its own identity and its body size

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,11 @@ MAINTENANT_DB=./maintenant.db
 # CORS allowed origins (comma-separated, empty = same-origin only)
 # MAINTENANT_CORS_ORIGINS=http://localhost:5173
 
+# Reverse proxies whose X-Forwarded-For / X-Real-IP / X-Forwarded-Host headers are
+# believed (comma-separated CIDRs or addresses). Unset, no forwarded header is read
+# and every quota is counted against the address that opened the connection.
+# MAINTENANT_TRUSTED_PROXIES=10.0.0.0/8,192.168.1.4
+
 # Container runtime override (auto-detected by default: docker or kubernetes)
 # MAINTENANT_RUNTIME=docker
 

--- a/cmd/maintenant/main.go
+++ b/cmd/maintenant/main.go
@@ -116,6 +116,13 @@ func main() {
 		os.Exit(1)
 	}
 
+	// A trusted-proxy list that does not parse must stop startup: falling back
+	// to "trust nothing" would count every quota against the proxy.
+	if err := cfg.ValidateProxies(); err != nil {
+		logger.Error("invalid proxy configuration", "error", err)
+		os.Exit(1)
+	}
+
 	// A threshold that does not parse must stop startup: falling back to "off"
 	// would leave the operator believing the check runs.
 	if err := cfg.ValidateAlerting(); err != nil {

--- a/docs/security.md
+++ b/docs/security.md
@@ -176,6 +176,36 @@ server {
 
 ---
 
+### Running behind a proxy
+
+`MAINTENANT_TRUSTED_PROXIES` takes a comma-separated list of CIDRs and bare
+addresses:
+
+```bash
+MAINTENANT_TRUSTED_PROXIES=10.0.0.0/8,192.168.1.4,2001:db8::/32
+```
+
+It is empty by default, and an empty list means **no forwarded header is
+believed**: `X-Forwarded-For`, `X-Real-IP` and `X-Forwarded-Host` are not read
+at all, and every rate-limit quota is counted against the address that opened
+the connection. Anyone able to reach the instance directly can otherwise send a
+different header on every request and get a fresh quota each time.
+
+When the list is set, a request is only credited to a forwarded address if its
+immediate peer is inside one of the prefixes. `X-Forwarded-For` is then walked
+right to left and the first hop that is not itself a listed proxy is the client;
+`X-Real-IP` is read only when `X-Forwarded-For` is absent. Anything that does
+not parse falls back to the peer address.
+
+The same list decides whether `X-Forwarded-Host` may name the gRPC URL handed to
+a new agent at enrolment. `X-Forwarded-Proto: grpc` never downgrades that URL to
+plaintext: the answer stays `grpcs://` and carries a
+`public_url_plaintext_refused` warning.
+
+A value that does not parse refuses to start rather than being ignored.
+
+---
+
 ## External database credentials
 
 When the server is pointed at a PostgreSQL with `MAINTENANT_DATABASE_URL`, the
@@ -205,14 +235,18 @@ Two per-IP token bucket rate limiters, one tight for the public surfaces and one
 
 | Setting | Public routes | Admin API |
 |---------|---------------|-----------|
-| Applied to | `/ping/`, `/status/*`, `/mcp` | `/api/v1/*` |
+| Applied to | `/ping/`, `/status/*`, `/mcp`, `/oauth/*` | `/api/v1/*` |
 | Rate | 10 requests/second per IP | 50 requests/second per IP |
 | Burst | 20 requests | 200 requests |
 | 429 response | `{"error":{"code":"rate_limited","message":"Too many requests"}}` with `Retry-After: 1` | Same |
 
 The admin API limit is a flood ceiling, not a quota. A dashboard page load fans out dozens of parallel calls, so the public bucket would reject ordinary use; at 50/s with a burst of 200 the interface never reaches it. It exists so an unauthenticated surface, or a stolen session, cannot hammer expensive routes for free.
 
-IP detection priority: `X-Real-IP` header → first entry in `X-Forwarded-For` → `RemoteAddr`.
+The public status page carries a third, much slower bucket of its own: `POST
+/status/subscribe` accepts five subscriptions per hour and per address.
+
+Which address a quota is counted against is decided by
+`MAINTENANT_TRUSTED_PROXIES` — see [Running behind a proxy](#running-behind-a-proxy).
 
 The `/status/subscribe` endpoint has an additional rate limit of 5 requests per IP per hour to prevent subscription abuse.
 

--- a/internal/agentserver/publicurl.go
+++ b/internal/agentserver/publicurl.go
@@ -14,7 +14,10 @@ package agentserver
 import (
 	"net"
 	"net/http"
+	"net/netip"
 	"strings"
+
+	"github.com/kolapsis/maintenant/internal/ratelimit"
 )
 
 // PublicURLConfig holds the inputs for resolving the gRPC public URL.
@@ -26,6 +29,9 @@ type PublicURLConfig struct {
 	// ListenAddr is the address the gRPC server is bound to (e.g. "127.0.0.1:8443").
 	// Used as fallback when neither Explicit nor request headers are available.
 	ListenAddr string
+
+	// TrustedProxies lists the peers whose X-Forwarded-* headers are believed.
+	TrustedProxies []netip.Prefix
 }
 
 // ResolvePublicURL returns the grpcs:// URL that remote agents should use plus a list
@@ -46,23 +52,21 @@ func ResolvePublicURL(req *http.Request, cfg PublicURLConfig) (string, []string)
 		return url, warnings
 	}
 
-	// 2. X-Forwarded-Host + X-Forwarded-Proto headers (reverse-proxy path).
+	// 2. X-Forwarded-Host headers, believed only from a configured proxy.
 	if req != nil {
-		fwdHost := req.Header.Get("X-Forwarded-Host")
-		fwdProto := req.Header.Get("X-Forwarded-Proto")
-		if fwdHost != "" {
-			// Normalise: remove standard gRPC port 443 suffix.
-			host := stripStandardPort(fwdHost, "443")
-			var url string
-			if fwdProto == "grpc" {
-				url = "grpc://" + host
-			} else {
-				url = "grpcs://" + host
+		if ratelimit.NewClientIPResolver(cfg.TrustedProxies).TrustsPeer(req) {
+			fwdHost := req.Header.Get("X-Forwarded-Host")
+			if fwdHost != "" {
+				// Normalise: remove standard gRPC port 443 suffix.
+				host := stripStandardPort(fwdHost, "443")
+				if proto := req.Header.Get("X-Forwarded-Proto"); proto == "grpc" {
+					warnings = append(warnings, "public_url_plaintext_refused")
+				}
+				if looksLocal(fwdHost) {
+					warnings = append(warnings, "public_url_appears_local")
+				}
+				return "grpcs://" + host, warnings
 			}
-			if looksLocal(fwdHost) {
-				warnings = append(warnings, "public_url_appears_local")
-			}
-			return url, warnings
 		}
 
 		// 3. Request Host header.

--- a/internal/agentserver/publicurl_test.go
+++ b/internal/agentserver/publicurl_test.go
@@ -13,10 +13,26 @@ package agentserver
 
 import (
 	"net/http"
+	"net/netip"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+// trustedProxy is the peer the forwarded-header tests speak from. Since a
+// forwarded host is only believed behind a configured proxy, every such test
+// has to name one.
+var trustedProxy = []netip.Prefix{netip.MustParsePrefix("10.9.0.0/24")}
+
+func proxiedRequest(t *testing.T) *http.Request {
+	t.Helper()
+	req, err := http.NewRequest("POST", "http://internal:8080/api/v1/agents/enrollment-tokens", nil)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	req.RemoteAddr = "10.9.0.7:51000"
+	return req
+}
 
 func TestResolvePublicURL_Explicit(t *testing.T) {
 	url, warnings := ResolvePublicURL(nil, PublicURLConfig{
@@ -49,30 +65,30 @@ func TestResolvePublicURL_ExplicitHTTPS(t *testing.T) {
 }
 
 func TestResolvePublicURL_ForwardedHeaders(t *testing.T) {
-	req, _ := http.NewRequest("POST", "http://internal:8080/api/v1/agents/enrollment-tokens", nil)
+	req := proxiedRequest(t)
 	req.Header.Set("X-Forwarded-Host", "server.example.com:8443")
 	req.Header.Set("X-Forwarded-Proto", "grpcs")
 
-	url, warnings := ResolvePublicURL(req, PublicURLConfig{})
+	url, warnings := ResolvePublicURL(req, PublicURLConfig{TrustedProxies: trustedProxy})
 	assert.Equal(t, "grpcs://server.example.com:8443", url)
 	assert.Empty(t, warnings)
 }
 
 func TestResolvePublicURL_ForwardedHeadersStandardPort(t *testing.T) {
-	req, _ := http.NewRequest("POST", "http://internal:8080/api/v1/agents/enrollment-tokens", nil)
+	req := proxiedRequest(t)
 	req.Header.Set("X-Forwarded-Host", "server.example.com:443")
 	req.Header.Set("X-Forwarded-Proto", "grpcs")
 
-	url, warnings := ResolvePublicURL(req, PublicURLConfig{})
+	url, warnings := ResolvePublicURL(req, PublicURLConfig{TrustedProxies: trustedProxy})
 	assert.Equal(t, "grpcs://server.example.com", url)
 	assert.Empty(t, warnings)
 }
 
 func TestResolvePublicURL_ForwardedLocalWarning(t *testing.T) {
-	req, _ := http.NewRequest("POST", "http://internal:8080/api/v1/agents/enrollment-tokens", nil)
+	req := proxiedRequest(t)
 	req.Header.Set("X-Forwarded-Host", "192.168.1.10:8443")
 
-	_, warnings := ResolvePublicURL(req, PublicURLConfig{})
+	_, warnings := ResolvePublicURL(req, PublicURLConfig{TrustedProxies: trustedProxy})
 	assert.Contains(t, warnings, "public_url_appears_local")
 }
 
@@ -101,11 +117,40 @@ func TestResolvePublicURL_RFC1918(t *testing.T) {
 }
 
 func TestResolvePublicURL_ExplicitPriorityOverHeaders(t *testing.T) {
-	req, _ := http.NewRequest("POST", "/", nil)
+	req := proxiedRequest(t)
 	req.Header.Set("X-Forwarded-Host", "header-host.example.com")
 
 	url, _ := ResolvePublicURL(req, PublicURLConfig{
 		Explicit: "grpcs://explicit.example.com:8443",
 	})
 	assert.Equal(t, "grpcs://explicit.example.com:8443", url)
+}
+
+func TestResolvePublicURL_ForwardedHostIgnoredFromUntrustedPeer(t *testing.T) {
+	req := proxiedRequest(t)
+	req.RemoteAddr = "203.0.113.9:51000"
+	req.Host = "server.example.com:8443"
+	req.Header.Set("X-Forwarded-Host", "attacker.example.net")
+
+	url, _ := ResolvePublicURL(req, PublicURLConfig{TrustedProxies: trustedProxy})
+	assert.Equal(t, "grpcs://server.example.com:8443", url)
+}
+
+func TestResolvePublicURL_ForwardedHostIgnoredWithoutTrustedProxies(t *testing.T) {
+	req := proxiedRequest(t)
+	req.Host = "server.example.com:8443"
+	req.Header.Set("X-Forwarded-Host", "attacker.example.net")
+
+	url, _ := ResolvePublicURL(req, PublicURLConfig{})
+	assert.Equal(t, "grpcs://server.example.com:8443", url)
+}
+
+func TestResolvePublicURL_ForwardedProtoNeverYieldsPlaintext(t *testing.T) {
+	req := proxiedRequest(t)
+	req.Header.Set("X-Forwarded-Host", "server.example.com:8443")
+	req.Header.Set("X-Forwarded-Proto", "grpc")
+
+	url, warnings := ResolvePublicURL(req, PublicURLConfig{TrustedProxies: trustedProxy})
+	assert.Equal(t, "grpcs://server.example.com:8443", url)
+	assert.Contains(t, warnings, "public_url_plaintext_refused")
 }

--- a/internal/api/v1/agents_handler.go
+++ b/internal/api/v1/agents_handler.go
@@ -16,6 +16,7 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
+	"net/netip"
 	"strconv"
 	"time"
 
@@ -33,6 +34,7 @@ type AgentHandler struct {
 	logger         *slog.Logger
 	grpcPublicURL  string
 	grpcListen     string
+	trustedProxies []netip.Prefix
 	staleThreshold time.Duration
 }
 
@@ -44,6 +46,7 @@ func NewAgentHandler(
 	grpcPublicURL string,
 	grpcListen string,
 	staleThreshold time.Duration,
+	trustedProxies []netip.Prefix,
 ) *AgentHandler {
 	return &AgentHandler{
 		store:          store,
@@ -53,6 +56,7 @@ func NewAgentHandler(
 		grpcPublicURL:  grpcPublicURL,
 		grpcListen:     grpcListen,
 		staleThreshold: staleThreshold,
+		trustedProxies: trustedProxies,
 	}
 }
 
@@ -112,8 +116,9 @@ func (h *AgentHandler) HandleCreateEnrollmentToken(w http.ResponseWriter, r *htt
 	}
 
 	publicURL, warnings := agentserver.ResolvePublicURL(r, agentserver.PublicURLConfig{
-		Explicit:   h.grpcPublicURL,
-		ListenAddr: h.grpcListen,
+		Explicit:       h.grpcPublicURL,
+		ListenAddr:     h.grpcListen,
+		TrustedProxies: h.trustedProxies,
 	})
 
 	WriteJSON(w, http.StatusCreated, map[string]any{

--- a/internal/api/v1/agents_token_handler_test.go
+++ b/internal/api/v1/agents_token_handler_test.go
@@ -44,7 +44,7 @@ func newTokenTestHandler(t *testing.T) (*AgentHandler, *store.AgentStore) {
 	db := storetest.Open(t, logger)
 
 	store := store.NewAgentStore(db)
-	return NewAgentHandler(store, nil, nil, logger, "grpcs://example.test:8443", "127.0.0.1:8443", time.Minute), store
+	return NewAgentHandler(store, nil, nil, logger, "grpcs://example.test:8443", "127.0.0.1:8443", time.Minute, nil), store
 }
 
 func createToken(t *testing.T, h *AgentHandler) map[string]any {

--- a/internal/api/v1/middleware.go
+++ b/internal/api/v1/middleware.go
@@ -145,12 +145,10 @@ func cors(origins []string, next http.Handler) http.Handler {
 	})
 }
 
-// bodyLimit limits the request body size for POST and PUT requests.
+// bodyLimit caps the request body size, whatever the method.
 func bodyLimit(maxBytes int64, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == http.MethodPost || r.Method == http.MethodPut {
-			r.Body = http.MaxBytesReader(w, r.Body, maxBytes)
-		}
+		r.Body = http.MaxBytesReader(w, r.Body, maxBytes)
 		next.ServeHTTP(w, r)
 	})
 }

--- a/internal/api/v1/middleware_test.go
+++ b/internal/api/v1/middleware_test.go
@@ -221,6 +221,25 @@ func TestBodyLimit_GetRequestNotLimited(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 }
 
+func TestBodyLimit_MethodsWithABodyAreAllLimited(t *testing.T) {
+	handler := bodyLimit(10, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if _, err := io.ReadAll(r.Body); err != nil {
+			w.WriteHeader(http.StatusRequestEntityTooLarge)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	for _, method := range []string{"POST", "PUT", "PATCH", "DELETE"} {
+		body := strings.NewReader(strings.Repeat("x", 20))
+		req := httptest.NewRequest(method, "/", body)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusRequestEntityTooLarge, rec.Code, "%s body must be capped", method)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // requestID middleware
 // ---------------------------------------------------------------------------

--- a/internal/api/v1/router.go
+++ b/internal/api/v1/router.go
@@ -16,6 +16,7 @@ import (
 	"encoding/json"
 	"log/slog"
 	"net/http"
+	"net/netip"
 	"time"
 
 	"github.com/kolapsis/maintenant/internal/alert"
@@ -148,6 +149,7 @@ type HandlerDeps struct {
 	OrganisationName     string
 	AllowPrivateWebhooks bool // dev only: skip HTTPS + SSRF check on webhook URLs
 	StatusURL            string
+	TrustedProxies       []netip.Prefix
 }
 
 // agentStoreDirectory adapts the sqlite agent store to AgentDirectory so the
@@ -930,7 +932,7 @@ func (r *Router) registerAgentRoutes(d HandlerDeps) {
 	if staleThreshold == 0 {
 		staleThreshold = 60 * time.Second
 	}
-	ah := NewAgentHandler(d.AgentStore, d.AgentSessions, d.Broker, d.Logger, d.GRPCPublicURL, d.GRPCListen, staleThreshold)
+	ah := NewAgentHandler(d.AgentStore, d.AgentSessions, d.Broker, d.Logger, d.GRPCPublicURL, d.GRPCListen, staleThreshold, d.TrustedProxies)
 
 	// Enrollment token endpoints (order matters: specific paths before wildcards)
 	r.mux.HandleFunc("GET /api/v1/agents/metrics", requireCapability(extension.CapMultihost, ah.HandleGetAgentMetrics))

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -122,6 +122,7 @@ type App struct {
 	scorer         *security.Scorer
 	rl             *ratelimit.Limiter
 	apiRL          *ratelimit.Limiter
+	subscribeRL    *ratelimit.Limiter
 	licenseMgr     *license.Manager
 	mcpServer      *gomcp.Server
 	// degradedPlanLogged keeps the multi-host degradation to one line: the
@@ -168,6 +169,22 @@ func New(cfg Config, logger *slog.Logger) (*App, error) {
 		cfg:    cfg,
 		logger: logger,
 	}
+
+	trustedProxies, err := cfg.ParseTrustedProxies()
+	if err != nil {
+		return nil, err
+	}
+	clientIP := ratelimit.NewClientIPResolver(trustedProxies)
+
+	// --- Rate limiters ---
+	// Public surfaces (/ping/, /status/, /mcp, /oauth/) take the tight bucket.
+	a.rl = ratelimit.New(10, 20, clientIP)
+	// /api/ gets its own, far looser one: a dashboard load fans out dozens of
+	// parallel calls, so the tight bucket would 429 ordinary use. This is a
+	// flood ceiling, not a quota — it must never be reachable by the UI.
+	a.apiRL = ratelimit.New(50, 200, clientIP)
+	// Status-page subscriptions: five per hour and per address.
+	a.subscribeRL = ratelimit.New(5.0/3600.0, 5, clientIP)
 
 	if cfg.K8sNamespaces != "" {
 		logger.Info("K8s namespace allowlist configured", "namespaces", cfg.K8sNamespaces)
@@ -464,7 +481,7 @@ func New(cfg Config, logger *slog.Logger) (*App, error) {
 	a.maintScheduler = status.NewMaintenanceScheduler(maintenanceStore, statusCompStore, incidentStore, a.statusSvc, logger)
 	a.personalizationSvc = status.NewPersonalizationService(personalizationStore, logger.With("component", "personalization"))
 	personalizationPublicHandler := status.NewPersonalizationPublicHandler(a.personalizationSvc, logger)
-	a.statusHandler = status.NewHandler(a.statusSvc, a.statusBroker, logger)
+	a.statusHandler = status.NewHandler(a.statusSvc, a.statusBroker, logger, a.subscribeRL)
 	a.statusHandler.SetPersonalizationHandler(personalizationPublicHandler)
 
 	// --- Webhook dispatcher ---
@@ -626,15 +643,8 @@ func New(cfg Config, logger *slog.Logger) (*App, error) {
 		BuildVersion:         cfg.Version,
 		OrganisationName:     cfg.OrgName,
 		AllowPrivateWebhooks: cfg.AllowPrivateWebhooks,
+		TrustedProxies:       trustedProxies,
 	})
-
-	// --- Rate limiters ---
-	// Public surfaces (/ping/, /status/, /mcp) take the tight bucket.
-	a.rl = ratelimit.New(10, 20)
-	// /api/ gets its own, far looser one: a dashboard load fans out dozens of
-	// parallel calls, so the tight bucket would 429 ordinary use. This is a
-	// flood ceiling, not a quota — it must never be reachable by the UI.
-	a.apiRL = ratelimit.New(50, 200)
 
 	// --- MCP Server ---
 	mcpSvc := &mcp.Services{
@@ -810,6 +820,7 @@ func (a *App) Start(ctx context.Context) error {
 	// Background services (always run, regardless of runtime availability)
 	go a.rl.Start(ctx)
 	go a.apiRL.Start(ctx)
+	go a.subscribeRL.Start(ctx)
 	go a.resourceSvc.Start(ctx)
 	go a.certSvc.Start(ctx)
 	go a.maintScheduler.Start(ctx)

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -14,11 +14,13 @@ package app
 import (
 	"errors"
 	"fmt"
+	"net/netip"
 	"os"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/kolapsis/maintenant/internal/ratelimit"
 	"github.com/kolapsis/maintenant/internal/resource"
 	"github.com/kolapsis/maintenant/internal/store"
 )
@@ -50,6 +52,9 @@ type Config struct {
 	// HTTP
 	CORSOrigins string
 	MaxBodySize int64
+	// TrustedProxies lists the CIDRs and addresses whose forwarded headers are
+	// believed, comma-separated. Empty means no header is ever read.
+	TrustedProxies string
 
 	// CACertFile is a PEM bundle appended to the system roots, so endpoints and
 	// certificates signed by an internal PKI validate without disabling checks.
@@ -180,6 +185,25 @@ func (c Config) ValidateStorage() error {
 	return nil
 }
 
+// ErrTrustedProxies refuses a proxy list that does not parse.
+var ErrTrustedProxies = errors.New(
+	"MAINTENANT_TRUSTED_PROXIES is not a valid list: use comma-separated CIDRs or IP addresses such as 10.0.0.0/8,192.168.1.4")
+
+// ParseTrustedProxies returns the prefixes whose forwarded headers are believed.
+func (c Config) ParseTrustedProxies() ([]netip.Prefix, error) {
+	prefixes, err := ratelimit.ParsePrefixes(c.TrustedProxies)
+	if err != nil {
+		return nil, fmt.Errorf("%w (%v)", ErrTrustedProxies, err)
+	}
+	return prefixes, nil
+}
+
+// ValidateProxies refuses a trusted-proxy list that would silently be ignored.
+func (c Config) ValidateProxies() error {
+	_, err := c.ParseTrustedProxies()
+	return err
+}
+
 // ErrContainerDownAfter refuses a container-down threshold that does not parse.
 var ErrContainerDownAfter = errors.New(
 	"MAINTENANT_CONTAINER_DOWN_AFTER is not a valid duration: use a Go duration such as 5m, 30s or 1h30m")
@@ -231,9 +255,10 @@ func ConfigFromEnv() Config {
 			AllowUnauthenticated: parseTruthy(os.Getenv("MAINTENANT_MCP_ALLOW_UNAUTHENTICATED")),
 		},
 
-		CORSOrigins: os.Getenv("MAINTENANT_CORS_ORIGINS"),
-		MaxBodySize: int64OrDefault("MAINTENANT_MAX_BODY_SIZE", 1048576),
-		CACertFile:  os.Getenv("MAINTENANT_CA_CERT"),
+		CORSOrigins:    os.Getenv("MAINTENANT_CORS_ORIGINS"),
+		TrustedProxies: os.Getenv("MAINTENANT_TRUSTED_PROXIES"),
+		MaxBodySize:    int64OrDefault("MAINTENANT_MAX_BODY_SIZE", 1048576),
+		CACertFile:     os.Getenv("MAINTENANT_CA_CERT"),
 
 		OrgName:   envOr("MAINTENANT_ORGANISATION_NAME", "Maintenant"),
 		StatusURL: os.Getenv("MAINTENANT_STATUS_URL"),

--- a/internal/app/config_test.go
+++ b/internal/app/config_test.go
@@ -12,6 +12,7 @@
 package app
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -137,5 +138,44 @@ func TestConfigFromEnv_ContainerDownAfterInvalidIsRefused(t *testing.T) {
 			assert.ErrorIs(t, err, ErrContainerDownAfter)
 			assert.Contains(t, err.Error(), raw)
 		})
+	}
+}
+
+func TestParseTrustedProxies(t *testing.T) {
+	cfg := Config{TrustedProxies: "10.0.0.0/8, 192.168.1.4 , 2001:db8::/32"}
+
+	prefixes, err := cfg.ParseTrustedProxies()
+	if err != nil {
+		t.Fatalf("ParseTrustedProxies: %v", err)
+	}
+	if err := cfg.ValidateProxies(); err != nil {
+		t.Fatalf("ValidateProxies: %v", err)
+	}
+
+	want := []string{"10.0.0.0/8", "192.168.1.4/32", "2001:db8::/32"}
+	if len(prefixes) != len(want) {
+		t.Fatalf("got %v, want %v", prefixes, want)
+	}
+	for i, p := range prefixes {
+		if p.String() != want[i] {
+			t.Fatalf("prefix %d: got %s, want %s", i, p, want[i])
+		}
+	}
+}
+
+func TestParseTrustedProxiesEmptyTrustsNothing(t *testing.T) {
+	prefixes, err := Config{}.ParseTrustedProxies()
+	if err != nil {
+		t.Fatalf("ParseTrustedProxies: %v", err)
+	}
+	if len(prefixes) != 0 {
+		t.Fatalf("got %v, want no prefix", prefixes)
+	}
+}
+
+func TestValidateProxiesRefusesGarbage(t *testing.T) {
+	err := Config{TrustedProxies: "10.0.0.0/8,nonsense"}.ValidateProxies()
+	if !errors.Is(err, ErrTrustedProxies) {
+		t.Fatalf("got %v, want ErrTrustedProxies", err)
 	}
 }

--- a/internal/app/flags.go
+++ b/internal/app/flags.go
@@ -19,6 +19,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/kolapsis/maintenant/internal/ratelimit"
 )
 
 // FlagType is the value type of a configuration flag.
@@ -79,6 +81,18 @@ func init() {
 			Type: FlagTypeString, Default: "",
 			Description: "Comma-separated CORS origins (empty = same-origin)",
 			ApplyTo:     func(c *Config, v string) error { c.CORSOrigins = v; return nil },
+		},
+		{
+			EnvName: "MAINTENANT_TRUSTED_PROXIES", FlagName: "trustedProxies",
+			Type: FlagTypeString, Default: "",
+			Description: "Comma-separated CIDRs/IPs whose forwarded headers are believed (empty = none)",
+			ApplyTo: func(c *Config, v string) error {
+				if _, err := ratelimit.ParsePrefixes(v); err != nil {
+					return err
+				}
+				c.TrustedProxies = v
+				return nil
+			},
 		},
 		// Storage
 		{
@@ -495,7 +509,7 @@ func init() {
 		{Name: "Branding", Specs: specsFor("organisationName", "statusUrl")},
 		{Name: "Runtime", Specs: specsFor("runtime")},
 		{Name: "Logging", Specs: specsFor("logLevel")},
-		{Name: "HTTP", Specs: specsFor("maxBodySize")},
+		{Name: "HTTP", Specs: specsFor("maxBodySize", "trustedProxies")},
 		{Name: "Updates", Specs: specsFor("updateInterval")},
 		{Name: "Security", Specs: specsFor("securityScoreThreshold", "disableTelemetry", "allowPrivateWebhooks")},
 		{Name: "Pro", Specs: specsFor("licenseKey")},

--- a/internal/app/http.go
+++ b/internal/app/http.go
@@ -214,8 +214,8 @@ func (a *App) buildHTTPServer() *http.Server {
 			}, mcpOAuthStore, a.logger.With("component", "mcp-oauth"))
 
 			topMux.HandleFunc("/.well-known/oauth-authorization-server", oauthSrv.HandleAuthServerMetadata)
-			topMux.HandleFunc("/oauth/authorize", oauthSrv.HandleAuthorize)
-			topMux.HandleFunc("/oauth/token", oauthSrv.HandleToken)
+			topMux.Handle("/oauth/authorize", a.rl.Middleware(http.HandlerFunc(oauthSrv.HandleAuthorize)))
+			topMux.Handle("/oauth/token", a.rl.Middleware(http.HandlerFunc(oauthSrv.HandleToken)))
 
 			topMux.Handle("/.well-known/oauth-protected-resource",
 				mcpauth.ProtectedResourceMetadataHandler(&oauthex.ProtectedResourceMetadata{

--- a/internal/ratelimit/clientip.go
+++ b/internal/ratelimit/clientip.go
@@ -1,0 +1,123 @@
+// Copyright 2026 Benjamin Touchard (Kolapsis)
+//
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+// or a commercial license. You may not use this file except in compliance
+// with one of these licenses.
+//
+// AGPL-3.0: https://www.gnu.org/licenses/agpl-3.0.html
+// Commercial: See COMMERCIAL-LICENSE.md
+//
+// Source: https://github.com/kolapsis/maintenant
+
+package ratelimit
+
+import (
+	"net"
+	"net/http"
+	"net/netip"
+	"strings"
+)
+
+// ClientIPResolver turns a request into the address a quota is counted against.
+type ClientIPResolver struct{ trusted []netip.Prefix }
+
+// NewClientIPResolver returns a resolver that reads forwarded headers only from the given prefixes.
+func NewClientIPResolver(trusted []netip.Prefix) *ClientIPResolver {
+	return &ClientIPResolver{trusted: trusted}
+}
+
+// Resolve returns the address the request is attributed to.
+func (r *ClientIPResolver) Resolve(req *http.Request) netip.Addr {
+	peer := peerAddr(req.RemoteAddr)
+	if !r.TrustsPeer(req) {
+		return peer
+	}
+
+	if fwd := req.Header.Get("X-Forwarded-For"); fwd != "" {
+		hops := strings.Split(fwd, ",")
+		for i := len(hops) - 1; i >= 0; i-- {
+			addr, err := netip.ParseAddr(strings.TrimSpace(hops[i]))
+			if err != nil {
+				continue
+			}
+			if addr = addr.Unmap(); !r.trusts(addr) {
+				return addr
+			}
+		}
+		return peer
+	}
+
+	if real := req.Header.Get("X-Real-IP"); real != "" {
+		if addr, err := netip.ParseAddr(strings.TrimSpace(real)); err == nil {
+			return addr.Unmap()
+		}
+	}
+	return peer
+}
+
+// TrustsPeer reports whether the request comes straight from a configured trusted proxy.
+func (r *ClientIPResolver) TrustsPeer(req *http.Request) bool {
+	if r == nil || len(r.trusted) == 0 || req == nil {
+		return false
+	}
+	return r.trusts(peerAddr(req.RemoteAddr))
+}
+
+// ClientIP returns the resolved address as the string key a quota is stored under.
+func (r *ClientIPResolver) ClientIP(req *http.Request) string {
+	if addr := r.Resolve(req); addr.IsValid() {
+		return addr.String()
+	}
+	return req.RemoteAddr
+}
+
+func (r *ClientIPResolver) trusts(addr netip.Addr) bool {
+	if !addr.IsValid() {
+		return false
+	}
+	for _, p := range r.trusted {
+		if p.Contains(addr) {
+			return true
+		}
+	}
+	return false
+}
+
+func peerAddr(remoteAddr string) netip.Addr {
+	host := remoteAddr
+	if h, _, err := net.SplitHostPort(remoteAddr); err == nil {
+		host = h
+	}
+	host = strings.TrimSuffix(strings.TrimPrefix(host, "["), "]")
+	addr, err := netip.ParseAddr(host)
+	if err != nil {
+		return netip.Addr{}
+	}
+	return addr.Unmap()
+}
+
+// ParsePrefixes reads a comma-separated list of CIDRs and bare IP addresses.
+func ParsePrefixes(list string) ([]netip.Prefix, error) {
+	var out []netip.Prefix
+	for _, raw := range strings.Split(list, ",") {
+		entry := strings.TrimSpace(raw)
+		if entry == "" {
+			continue
+		}
+		if strings.Contains(entry, "/") {
+			p, err := netip.ParsePrefix(entry)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, p.Masked())
+			continue
+		}
+		addr, err := netip.ParseAddr(entry)
+		if err != nil {
+			return nil, err
+		}
+		addr = addr.Unmap()
+		out = append(out, netip.PrefixFrom(addr, addr.BitLen()))
+	}
+	return out, nil
+}

--- a/internal/ratelimit/clientip_test.go
+++ b/internal/ratelimit/clientip_test.go
@@ -1,0 +1,159 @@
+// Copyright 2026 Benjamin Touchard (Kolapsis)
+//
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+// or a commercial license. You may not use this file except in compliance
+// with one of these licenses.
+//
+// AGPL-3.0: https://www.gnu.org/licenses/agpl-3.0.html
+// Commercial: See COMMERCIAL-LICENSE.md
+//
+// Source: https://github.com/kolapsis/maintenant
+
+package ratelimit
+
+import (
+	"net/http"
+	"net/netip"
+	"testing"
+)
+
+func request(remoteAddr string, headers map[string]string) *http.Request {
+	req := &http.Request{
+		RemoteAddr: remoteAddr,
+		Header:     http.Header{},
+	}
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	return req
+}
+
+func prefixes(t *testing.T, list string) []netip.Prefix {
+	t.Helper()
+	p, err := ParsePrefixes(list)
+	if err != nil {
+		t.Fatalf("ParsePrefixes(%q): %v", list, err)
+	}
+	return p
+}
+
+func TestResolveIgnoresHeadersWithoutTrustedProxies(t *testing.T) {
+	r := NewClientIPResolver(nil)
+	req := request("203.0.113.5:44000", map[string]string{
+		"X-Forwarded-For": "1.2.3.4",
+		"X-Real-IP":       "5.6.7.8",
+	})
+
+	if got := r.Resolve(req).String(); got != "203.0.113.5" {
+		t.Fatalf("got %s, want the peer address", got)
+	}
+}
+
+func TestResolveTakesLastUntrustedForwardedHop(t *testing.T) {
+	r := NewClientIPResolver(prefixes(t, "10.0.0.0/8"))
+	req := request("10.0.0.1:44000", map[string]string{
+		"X-Forwarded-For": "198.51.100.7, 10.0.0.9",
+	})
+
+	if got := r.Resolve(req).String(); got != "198.51.100.7" {
+		t.Fatalf("got %s, want 198.51.100.7", got)
+	}
+}
+
+func TestResolveIgnoresForgedHeaderFromUntrustedPeer(t *testing.T) {
+	r := NewClientIPResolver(prefixes(t, "10.0.0.0/8"))
+	req := request("203.0.113.5:44000", map[string]string{
+		"X-Forwarded-For": "1.2.3.4",
+	})
+
+	if got := r.Resolve(req).String(); got != "203.0.113.5" {
+		t.Fatalf("got %s, want the peer address", got)
+	}
+}
+
+func TestResolveRealIPOnlyWhenForwardedForAbsent(t *testing.T) {
+	r := NewClientIPResolver(prefixes(t, "10.0.0.0/8"))
+
+	behind := request("10.0.0.1:44000", map[string]string{"X-Real-IP": "198.51.100.7"})
+	if got := r.Resolve(behind).String(); got != "198.51.100.7" {
+		t.Fatalf("trusted peer: got %s, want 198.51.100.7", got)
+	}
+
+	withXFF := request("10.0.0.1:44000", map[string]string{
+		"X-Forwarded-For": "203.0.113.9",
+		"X-Real-IP":       "198.51.100.7",
+	})
+	if got := r.Resolve(withXFF).String(); got != "203.0.113.9" {
+		t.Fatalf("X-Forwarded-For wins: got %s, want 203.0.113.9", got)
+	}
+
+	direct := request("203.0.113.5:44000", map[string]string{"X-Real-IP": "198.51.100.7"})
+	if got := r.Resolve(direct).String(); got != "203.0.113.5" {
+		t.Fatalf("untrusted peer: got %s, want the peer address", got)
+	}
+}
+
+func TestResolveIPv6Peer(t *testing.T) {
+	r := NewClientIPResolver(nil)
+
+	bracketed := request("[2001:db8::1]:44000", nil)
+	if got := r.Resolve(bracketed).String(); got != "2001:db8::1" {
+		t.Fatalf("bracketed: got %s", got)
+	}
+
+	bare := request("2001:db8::1", nil)
+	if got := r.Resolve(bare).String(); got != "2001:db8::1" {
+		t.Fatalf("bare: got %s", got)
+	}
+}
+
+func TestResolveIPv6TrustedProxy(t *testing.T) {
+	r := NewClientIPResolver(prefixes(t, "2001:db8::/32"))
+	req := request("[2001:db8::1]:44000", map[string]string{
+		"X-Forwarded-For": "198.51.100.7, 2001:db8::5",
+	})
+
+	if got := r.Resolve(req).String(); got != "198.51.100.7" {
+		t.Fatalf("got %s, want 198.51.100.7", got)
+	}
+}
+
+func TestResolveGarbageHeaderFallsBackToPeer(t *testing.T) {
+	r := NewClientIPResolver(prefixes(t, "10.0.0.0/8"))
+
+	garbageXFF := request("10.0.0.1:44000", map[string]string{"X-Forwarded-For": "not-an-ip, ../../etc"})
+	if got := r.Resolve(garbageXFF).String(); got != "10.0.0.1" {
+		t.Fatalf("garbage X-Forwarded-For: got %s", got)
+	}
+
+	garbageReal := request("10.0.0.1:44000", map[string]string{"X-Real-IP": "not-an-ip"})
+	if got := r.Resolve(garbageReal).String(); got != "10.0.0.1" {
+		t.Fatalf("garbage X-Real-IP: got %s", got)
+	}
+}
+
+func TestClientIPFallsBackToRemoteAddr(t *testing.T) {
+	r := NewClientIPResolver(nil)
+	if got := r.ClientIP(request("unix-socket", nil)); got != "unix-socket" {
+		t.Fatalf("got %s, want the raw RemoteAddr", got)
+	}
+}
+
+func TestParsePrefixesAcceptsBareAddressesAndCIDRs(t *testing.T) {
+	got := prefixes(t, " 10.0.0.0/8 , 192.168.1.4 ,, 2001:db8::/32 ")
+	want := []string{"10.0.0.0/8", "192.168.1.4/32", "2001:db8::/32"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i, p := range got {
+		if p.String() != want[i] {
+			t.Fatalf("prefix %d: got %s, want %s", i, p, want[i])
+		}
+	}
+}
+
+func TestParsePrefixesRefusesGarbage(t *testing.T) {
+	if _, err := ParsePrefixes("10.0.0.0/8,nonsense"); err == nil {
+		t.Fatal("expected an error")
+	}
+}

--- a/internal/ratelimit/limiter.go
+++ b/internal/ratelimit/limiter.go
@@ -13,9 +13,6 @@ package ratelimit
 
 import (
 	"context"
-	"net"
-	"net/http"
-	"strings"
 	"sync"
 	"time"
 )
@@ -30,14 +27,19 @@ type visitor struct {
 type Limiter struct {
 	rate     float64
 	burst    int
+	resolver *ClientIPResolver
 	visitors sync.Map // IP string → *visitor
 }
 
 // New creates a rate limiter allowing rate tokens per second with the given burst capacity.
-func New(rate float64, burst int) *Limiter {
+func New(rate float64, burst int, resolver *ClientIPResolver) *Limiter {
+	if resolver == nil {
+		resolver = NewClientIPResolver(nil)
+	}
 	return &Limiter{
-		rate:  rate,
-		burst: burst,
+		rate:     rate,
+		burst:    burst,
+		resolver: resolver,
 	}
 }
 
@@ -71,18 +73,29 @@ func (l *Limiter) Allow(ip string) bool {
 	return true
 }
 
+// Len reports how many addresses currently hold a bucket.
+func (l *Limiter) Len() int {
+	n := 0
+	l.visitors.Range(func(_, _ any) bool {
+		n++
+		return true
+	})
+	return n
+}
+
 // Start launches a background goroutine that evicts inactive visitors every 60 seconds.
 // It stops when ctx is cancelled.
 func (l *Limiter) Start(ctx context.Context) {
 	ticker := time.NewTicker(60 * time.Second)
 	defer ticker.Stop()
 
+	idle := l.idleBeforeEviction()
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case now := <-ticker.C:
-			cutoff := now.Add(-3 * time.Minute)
+			cutoff := now.Add(-idle)
 			l.visitors.Range(func(key, val any) bool {
 				v := val.(*visitor)
 				v.mu.Lock()
@@ -97,17 +110,17 @@ func (l *Limiter) Start(ctx context.Context) {
 	}
 }
 
-// ClientIP extracts the client IP from the request, respecting reverse proxy headers.
-func ClientIP(r *http.Request) string {
-	if ip := r.Header.Get("X-Real-IP"); ip != "" {
-		return strings.TrimSpace(ip)
+// idleBeforeEviction is how long a visitor must go untouched before its bucket is
+// dropped. A bucket may only be forgotten once it has refilled to its burst: on a
+// long window (a few tokens per hour) an earlier eviction would hand the quota back.
+func (l *Limiter) idleBeforeEviction() time.Duration {
+	const floor = 3 * time.Minute
+	if l.rate <= 0 {
+		return floor
 	}
-	if fwd := r.Header.Get("X-Forwarded-For"); fwd != "" {
-		return strings.TrimSpace(strings.SplitN(fwd, ",", 2)[0])
+	refill := time.Duration(float64(l.burst) / l.rate * float64(time.Second))
+	if refill < floor {
+		return floor
 	}
-	host, _, err := net.SplitHostPort(r.RemoteAddr)
-	if err != nil {
-		return r.RemoteAddr
-	}
-	return host
+	return refill
 }

--- a/internal/ratelimit/limiter_test.go
+++ b/internal/ratelimit/limiter_test.go
@@ -1,0 +1,89 @@
+// Copyright 2026 Benjamin Touchard (Kolapsis)
+//
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+// or a commercial license. You may not use this file except in compliance
+// with one of these licenses.
+//
+// AGPL-3.0: https://www.gnu.org/licenses/agpl-3.0.html
+// Commercial: See COMMERCIAL-LICENSE.md
+//
+// Source: https://github.com/kolapsis/maintenant
+
+package ratelimit
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// A caller that renames itself on every request must not get a fresh bucket:
+// with no trusted proxy the header is not read at all.
+func TestMiddlewareSpoofedHeadersShareOneBucket(t *testing.T) {
+	l := New(0.0001, 2, NewClientIPResolver(nil))
+	h := l.Middleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	codes := make([]int, 0, 3)
+	for _, spoofed := range []string{"1.1.1.1", "2.2.2.2", "3.3.3.3"} {
+		req := httptest.NewRequest(http.MethodGet, "/ping/x", nil)
+		req.RemoteAddr = "203.0.113.5:44000"
+		req.Header.Set("X-Real-IP", spoofed)
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		codes = append(codes, rec.Code)
+	}
+
+	if codes[0] != http.StatusOK || codes[1] != http.StatusOK {
+		t.Fatalf("first two requests should pass, got %v", codes)
+	}
+	if codes[2] != http.StatusTooManyRequests {
+		t.Fatalf("third request should be rate limited, got %d", codes[2])
+	}
+}
+
+// Behind a declared proxy the quota follows the forwarded client, so two
+// distinct clients arriving through the same proxy keep separate buckets.
+func TestMiddlewareCountsForwardedClientBehindTrustedProxy(t *testing.T) {
+	trusted, err := ParsePrefixes("10.0.0.0/8")
+	if err != nil {
+		t.Fatalf("ParsePrefixes: %v", err)
+	}
+	l := New(0.0001, 1, NewClientIPResolver(trusted))
+	h := l.Middleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	call := func(client string) int {
+		req := httptest.NewRequest(http.MethodGet, "/ping/x", nil)
+		req.RemoteAddr = "10.0.0.1:44000"
+		req.Header.Set("X-Forwarded-For", client)
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		return rec.Code
+	}
+
+	if code := call("198.51.100.7"); code != http.StatusOK {
+		t.Fatalf("first client: got %d", code)
+	}
+	if code := call("203.0.113.9"); code != http.StatusOK {
+		t.Fatalf("second client must have its own bucket: got %d", code)
+	}
+	if code := call("198.51.100.7"); code != http.StatusTooManyRequests {
+		t.Fatalf("first client past its burst: got %d", code)
+	}
+}
+
+func TestLimiterEvictionWaitsForARefilledBucket(t *testing.T) {
+	tight := New(10, 20, nil)
+	if got := tight.idleBeforeEviction(); got != 3*time.Minute {
+		t.Fatalf("tight bucket: got %s, want the 3 minute floor", got)
+	}
+
+	hourly := New(5.0/3600.0, 5, nil)
+	if got := hourly.idleBeforeEviction(); got != time.Hour {
+		t.Fatalf("hourly bucket: got %s, want 1h", got)
+	}
+}

--- a/internal/ratelimit/middleware.go
+++ b/internal/ratelimit/middleware.go
@@ -13,11 +13,16 @@ package ratelimit
 
 import "net/http"
 
+// AllowRequest consumes one token for the address the request is attributed to.
+func (l *Limiter) AllowRequest(r *http.Request) bool {
+	return l.Allow(l.resolver.ClientIP(r))
+}
+
 // Middleware wraps an http.Handler and rejects requests that exceed the rate limit
 // with a 429 status code.
 func (l *Limiter) Middleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if !l.Allow(ClientIP(r)) {
+		if !l.AllowRequest(r) {
 			w.Header().Set("Content-Type", "application/json")
 			w.Header().Set("Retry-After", "1")
 			w.WriteHeader(http.StatusTooManyRequests)

--- a/internal/status/handler.go
+++ b/internal/status/handler.go
@@ -14,12 +14,14 @@ package status
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"html"
 	"log/slog"
 	"net/http"
-	"strings"
-	"sync"
+	"net/mail"
 	"time"
+
+	"github.com/kolapsis/maintenant/internal/ratelimit"
 )
 
 // Handler serves the public status page API and SSE endpoints.
@@ -29,23 +31,17 @@ type Handler struct {
 	logger          *slog.Logger
 	personalization *PersonalizationPublicHandler
 	indexHTML       []byte
-
-	rateMu     sync.Mutex
-	rateMap    map[string][]time.Time
-	rateLimit  int
-	rateWindow time.Duration
+	subscribeRL     *ratelimit.Limiter
 }
 
 // NewHandler creates a new public status page handler.
 // sseHandler should be an SSEBroker that implements http.Handler for /status/events.
-func NewHandler(service *Service, sseHandler http.Handler, logger *slog.Logger) *Handler {
+func NewHandler(service *Service, sseHandler http.Handler, logger *slog.Logger, subscribeRL *ratelimit.Limiter) *Handler {
 	return &Handler{
-		service:    service,
-		sseHandler: sseHandler,
-		logger:     logger,
-		rateMap:    make(map[string][]time.Time),
-		rateLimit:  5,
-		rateWindow: time.Hour,
+		service:     service,
+		sseHandler:  sseHandler,
+		logger:      logger,
+		subscribeRL: subscribeRL,
 	}
 }
 
@@ -66,6 +62,12 @@ type Middleware func(http.Handler) http.Handler
 // /status/ serves the Vue SPA index.html — Traefik rewrites the status subdomain root
 // to /status/ so that Vue Router can initialise at the correct route.
 func (h *Handler) Register(mux *http.ServeMux, mw Middleware) {
+	outer := mw
+	if outer == nil {
+		outer = func(next http.Handler) http.Handler { return next }
+	}
+	mw = func(next http.Handler) http.Handler { return outer(limitBody(maxStatusBody, next)) }
+
 	// Page HTML — catch-all for /status/ (more specific patterns below take precedence).
 	mux.Handle("GET /status/", mw(http.HandlerFunc(h.HandleStatusPage)))
 	// API & SSE endpoints.
@@ -213,40 +215,18 @@ func (h *Handler) HandleStatusAPI(w http.ResponseWriter, r *http.Request) {
 
 // --- Subscription endpoints ---
 
-func clientIP(r *http.Request) string {
-	if fwd := r.Header.Get("X-Forwarded-For"); fwd != "" {
-		parts := strings.SplitN(fwd, ",", 2)
-		return strings.TrimSpace(parts[0])
-	}
-	addr := r.RemoteAddr
-	if idx := strings.LastIndex(addr, ":"); idx > 0 {
-		return addr[:idx]
-	}
-	return addr
-}
+// maxStatusBody bounds every public status-page request body.
+const maxStatusBody = 4 << 10
 
-func (h *Handler) checkRateLimit(ip string) bool {
-	h.rateMu.Lock()
-	defer h.rateMu.Unlock()
+// maxEmailLength is the longest address RFC 5321 lets a mailbox be.
+const maxEmailLength = 254
 
-	now := time.Now()
-	cutoff := now.Add(-h.rateWindow)
-
-	entries := h.rateMap[ip]
-	var valid []time.Time
-	for _, t := range entries {
-		if t.After(cutoff) {
-			valid = append(valid, t)
-		}
-	}
-
-	if len(valid) >= h.rateLimit {
-		h.rateMap[ip] = valid
-		return false
-	}
-
-	h.rateMap[ip] = append(valid, now)
-	return true
+// limitBody caps the request body of a public route.
+func limitBody(maxBytes int64, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r.Body = http.MaxBytesReader(w, r.Body, maxBytes)
+		next.ServeHTTP(w, r)
+	})
 }
 
 // HandleSubscribe processes a new email subscription request.
@@ -256,7 +236,9 @@ func (h *Handler) HandleSubscribe(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !h.checkRateLimit(clientIP(r)) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxStatusBody)
+
+	if !h.subscribeRL.AllowRequest(r) {
 		http.Error(w, "Too many requests", http.StatusTooManyRequests)
 		return
 	}
@@ -268,17 +250,37 @@ func (h *Handler) HandleSubscribe(w http.ResponseWriter, r *http.Request) {
 	contentType := r.Header.Get("Content-Type")
 	if contentType == "application/json" {
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			var tooLarge *http.MaxBytesError
+			if errors.As(err, &tooLarge) {
+				http.Error(w, "Request body too large", http.StatusRequestEntityTooLarge)
+				return
+			}
 			http.Error(w, "Invalid JSON", http.StatusBadRequest)
 			return
 		}
 	} else {
-		req.Email = r.FormValue("email")
+		if err := r.ParseForm(); err != nil {
+			var tooLarge *http.MaxBytesError
+			if errors.As(err, &tooLarge) {
+				http.Error(w, "Request body too large", http.StatusRequestEntityTooLarge)
+				return
+			}
+			http.Error(w, "Invalid form", http.StatusBadRequest)
+			return
+		}
+		req.Email = r.PostFormValue("email")
 	}
 
-	if req.Email == "" {
-		http.Error(w, "Email is required", http.StatusBadRequest)
+	if len(req.Email) > maxEmailLength {
+		http.Error(w, "Email is too long", http.StatusBadRequest)
 		return
 	}
+	addr, err := mail.ParseAddress(req.Email)
+	if err != nil {
+		http.Error(w, "Email is not a valid address", http.StatusBadRequest)
+		return
+	}
+	req.Email = addr.Address
 
 	if err := h.service.subscribers.Subscribe(r.Context(), req.Email); err != nil {
 		h.logger.Error("subscribe failed", "error", err)

--- a/internal/status/handler_test.go
+++ b/internal/status/handler_test.go
@@ -1,0 +1,153 @@
+// Copyright 2026 Benjamin Touchard (Kolapsis)
+//
+// Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
+// or a commercial license. You may not use this file except in compliance
+// with one of these licenses.
+//
+// AGPL-3.0: https://www.gnu.org/licenses/agpl-3.0.html
+// Commercial: See COMMERCIAL-LICENSE.md
+//
+// Source: https://github.com/kolapsis/maintenant
+
+package status
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/kolapsis/maintenant/internal/ratelimit"
+)
+
+type recordingSubscriberStore struct {
+	SubscriberStore
+	created []string
+}
+
+func (s *recordingSubscriberStore) CreateSubscriber(_ context.Context, sub *StatusSubscriber) (string, error) {
+	s.created = append(s.created, sub.Email)
+	return "id", nil
+}
+
+func newSubscribeHandler(t *testing.T) (*Handler, *recordingSubscriberStore) {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	store := &recordingSubscriberStore{}
+	return &Handler{
+		service:     &Service{subscribers: NewSubscriberService(store, nil, "http://localhost", logger)},
+		logger:      logger,
+		subscribeRL: ratelimit.New(5.0/3600.0, 5, ratelimit.NewClientIPResolver(nil)),
+	}, store
+}
+
+func postSubscribe(t *testing.T, h *Handler, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/status/subscribe", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.RemoteAddr = "203.0.113.5:44000"
+	rec := httptest.NewRecorder()
+	h.HandleSubscribe(rec, req)
+	return rec
+}
+
+func TestHandleSubscribeRefusesOversizedBody(t *testing.T) {
+	h, store := newSubscribeHandler(t)
+
+	body := `{"email":"` + strings.Repeat("a", 1<<20) + `@example.com"}`
+	rec := postSubscribe(t, h, body)
+
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("got %d, want 413", rec.Code)
+	}
+	if len(store.created) != 0 {
+		t.Fatalf("the store was written to: %v", store.created)
+	}
+}
+
+func TestHandleSubscribeRefusesOverlongAddress(t *testing.T) {
+	h, store := newSubscribeHandler(t)
+
+	rec := postSubscribe(t, h, `{"email":"`+strings.Repeat("a", 300)+`@example.com"}`)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("got %d, want 400", rec.Code)
+	}
+	if len(store.created) != 0 {
+		t.Fatalf("the store was written to: %v", store.created)
+	}
+}
+
+func TestHandleSubscribeRefusesMalformedAddress(t *testing.T) {
+	h, store := newSubscribeHandler(t)
+
+	for _, email := range []string{"", "not-an-address", "a@b@c", "<script>alert(1)</script>"} {
+		rec := postSubscribe(t, h, `{"email":`+quoteJSON(email)+`}`)
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("%q: got %d, want 400", email, rec.Code)
+		}
+	}
+	if len(store.created) != 0 {
+		t.Fatalf("the store was written to: %v", store.created)
+	}
+}
+
+func TestHandleSubscribeQuotaIsFivePerWindow(t *testing.T) {
+	h, store := newSubscribeHandler(t)
+
+	for i := 0; i < 5; i++ {
+		if rec := postSubscribe(t, h, `{"email":"ok@example.com"}`); rec.Code != http.StatusOK {
+			t.Fatalf("request %d: got %d, want 200", i+1, rec.Code)
+		}
+	}
+	if rec := postSubscribe(t, h, `{"email":"ok@example.com"}`); rec.Code != http.StatusTooManyRequests {
+		t.Fatalf("sixth request: got %d, want 429", rec.Code)
+	}
+	if len(store.created) != 5 {
+		t.Fatalf("stored %d subscriptions, want 5", len(store.created))
+	}
+}
+
+// A caller renaming itself on every request must not enlarge the quota map:
+// without a trusted proxy the header is never read, so one bucket is created.
+func TestHandleSubscribeSpoofedHeadersDoNotGrowTheLimiter(t *testing.T) {
+	h, _ := newSubscribeHandler(t)
+
+	for i := 0; i < 50; i++ {
+		req := httptest.NewRequest(http.MethodPost, "/status/subscribe",
+			strings.NewReader(`{"email":"ok@example.com"}`))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("X-Forwarded-For", "198.51.100."+string(rune('0'+i%10)))
+		req.Header.Set("X-Real-IP", "203.0.113."+string(rune('0'+i%10)))
+		req.RemoteAddr = "203.0.113.5:44000"
+		h.HandleSubscribe(httptest.NewRecorder(), req)
+	}
+
+	if buckets := h.subscribeRL.Len(); buckets != 1 {
+		t.Fatalf("the limiter holds %d buckets, want 1", buckets)
+	}
+}
+
+func TestRegisterCapsTheStatusBodies(t *testing.T) {
+	h, _ := newSubscribeHandler(t)
+	mux := http.NewServeMux()
+	h.Register(mux, nil)
+
+	req := httptest.NewRequest(http.MethodPost, "/status/subscribe",
+		strings.NewReader(`{"email":"`+strings.Repeat("a", 1<<16)+`@example.com"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.RemoteAddr = "203.0.113.5:44000"
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("got %d, want 413", rec.Code)
+	}
+}
+
+func quoteJSON(s string) string {
+	return `"` + strings.ReplaceAll(s, `"`, `\"`) + `"`
+}


### PR DESCRIPTION
Every quota was counted against an address the caller supplied. `ClientIP`
returned `X-Real-IP`, or the first element of `X-Forwarded-For`, with no check
that the peer was a proxy at all and no parsing of what it read. On a directly
reachable instance a fresh header per request meant a fresh bucket per request,
so the limiter limited nothing. The status page had a second implementation of
the same idea, wrong on a bare IPv6 literal, and its counter map grew a key per
distinct value it was handed and never dropped one. `X-Forwarded-Host` was
believed the same way to build the agent enrolment URL, which carries a token in
clear, and a header could even downgrade that URL to plaintext gRPC.

`MAINTENANT_TRUSTED_PROXIES` and one resolver now read a forwarded header only
when the peer sits in a declared prefix, walking `X-Forwarded-For` right to left
to the first hop that is not itself a proxy. Unset — the default — nothing but
the connecting address is ever believed. The duplicate is gone, the status page
shares the evicting limiter, and the enrolment URL never becomes plaintext
because a header asked.

Reusing the shared limiter for the five-per-hour subscription quota required
fixing its eviction first: a flat three-minute idle cutoff would have dropped an
hourly bucket and handed the quota back every three minutes. A bucket is now
kept until it has refilled to its burst.

Body limits were as partial. `bodyLimit` only wrapped POST and PUT, leaving the
PATCH routes unbounded, and the public `/status` routes are mounted on the top
mux, which never carried it: `POST /status/subscribe` decoded JSON with no
ceiling and accepted any non-empty string as an address. Limits now apply to any
request that can carry a body, `/status` has its own, and an address is parsed
and bounded before the store is touched.

`/oauth/authorize` and `/oauth/token` had no rate limiter of any kind. They do
now.

Found by an external security audit of `2c6654c` (findings S-05, S-06); the
X-Forwarded-For and X-Forwarded-Host defects were noted as #11 and #13 in the
July audit and left open.
