### PR TITLE
fix(startup): fail on a busy port, serve the status page under the CSP, build from a clean clone

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,12 +211,6 @@ jobs:
         with:
           go-version-file: go.mod
 
-      # cmd/maintenant/web/web.go embeds `all:dist`. That directory is built by
-      # the frontend and never committed, so without this placeholder the Go
-      # build fails before lint or tests even start.
-      - name: Prepare embedded assets
-        run: mkdir -p cmd/maintenant/web/dist && touch cmd/maintenant/web/dist/.gitkeep
-
       # go.sum carries the hash of every module: `go mod verify` is what turns
       # the lockfile into an integrity check rather than a version list.
       - name: Verify module hashes (go.sum)
@@ -264,9 +258,6 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
-
-      - name: Prepare embedded assets
-        run: mkdir -p cmd/maintenant/web/dist && touch cmd/maintenant/web/dist/.gitkeep
 
       # The default pass: SQLite, which is what an unconfigured install uses.
       # PostgreSQL cases skip when MAINTENANT_TEST_DATABASE_URL is unset.
@@ -408,9 +399,6 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Prepare embedded assets
-        run: mkdir -p cmd/maintenant/web/dist && touch cmd/maintenant/web/dist/.gitkeep
-
       # Complements CodeQL rather than replacing it: CodeQL carries the deep
       # data-flow analysis, gosec adds the Go-specific rule set.
       #
@@ -451,9 +439,6 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
-
-      - name: Prepare embedded assets
-        run: mkdir -p cmd/maintenant/web/dist && touch cmd/maintenant/web/dist/.gitkeep
 
       # govulncheck is call-graph aware: it only reports advisories on code the
       # binary actually reaches, so a finding here is genuinely exploitable.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -94,12 +94,6 @@ jobs:
         with:
           persist-credentials: false
 
-      # cmd/maintenant/web/web.go embeds `all:dist`: without that directory the
-      # Go autobuild fails.
-      - name: Prepare embedded assets
-        if: matrix.language == 'go'
-        run: mkdir -p cmd/maintenant/web/dist && touch cmd/maintenant/web/dist/.gitkeep
-
       - name: Initialize CodeQL
         uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ tmp/
 # Node.js / Frontend
 node_modules/
 dist/
+# dist/ above ignores this directory too; git won't descend into it to reinclude .gitkeep, so un-ignore the directory first.
+!cmd/maintenant/web/dist/
+cmd/maintenant/web/dist/*
 !cmd/maintenant/web/dist/.gitkeep
 frontend/dist/
 *.log

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-cover lint build proto-gen test-pg \
+.PHONY: test test-cover lint build check frontend proto-gen test-pg \
 	e2e-sqlite e2e-postgres e2e-both e2e-up-sqlite e2e-up-postgres e2e-logs e2e-down e2e-migrate
 
 test:
@@ -10,8 +10,26 @@ test-cover:
 lint:
 	golangci-lint run
 
-build:
+# Rebuilds the embedded SPA before every binary build: cmd/maintenant/web/web.go
+# embeds all:dist, and go build silently reuses whatever is already there
+# otherwise.
+build: frontend
 	go build -o ./bin/maintenant ./cmd/maintenant
+
+# Builds the SPA and drops it where cmd/maintenant/web/web.go embeds it from.
+# Clears the target's contents first (leaving .gitkeep, which frontend/dist
+# never produces) so a second run doesn't accumulate stale hashed assets.
+frontend:
+	cd frontend && npm ci --ignore-scripts && npm run type-check && npm run build-only
+	rm -rf cmd/maintenant/web/dist/*
+	cp -r frontend/dist/. cmd/maintenant/web/dist/
+
+# Mirrors what CI gates on, for the same result before it costs a push.
+check:
+	go vet ./...
+	golangci-lint run ./...
+	go test -race ./...
+	cd frontend && npm ci --ignore-scripts && npm run type-check
 
 proto-gen:
 	mkdir -p internal/agentpb

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ services:
   maintenant:
     image: ghcr.io/kolapsis/maintenant:latest
     ports:
+      # ⚠️  SECURITY: publishes the UI/API (no authentication of their own) on
+      # every interface; put an auth reverse proxy in front, or bind "127.0.0.1:8080:8080". See https://docs.maintenant.dev/security/#reverse-proxy-setup.
       - "8080:8080"
     read_only: true
     security_opt:
@@ -299,6 +301,8 @@ services:
   maintenant:
     image: ghcr.io/kolapsis/maintenant:latest
     ports:
+      # ⚠️  SECURITY: publishes the UI/API (no authentication of their own) on
+      # every interface; put an auth reverse proxy in front, or bind "127.0.0.1:8080:8080". See https://docs.maintenant.dev/security/#reverse-proxy-setup.
       - "8080:8080"
     read_only: true
     security_opt:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -77,8 +77,8 @@ The threat model of a monitoring agent is dominated by what you grant it. Two
 points matter more than the rest:
 
 - **Do not mount `/var/run/docker.sock` directly.** Use a read-only
-  docker-socket-proxy; see `docs/` for the recommended configuration. A mounted
-  socket is equivalent to root on the host.
+  docker-socket-proxy; see [Recommended: Docker Socket Proxy](https://docs.maintenant.dev/security/#recommended-docker-socket-proxy)
+  for the configuration. A mounted socket is equivalent to root on the host.
 - **Do not bind the listener to `0.0.0.0`** on a machine reachable from an
-  untrusted network. Bind to a private interface and put a TLS terminator in
-  front.
+  untrusted network. Bind to a private interface, or put an authenticating
+  reverse proxy in front; see [Reverse Proxy Setup](https://docs.maintenant.dev/security/#reverse-proxy-setup).

--- a/compose.yml
+++ b/compose.yml
@@ -10,13 +10,14 @@ services:
       # ⚠️  SECURITY: this publishes the UI/API on ALL interfaces (0.0.0.0) and the
       # app has NO authentication of its own. Fine on a trusted/private network to
       # get started; before exposing it to an untrusted network put an auth reverse
-      # proxy in front (see SECURITY.md and compose.prod.yml), or restrict the bind
-      # to "127.0.0.1:8080:8080".
+      # proxy in front (see https://docs.maintenant.dev/security/#reverse-proxy-setup),
+      # or restrict the bind to "127.0.0.1:8080:8080".
       - "8080:8080"
     volumes:
       # WARNING: mounting the Docker socket grants root-equivalent access to the
       # host. `:ro` does NOT restrict the Docker API. For any exposed deployment
-      # use a read-only docker-socket-proxy instead (see compose.prod.yml).
+      # use a read-only docker-socket-proxy instead
+      # (see https://docs.maintenant.dev/security/#recommended-docker-socket-proxy).
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - /proc:/host/proc:ro
       - maintenant-data:/data

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -151,7 +151,7 @@ For detailed Kubernetes configuration and all Helm values, see the [Kubernetes G
 
 | Tool | Minimum Version |
 |------|----------------|
-| Go | >= 1.25 |
+| Go | >= 1.26.6 |
 | Node.js | >= 20 |
 | CGO | Enabled |
 | Docker | For testing |
@@ -165,12 +165,13 @@ cd maintenant
 
 # Build the frontend
 cd frontend
-npm install
+npm ci
 npm run build-only
 cd ..
 
 # Copy frontend assets into the embed directory
-cp -r frontend/dist cmd/maintenant/web/dist/
+rm -rf cmd/maintenant/web/dist/*
+cp -r frontend/dist/. cmd/maintenant/web/dist/
 
 # Build the Go binary
 CGO_ENABLED=1 go build -o maintenant ./cmd/maintenant

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2384,15 +2384,15 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.1.tgz",
-      "integrity": "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==",
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@eslint/object-schema": "^2.1.7",
         "debug": "^4.3.1",
-        "minimatch": "^3.1.2"
+        "minimatch": "^3.1.5"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2425,20 +2425,20 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.3.tgz",
-      "integrity": "sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ==",
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.7.tgz",
+      "integrity": "sha512-F42g89Qd5oAWtp0k0nnSrjziAKza7w8SVT4mStc18LZMaRb4J1HQAHLCalEtDCxrTuksx7NU9qsmeLwpOfPqWw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ajv": "^6.12.4",
+        "ajv": "^6.14.0",
         "debug": "^4.3.2",
         "espree": "^10.0.1",
         "globals": "^14.0.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.1",
-        "minimatch": "^3.1.2",
+        "js-yaml": "^4.3.2",
+        "minimatch": "^3.1.5",
         "strip-json-comments": "^3.1.1"
       },
       "engines": {
@@ -2449,9 +2449,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.39.3",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.3.tgz",
-      "integrity": "sha512-1B1VkCq6FuUNlQvlBYb+1jDu/gV297TIs/OeiaSR9l1H27SVW55ONE1e1Vp16NqP683+xEGzxYtv4XCiDPaQiw==",
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2504,25 +2504,39 @@
       }
     },
     "node_modules/@humanfs/core": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
       "engines": {
         "node": ">=18.18.0"
       }
     },
     "node_modules/@humanfs/node": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
-      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@humanfs/core": "^0.19.1",
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
         "@humanwhocodes/retry": "^0.4.0"
       },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
       }
@@ -4833,9 +4847,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6038,25 +6052,26 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.39.3",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.3.tgz",
-      "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.5.tgz",
+      "integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
+      "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.21.1",
+        "@eslint/config-array": "^0.21.2",
         "@eslint/config-helpers": "^0.4.2",
         "@eslint/core": "^0.17.0",
-        "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.39.3",
+        "@eslint/eslintrc": "^3.3.6",
+        "@eslint/js": "9.39.5",
         "@eslint/plugin-kit": "^0.4.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
-        "ajv": "^6.12.4",
+        "ajv": "^6.14.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
@@ -6075,7 +6090,7 @@
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "lodash.merge": "^4.6.2",
-        "minimatch": "^3.1.2",
+        "minimatch": "^3.1.5",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -7569,9 +7584,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
       "funding": [
         {

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -36,7 +36,10 @@ const EscalationPage = () => import('../pages/EscalationPage.vue')
 const ChannelsPage = () => import('../pages/ChannelsPage.vue')
 const AgentsPage = () => import('../pages/AgentsPage.vue')
 
-const isStatusSubdomain = (window as unknown as { __MAINTENANT_STATUS?: boolean }).__MAINTENANT_STATUS === true
+const isStatusSubdomain =
+  document.querySelector('meta[name="maintenant-status"]')?.getAttribute('content') === 'true' ||
+  // Fallback for an index.html cached by the service worker before the meta tag shipped.
+  (window as unknown as { __MAINTENANT_STATUS?: boolean }).__MAINTENANT_STATUS === true
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),

--- a/internal/agentserver/server.go
+++ b/internal/agentserver/server.go
@@ -61,8 +61,10 @@ func New(deps Deps) *Server {
 	}
 }
 
-// Start binds to listen, registers the Ingest service, and begins serving.
-// It blocks until the context is cancelled or an error occurs.
+// Start binds to listen and registers the Ingest service, then serves in the
+// background. It returns as soon as the bind succeeds or fails, so call it
+// synchronously and check the error; the server then runs and stops on its
+// own as ctx allows.
 // If tlsCfg is nil the server listens in h2c (plaintext) — only safe behind a
 // trusted reverse proxy (MAINTENANT_GRPC_TLS_INSECURE=true).
 func (s *Server) Start(ctx context.Context, listen string, tlsCfg *tls.Config) error {
@@ -91,13 +93,18 @@ func (s *Server) Start(ctx context.Context, listen string, tlsCfg *tls.Config) e
 		errCh <- s.grpc.Serve(lis)
 	}()
 
-	select {
-	case <-ctx.Done():
-		s.grpc.GracefulStop()
-		return nil
-	case err := <-errCh:
-		return fmt.Errorf("agentserver: serve: %w", err)
-	}
+	go func() {
+		select {
+		case <-ctx.Done():
+			s.grpc.GracefulStop()
+		case err := <-errCh:
+			if err != nil {
+				s.deps.Logger.Error("agentserver: serve", "err", err)
+			}
+		}
+	}()
+
+	return nil
 }
 
 // Stop performs a graceful shutdown of the gRPC server.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -751,6 +751,12 @@ func (a *App) Start(ctx context.Context) error {
 		return err
 	}
 
+	// Derived so an early return (e.g. a failed bind below) cancels every
+	// background goroutine started with ctx, instead of leaking them until
+	// the caller's own context is cancelled.
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	a.db.StartWriter(ctx)
 
 	// Registered after the writer starts: on SQLite every write goes through it.
@@ -892,9 +898,13 @@ func (a *App) Start(ctx context.Context) error {
 	if a.cfg.Mode == "agent" {
 		a.logger.Warn("agent mode: HTTP server disabled")
 	} else {
+		ln, err := net.Listen("tcp", a.srv.Addr)
+		if err != nil {
+			return fmt.Errorf("listen on %s: %w", a.srv.Addr, err)
+		}
+		a.logger.Info("starting HTTP server", "addr", a.cfg.Addr)
 		go func() {
-			a.logger.Info("starting HTTP server", "addr", a.cfg.Addr)
-			if err := a.srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			if err := a.srv.Serve(ln); err != nil && !errors.Is(err, http.ErrServerClosed) {
 				a.logger.Error("HTTP server error", "error", err)
 			}
 		}()
@@ -1046,12 +1056,10 @@ func (a *App) startAgentGRPC(ctx context.Context) error {
 	}
 
 	a.agentSrv.StartTokenGC(ctx)
-	go func() {
-		if err := a.agentSrv.Start(ctx, listen, tlsCfg); err != nil && !errors.Is(err, context.Canceled) {
-			a.logger.Error("agentserver: stopped", "err", err)
-		}
-	}()
-	a.logger.Info("agent gRPC server scheduled", "listen", listen)
+	if err := a.agentSrv.Start(ctx, listen, tlsCfg); err != nil {
+		return err
+	}
+	a.logger.Info("agent gRPC server listening", "listen", listen)
 	return nil
 }
 

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -89,3 +89,23 @@ func TestStart_DegradedMode(t *testing.T) {
 		t.Fatal("Start() did not return after context cancellation")
 	}
 }
+
+// TestStart_FailsOnBusyPort: Start() must fail fast, not silently run without
+// an HTTP surface, when its configured address is already bound.
+func TestStart_FailsOnBusyPort(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer func() { _ = ln.Close() }()
+
+	cfg, logger := degradedEnv(t, t.TempDir())
+	cfg.Addr = ln.Addr().String()
+
+	a, err := app.New(cfg, logger)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	err = a.Start(ctx)
+	assert.Error(t, err, "Start() must return an error when its address is already in use")
+}

--- a/internal/app/http_test.go
+++ b/internal/app/http_test.go
@@ -191,7 +191,7 @@ func TestStatusPageHTML_NoUnhashedInlineScript(t *testing.T) {
 
 	policy := contentSecurityPolicy(index)
 
-	h := status.NewHandler(nil, nil, nil)
+	h := status.NewHandler(nil, nil, nil, nil)
 	h.SetIndexHTML(index)
 
 	rec := httptest.NewRecorder()

--- a/internal/app/http_test.go
+++ b/internal/app/http_test.go
@@ -18,6 +18,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/kolapsis/maintenant/internal/status"
 )
 
 // The digest a browser computes for the body of `<script>alert(1)</script>`,
@@ -172,4 +174,36 @@ func TestSecurityHeaders_HandlerCanTightenPolicy(t *testing.T) {
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/status/assets/logo", nil))
 
 	assert.Equal(t, strict, rec.Header().Get("Content-Security-Policy"))
+}
+
+// The status page injects a marker into the embedded index.html so the SPA
+// router can detect the status subdomain. That marker must never be an inline
+// script: contentSecurityPolicy only hashes what ships in the embedded
+// frontend, so anything injected afterward is unhashed and a browser blocks it.
+func TestStatusPageHTML_NoUnhashedInlineScript(t *testing.T) {
+	index := []byte(`<!DOCTYPE html><html><head></head><body>
+	<script>
+	  (function() { document.documentElement.setAttribute('data-theme', 'dark'); })();
+	</script>
+	<div id="app"></div>
+	<script type="module" src="/assets/index.js"></script>
+	</body></html>`)
+
+	policy := contentSecurityPolicy(index)
+
+	h := status.NewHandler(nil, nil, nil)
+	h.SetIndexHTML(index)
+
+	rec := httptest.NewRecorder()
+	SecurityHeaders(policy)(http.HandlerFunc(h.HandleStatusPage)).
+		ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/status/", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	served := rec.Body.Bytes()
+	sentCSP := rec.Header().Get("Content-Security-Policy")
+
+	for _, h := range inlineScriptHashes(served) {
+		assert.Contains(t, sentCSP, h,
+			"served HTML has an inline script whose digest is not in the CSP the server sends")
+	}
 }

--- a/internal/status/handler.go
+++ b/internal/status/handler.go
@@ -80,11 +80,13 @@ func (h *Handler) Register(mux *http.ServeMux, mw Middleware) {
 	}
 }
 
-const urlFixScript = `<script>window.__MAINTENANT_STATUS=true</script>`
+const statusMetaTag = `<meta name="maintenant-status" content="true">`
 
 // HandleStatusPage serves the Vue SPA index.html for the /status/ path.
-// A small inline script is injected so that Vue Router initialises at /status when
-// the page is accessed from the dedicated status subdomain (browser path is "/").
+// A meta tag is injected so that Vue Router initialises at /status when the
+// page is accessed from the dedicated status subdomain (browser path is "/").
+// It must not be an inline <script>: the CSP hashes only the scripts already
+// present in the embedded index.html, so an injected script gets blocked.
 func (h *Handler) HandleStatusPage(w http.ResponseWriter, r *http.Request) {
 	if r.URL.Path != "/status/" && r.URL.Path != "/status" {
 		http.NotFound(w, r)
@@ -94,7 +96,7 @@ func (h *Handler) HandleStatusPage(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Status page not available", http.StatusServiceUnavailable)
 		return
 	}
-	html := bytes.Replace(h.indexHTML, []byte("</head>"), []byte(urlFixScript+"</head>"), 1)
+	html := bytes.Replace(h.indexHTML, []byte("</head>"), []byte(statusMetaTag+"</head>"), 1)
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
 	_, _ = w.Write(html)


### PR DESCRIPTION
Three defects an operator meets on the first day.

**The status page could not bootstrap under its own CSP.** It injected a
`<script>` into the HTML it served to tell the frontend it was on a status
subdomain, but the policy is computed at startup from the embedded
`index.html`, so that script's digest was never in it and a conforming browser
dropped it — the subdomain root then fell through to the dashboard routing. The
flag travels as a `<meta>` tag now, which needs no digest; the old `window`
property is still read so an `index.html` held by a service worker keeps
working.

**A busy port did not fail startup.** `ListenAndServe` ran inside a goroutine
and only logged anything other than a clean shutdown, so the process stayed up
with no HTTP surface and exited zero. The listener is opened before the
goroutine and its error fails `Start`. The agent gRPC server had the same shape
and gets the same treatment, and `Start` now cancels its own context on every
early return rather than leaving background goroutines behind.

**A fresh clone did not build.** The binary embeds `cmd/maintenant/web/dist` and
that directory was untracked: the `dist/` pattern kept git from ever descending
far enough to honour the `.gitkeep` negation. CI papered over it by creating the
file in five jobs. The ignore rules are fixed, the placeholder is tracked, those
five steps are gone, and `make build` now builds the frontend it embeds instead
of assuming someone did it first. A `make check` target runs what CI runs.

Documentation follows: the install guide states the Go version `go.mod` actually
requires and copies the assets idempotently, and the quick start says what
publishing 8080 exposes, pointing at `docs/security.md` rather than at a
`compose.prod.yml` the public repository does not contain.

Also bumps the dev-only `@humanfs/node` past GHSA-p498-v437-472g.

Found by an external security audit of `2c6654c` (findings Q-04, Q-07, S-07,
the build section, and the documentation half of S-03).
