### PR TITLE
test(alert): wait for the condition instead of sleeping past it

### DIFF
--- a/internal/agent/collector_k8s_test.go
+++ b/internal/agent/collector_k8s_test.go
@@ -84,9 +84,8 @@ func TestCollectKubernetesRuntime_EmitsTopologyAndHostSamples(t *testing.T) {
 		done <- collectKubernetesRuntime(ctx, id, &fakeSnapshotSource{}, stream, slog.Default())
 	}()
 
-	deadline := time.Now().Add(3 * time.Second)
 	var sawTopology, sawHostSample bool
-	for time.Now().Before(deadline) && (!sawTopology || !sawHostSample) {
+	require.Eventually(t, func() bool {
 		for _, ev := range fake.events() {
 			if ev.GetKubernetes() != nil {
 				sawTopology = true
@@ -95,8 +94,8 @@ func TestCollectKubernetesRuntime_EmitsTopologyAndHostSamples(t *testing.T) {
 				sawHostSample = true
 			}
 		}
-		time.Sleep(5 * time.Millisecond)
-	}
+		return sawTopology && sawHostSample
+	}, 3*time.Second, 5*time.Millisecond, "kubernetes agent must push both a topology event and a host-level resource sample")
 	cancel()
 	<-done
 

--- a/internal/agent/commands_test.go
+++ b/internal/agent/commands_test.go
@@ -111,14 +111,7 @@ func logsCmd(requestID string, follow bool) *agentpb.AgentCommand {
 // waitFor polls until cond holds or the deadline passes.
 func waitFor(t *testing.T, cond func() bool, msg string) {
 	t.Helper()
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		if cond() {
-			return
-		}
-		time.Sleep(5 * time.Millisecond)
-	}
-	t.Fatal(msg)
+	require.Eventually(t, cond, 2*time.Second, 5*time.Millisecond, msg)
 }
 
 func TestCommandRunner_SnapshotReturnsLinesAndTerminates(t *testing.T) {
@@ -266,8 +259,11 @@ func TestCommandRunner_EmptyRequestIDIgnored(t *testing.T) {
 
 	r.Handle(context.Background(), out, logsCmd("", false))
 
-	time.Sleep(100 * time.Millisecond)
-	assert.Empty(t, out.snapshot(), "a command with no request id cannot be answered")
+	// Negative check: a command with no request id must never be answered,
+	// held over a window rather than sampled once.
+	assert.Never(t, func() bool {
+		return len(out.snapshot()) > 0
+	}, 300*time.Millisecond, 10*time.Millisecond, "a command with no request id cannot be answered")
 }
 
 func TestClampLogLines(t *testing.T) {

--- a/internal/alert/engine_collision_test.go
+++ b/internal/alert/engine_collision_test.go
@@ -80,7 +80,11 @@ func TestEngine_DedupKeyCollision_LogsAndRefreshes(t *testing.T) {
 			Message:    "Update available for " + name,
 			Timestamp:  time.Now(),
 		}
-		time.Sleep(150 * time.Millisecond)
+		wantMessage := "Update available for " + name
+		require.Eventually(t, func() bool {
+			active, err := alertStore.ListActiveAlerts(ctx)
+			return err == nil && len(active) == 1 && active[0].Message == wantMessage && active[0].Severity == severity
+		}, 5*time.Second, 10*time.Millisecond, "the alert engine must have processed the event for "+name)
 	}
 
 	send("bitwarden-postgres", alert.SeverityWarning) // creates the alert

--- a/internal/alert/engine_maintenance_test.go
+++ b/internal/alert/engine_maintenance_test.go
@@ -91,7 +91,22 @@ func TestEngineSuppressesAlertDuringMaintenanceWindow(t *testing.T) {
 		Source: "container", AlertType: "restart", Severity: "warning",
 		EntityType: "container", EntityID: "42", EntityName: "c42", Timestamp: now,
 	}
-	time.Sleep(100 * time.Millisecond)
+
+	// At least one silenced alert must be persisted for container:42 (audit trail)
+	var silenced []*alert.Alert
+	require.Eventually(t, func() bool {
+		var err error
+		silenced, err = alertStore.ListAlerts(ctx, alert.ListAlertsOpts{Status: "silenced", Limit: 20})
+		if err != nil {
+			return false
+		}
+		for _, a := range silenced {
+			if a.EntityType == "container" && a.EntityID == "42" {
+				return true
+			}
+		}
+		return false
+	}, 5*time.Second, 10*time.Millisecond, "silenced audit record must exist for container:42")
 
 	// container:42 must NOT appear in active alerts
 	activeAlerts, err := alertStore.ListActiveAlerts(ctx)
@@ -102,9 +117,6 @@ func TestEngineSuppressesAlertDuringMaintenanceWindow(t *testing.T) {
 		}
 	}
 
-	// At least one silenced alert must be persisted for container:42 (audit trail)
-	silenced, err := alertStore.ListAlerts(ctx, alert.ListAlertsOpts{Status: "silenced", Limit: 20})
-	require.NoError(t, err)
 	found := false
 	for _, a := range silenced {
 		if a.EntityType == "container" && a.EntityID == "42" {
@@ -119,10 +131,20 @@ func TestEngineSuppressesAlertDuringMaintenanceWindow(t *testing.T) {
 		Source: "container", AlertType: "restart", Severity: "warning",
 		EntityType: "container", EntityID: "99", EntityName: "c99", Timestamp: now,
 	}
-	time.Sleep(100 * time.Millisecond)
 
-	activeAlerts, err = alertStore.ListActiveAlerts(ctx)
-	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		activeAlerts, err = alertStore.ListActiveAlerts(ctx)
+		if err != nil {
+			return false
+		}
+		for _, a := range activeAlerts {
+			if a.EntityType == "container" && a.EntityID == "99" {
+				return true
+			}
+		}
+		return false
+	}, 5*time.Second, 10*time.Millisecond, "container:99 must have an active alert")
+
 	found99 := false
 	for _, a := range activeAlerts {
 		if a.EntityType == "container" && a.EntityID == "99" {

--- a/internal/alert/engine_triggers_test.go
+++ b/internal/alert/engine_triggers_test.go
@@ -100,20 +100,35 @@ func seedTriggerForChannel(t *testing.T, ts alert.TriggerStore, name string, ena
 	return id
 }
 
-func countDeliveriesForChannel(t *testing.T, cs alert.ChannelStore, alertID, channelID string) int {
-	t.Helper()
+// deliveryCountForChannel is the error-returning core used by predicates
+// polled inside Eventually/Never: those run on a goroutine of testify's own,
+// and require/assert failures must only ever be raised from the test's own
+// goroutine.
+func deliveryCountForChannel(cs alert.ChannelStore, alertID, channelID string) (int, error) {
 	deliveries, err := cs.ListDeliveriesByAlert(context.Background(), alertID)
-	require.NoError(t, err)
+	if err != nil {
+		return 0, err
+	}
 	count := 0
 	for _, d := range deliveries {
 		if d.ChannelID == channelID {
 			count++
 		}
 	}
+	return count, nil
+}
+
+func countDeliveriesForChannel(t *testing.T, cs alert.ChannelStore, alertID, channelID string) int {
+	t.Helper()
+	count, err := deliveryCountForChannel(cs, alertID, channelID)
+	require.NoError(t, err)
 	return count
 }
 
-func fireEvent(eng *alert.Engine, severity, source, entityType string, entityID string) {
+// fireEvent sends a non-recovery event and waits until the engine has
+// persisted the resulting active alert, so callers can safely read it back.
+func fireEvent(t *testing.T, ctx context.Context, alertStore alert.AlertStore, eng *alert.Engine, severity, source, entityType string, entityID string) {
+	t.Helper()
 	eng.EventChannel() <- alert.Event{
 		Source:     source,
 		AlertType:  "test",
@@ -123,7 +138,10 @@ func fireEvent(eng *alert.Engine, severity, source, entityType string, entityID 
 		EntityName: "test-entity",
 		Timestamp:  time.Now(),
 	}
-	time.Sleep(150 * time.Millisecond)
+	require.Eventually(t, func() bool {
+		alerts, err := alertStore.ListActiveAlerts(ctx)
+		return err == nil && len(alerts) == 1
+	}, 5*time.Second, 10*time.Millisecond, "the alert engine must have created the active alert")
 }
 
 // capturingWebhookServer records every JSON payload POSTed to it.
@@ -175,12 +193,21 @@ func TestEngineRecovery_NotificationReadsAsRecovery(t *testing.T) {
 		Message:    "Heartbeat 'backup' missed deadline",
 		Timestamp:  time.Now(),
 	}
-	time.Sleep(150 * time.Millisecond)
 
-	alerts, err := alertStore.ListActiveAlerts(ctx)
-	require.NoError(t, err)
-	require.Len(t, alerts, 1)
-	originalID := alerts[0].ID
+	var originalID string
+	require.Eventually(t, func() bool {
+		alerts, err := alertStore.ListActiveAlerts(ctx)
+		if err != nil || len(alerts) != 1 {
+			return false
+		}
+		originalID = alerts[0].ID
+		return true
+	}, 5*time.Second, 10*time.Millisecond, "the alert engine must have created the active alert")
+
+	require.Eventually(t, func() bool {
+		n, err := deliveryCountForChannel(channelStore, originalID, chID)
+		return err == nil && n == 1
+	}, 5*time.Second, 10*time.Millisecond, "initial critical alert must be delivered")
 	assert.Equal(t, 1, countDeliveriesForChannel(t, channelStore, originalID, chID), "initial critical alert must be delivered")
 
 	eng.EventChannel() <- alert.Event{
@@ -194,7 +221,12 @@ func TestEngineRecovery_NotificationReadsAsRecovery(t *testing.T) {
 		Message:    "Heartbeat 'backup' recovered",
 		Timestamp:  time.Now(),
 	}
-	time.Sleep(150 * time.Millisecond)
+
+	// The subsequent assertions read the captured webhook payload directly, so
+	// that (not the DB delivery count, which lands earlier) is the outcome to wait on.
+	require.Eventually(t, func() bool {
+		return len(capturedBodies()) == 2
+	}, 5*time.Second, 10*time.Millisecond, "webhook must have received both the failure and the recovery")
 
 	active, err := alertStore.ListActiveAlerts(ctx)
 	require.NoError(t, err)
@@ -222,7 +254,11 @@ func TestEngineRecovery_NotificationReadsAsRecovery(t *testing.T) {
 	assert.NotEmpty(t, recoveryPayload["resolved_at"])
 }
 
-func recoverEvent(eng *alert.Engine, severity, source, entityType string, entityID string) {
+// recoverEvent sends a recovery event and waits until the engine has removed
+// the entity from the active-alert set, so callers can safely assert on
+// whatever the recovery is expected to have triggered (or not).
+func recoverEvent(t *testing.T, ctx context.Context, alertStore alert.AlertStore, eng *alert.Engine, severity, source, entityType string, entityID string) {
+	t.Helper()
 	eng.EventChannel() <- alert.Event{
 		Source:     source,
 		AlertType:  "test",
@@ -233,7 +269,18 @@ func recoverEvent(eng *alert.Engine, severity, source, entityType string, entity
 		EntityName: "test-entity",
 		Timestamp:  time.Now(),
 	}
-	time.Sleep(150 * time.Millisecond)
+	require.Eventually(t, func() bool {
+		alerts, err := alertStore.ListActiveAlerts(ctx)
+		if err != nil {
+			return false
+		}
+		for _, a := range alerts {
+			if a.EntityType == entityType && a.EntityID == entityID {
+				return false
+			}
+		}
+		return true
+	}, 5*time.Second, 10*time.Millisecond, "the alert engine must have resolved the alert")
 }
 
 func seedTriggerNotifyOnResolve(t *testing.T, ts alert.TriggerStore, name string, notifyOnResolve bool, severities, sources string, channelIDs []string) string {
@@ -261,13 +308,18 @@ func TestEngineDispatch_TriggerMatch_DeliveriesCreated(t *testing.T) {
 	ch2 := seedWebhookChannel(t, channelStore, "slack-2", true)
 	seedTriggerForChannel(t, triggerStore, "CritAll", true, "critical", "container", []string{ch1, ch2})
 
-	fireEvent(eng, "critical", "container", "container", "10")
+	fireEvent(t, ctx, alertStore, eng, "critical", "container", "container", "10")
 
 	alerts, err := alertStore.ListActiveAlerts(ctx)
 	require.NoError(t, err)
 	require.Len(t, alerts, 1)
-
 	alertID := alerts[0].ID
+
+	require.Eventually(t, func() bool {
+		n1, err1 := deliveryCountForChannel(channelStore, alertID, ch1)
+		n2, err2 := deliveryCountForChannel(channelStore, alertID, ch2)
+		return err1 == nil && err2 == nil && n1 == 1 && n2 == 1
+	}, 5*time.Second, 10*time.Millisecond, "both channels must receive a delivery")
 	assert.Equal(t, 1, countDeliveriesForChannel(t, channelStore, alertID, ch1), "ch1 should have 1 delivery")
 	assert.Equal(t, 1, countDeliveriesForChannel(t, channelStore, alertID, ch2), "ch2 should have 1 delivery")
 }
@@ -281,13 +333,19 @@ func TestEngineDispatch_DisabledChannel_NoDelivery(t *testing.T) {
 	chID := seedWebhookChannel(t, channelStore, "disabled-ch", false)
 	seedTriggerForChannel(t, triggerStore, "TrigDisCh", true, "critical", "endpoint", []string{chID})
 
-	fireEvent(eng, "critical", "endpoint", "endpoint", "20")
+	fireEvent(t, ctx, alertStore, eng, "critical", "endpoint", "endpoint", "20")
 
 	alerts, err := alertStore.ListActiveAlerts(ctx)
 	require.NoError(t, err)
 	require.Len(t, alerts, 1)
+	alertID := alerts[0].ID
 
-	assert.Equal(t, 0, countDeliveriesForChannel(t, channelStore, alerts[0].ID, chID), "disabled channel must not receive delivery")
+	// Negative check: a disabled channel must never receive a delivery, held
+	// over a window rather than sampled once.
+	assert.Never(t, func() bool {
+		n, err := deliveryCountForChannel(channelStore, alertID, chID)
+		return err == nil && n != 0
+	}, 300*time.Millisecond, 10*time.Millisecond, "disabled channel must not receive delivery")
 }
 
 // T077 — E2E test 3: disabled trigger → no delivery.
@@ -299,13 +357,18 @@ func TestEngineDispatch_DisabledTrigger_NoDelivery(t *testing.T) {
 	chID := seedWebhookChannel(t, channelStore, "ch-dis-trig", true)
 	seedTriggerForChannel(t, triggerStore, "DisabledTrigger", false, "", "", []string{chID})
 
-	fireEvent(eng, "warning", "container", "container", "30")
+	fireEvent(t, ctx, alertStore, eng, "warning", "container", "container", "30")
 
 	alerts, err := alertStore.ListActiveAlerts(ctx)
 	require.NoError(t, err)
 	require.Len(t, alerts, 1)
+	alertID := alerts[0].ID
 
-	assert.Equal(t, 0, countDeliveriesForChannel(t, channelStore, alerts[0].ID, chID), "disabled trigger must not produce delivery")
+	// Negative check: a disabled trigger must never produce a delivery.
+	assert.Never(t, func() bool {
+		n, err := deliveryCountForChannel(channelStore, alertID, chID)
+		return err == nil && n != 0
+	}, 300*time.Millisecond, 10*time.Millisecond, "disabled trigger must not produce delivery")
 }
 
 // T077 — E2E test 4: two triggers pointing same channel → single delivery (dedup).
@@ -318,13 +381,18 @@ func TestEngineDispatch_TwoTriggersOneChannel_Dedup(t *testing.T) {
 	seedTriggerForChannel(t, triggerStore, "Trigger-A", true, "critical", "", []string{chID})
 	seedTriggerForChannel(t, triggerStore, "Trigger-B", true, "critical", "", []string{chID})
 
-	fireEvent(eng, "critical", "heartbeat", "heartbeat", "40")
+	fireEvent(t, ctx, alertStore, eng, "critical", "heartbeat", "heartbeat", "40")
 
 	alerts, err := alertStore.ListActiveAlerts(ctx)
 	require.NoError(t, err)
 	require.Len(t, alerts, 1)
+	alertID := alerts[0].ID
 
-	assert.Equal(t, 1, countDeliveriesForChannel(t, channelStore, alerts[0].ID, chID), "channel must receive exactly 1 delivery even with two matching triggers")
+	require.Eventually(t, func() bool {
+		n, err := deliveryCountForChannel(channelStore, alertID, chID)
+		return err == nil && n == 1
+	}, 5*time.Second, 10*time.Millisecond, "channel must receive exactly 1 delivery even with two matching triggers")
+	assert.Equal(t, 1, countDeliveriesForChannel(t, channelStore, alertID, chID), "channel must receive exactly 1 delivery even with two matching triggers")
 }
 
 // T077 — E2E test 5: alert doesn't match any trigger → no delivery.
@@ -337,13 +405,17 @@ func TestEngineDispatch_NoMatchingTrigger_NoDelivery(t *testing.T) {
 	// Trigger only fires on "critical"; we fire "warning" → no match.
 	seedTriggerForChannel(t, triggerStore, "CritOnly", true, "critical", "", []string{chID})
 
-	fireEvent(eng, "warning", "container", "container", "50")
+	fireEvent(t, ctx, alertStore, eng, "warning", "container", "container", "50")
 
 	alerts, err := alertStore.ListActiveAlerts(ctx)
 	require.NoError(t, err)
 	require.Len(t, alerts, 1)
+	alertID := alerts[0].ID
 
-	assert.Equal(t, 0, countDeliveriesForChannel(t, channelStore, alerts[0].ID, chID), "no delivery expected when alert doesn't match trigger filter")
+	assert.Never(t, func() bool {
+		n, err := deliveryCountForChannel(channelStore, alertID, chID)
+		return err == nil && n != 0
+	}, 300*time.Millisecond, 10*time.Millisecond, "no delivery expected when alert doesn't match trigger filter")
 }
 
 // T077 — E2E test 6: source filter narrows correctly.
@@ -359,14 +431,25 @@ func TestEngineDispatch_SourceFilter_OnlyMatchesCorrectSource(t *testing.T) {
 	seedTriggerForChannel(t, triggerStore, "EndpointOnly", true, "", "endpoint", []string{chEndpoint})
 
 	// Fire a container alert.
-	fireEvent(eng, "critical", "container", "container", "60")
+	fireEvent(t, ctx, alertStore, eng, "critical", "container", "container", "60")
 
 	alerts, err := alertStore.ListActiveAlerts(ctx)
 	require.NoError(t, err)
 	require.Len(t, alerts, 1)
+	alertID := alerts[0].ID
 
-	assert.Equal(t, 1, countDeliveriesForChannel(t, channelStore, alerts[0].ID, chContainer), "container trigger must deliver to container channel")
-	assert.Equal(t, 0, countDeliveriesForChannel(t, channelStore, alerts[0].ID, chEndpoint), "endpoint trigger must not fire for container alert")
+	require.Eventually(t, func() bool {
+		n, err := deliveryCountForChannel(channelStore, alertID, chContainer)
+		return err == nil && n == 1
+	}, 5*time.Second, 10*time.Millisecond, "container trigger must deliver to container channel")
+	assert.Equal(t, 1, countDeliveriesForChannel(t, channelStore, alertID, chContainer), "container trigger must deliver to container channel")
+
+	// Negative check: the endpoint-only trigger's source filter must never
+	// match a container alert.
+	assert.Never(t, func() bool {
+		n, err := deliveryCountForChannel(channelStore, alertID, chEndpoint)
+		return err == nil && n != 0
+	}, 300*time.Millisecond, 10*time.Millisecond, "endpoint trigger must not fire for container alert")
 }
 
 // T079 — Reserved-escalation channel: channel with no trigger → 0 initial deliveries.
@@ -383,14 +466,25 @@ func TestEngineDispatch_ReservedEscalationChannel_NoInitialDelivery(t *testing.T
 	slackOps := seedWebhookChannel(t, channelStore, "slack-ops", true)
 	seedTriggerForChannel(t, triggerStore, "AllAlerts", true, "", "", []string{slackOps})
 
-	fireEvent(eng, "critical", "container", "container", "70")
+	fireEvent(t, ctx, alertStore, eng, "critical", "container", "container", "70")
 
 	alerts, err := alertStore.ListActiveAlerts(ctx)
 	require.NoError(t, err)
 	require.Len(t, alerts, 1)
+	alertID := alerts[0].ID
 
-	assert.Equal(t, 1, countDeliveriesForChannel(t, channelStore, alerts[0].ID, slackOps), "slack-ops should receive initial delivery")
-	assert.Equal(t, 0, countDeliveriesForChannel(t, channelStore, alerts[0].ID, emailCTO), "email-cto must not receive initial delivery — it is reserved for escalation only")
+	require.Eventually(t, func() bool {
+		n, err := deliveryCountForChannel(channelStore, alertID, slackOps)
+		return err == nil && n == 1
+	}, 5*time.Second, 10*time.Millisecond, "slack-ops should receive initial delivery")
+	assert.Equal(t, 1, countDeliveriesForChannel(t, channelStore, alertID, slackOps), "slack-ops should receive initial delivery")
+
+	// Negative check: email-cto is reserved for escalation only, no trigger
+	// references it, so it must never receive an initial delivery.
+	assert.Never(t, func() bool {
+		n, err := deliveryCountForChannel(channelStore, alertID, emailCTO)
+		return err == nil && n != 0
+	}, 300*time.Millisecond, 10*time.Millisecond, "email-cto must not receive initial delivery — it is reserved for escalation only")
 
 	// Verify triggerStore confirms no trigger links email-cto.
 	triggersForCTO, err := triggerStore.ListTriggersForChannel(ctx, emailCTO)
@@ -407,17 +501,26 @@ func TestEngineDispatch_NotifyOnResolveFalse_NoRecoveryDelivery(t *testing.T) {
 	chID := seedWebhookChannel(t, channelStore, "fires-only-ch", true)
 	seedTriggerNotifyOnResolve(t, triggerStore, "FiresOnly", false, "critical", "container", []string{chID})
 
-	fireEvent(eng, "critical", "container", "container", "80")
+	fireEvent(t, ctx, alertStore, eng, "critical", "container", "container", "80")
 
 	alerts, err := alertStore.ListActiveAlerts(ctx)
 	require.NoError(t, err)
 	require.Len(t, alerts, 1)
 	alertID := alerts[0].ID
+
+	require.Eventually(t, func() bool {
+		n, err := deliveryCountForChannel(channelStore, alertID, chID)
+		return err == nil && n == 1
+	}, 5*time.Second, 10*time.Millisecond, "trigger must deliver the fire")
 	assert.Equal(t, 1, countDeliveriesForChannel(t, channelStore, alertID, chID), "trigger must deliver the fire")
 
-	recoverEvent(eng, "critical", "container", "container", "80")
+	recoverEvent(t, ctx, alertStore, eng, "critical", "container", "container", "80")
 
-	assert.Equal(t, 1, countDeliveriesForChannel(t, channelStore, alertID, chID), "trigger with notify_on_resolve=false must not deliver the recovery")
+	// Negative check: notify_on_resolve=false must never add a second delivery.
+	assert.Never(t, func() bool {
+		n, err := deliveryCountForChannel(channelStore, alertID, chID)
+		return err == nil && n != 1
+	}, 300*time.Millisecond, 10*time.Millisecond, "trigger with notify_on_resolve=false must not deliver the recovery")
 }
 
 // NotifyOnResolve=true (default): both fire and recovery deliver.
@@ -429,15 +532,24 @@ func TestEngineDispatch_NotifyOnResolveTrue_RecoveryDelivered(t *testing.T) {
 	chID := seedWebhookChannel(t, channelStore, "fires-and-recovers-ch", true)
 	seedTriggerNotifyOnResolve(t, triggerStore, "FiresAndRecovers", true, "critical", "container", []string{chID})
 
-	fireEvent(eng, "critical", "container", "container", "90")
+	fireEvent(t, ctx, alertStore, eng, "critical", "container", "container", "90")
 
 	alerts, err := alertStore.ListActiveAlerts(ctx)
 	require.NoError(t, err)
 	require.Len(t, alerts, 1)
 	alertID := alerts[0].ID
+
+	require.Eventually(t, func() bool {
+		n, err := deliveryCountForChannel(channelStore, alertID, chID)
+		return err == nil && n == 1
+	}, 5*time.Second, 10*time.Millisecond, "trigger must deliver the fire")
 	assert.Equal(t, 1, countDeliveriesForChannel(t, channelStore, alertID, chID), "trigger must deliver the fire")
 
-	recoverEvent(eng, "critical", "container", "container", "90")
+	recoverEvent(t, ctx, alertStore, eng, "critical", "container", "container", "90")
 
+	require.Eventually(t, func() bool {
+		n, err := deliveryCountForChannel(channelStore, alertID, chID)
+		return err == nil && n == 2
+	}, 5*time.Second, 10*time.Millisecond, "trigger with notify_on_resolve=true must also deliver the recovery")
 	assert.Equal(t, 2, countDeliveriesForChannel(t, channelStore, alertID, chID), "trigger with notify_on_resolve=true must also deliver the recovery")
 }

--- a/internal/alert/escalation/runner_test.go
+++ b/internal/alert/escalation/runner_test.go
@@ -519,14 +519,9 @@ func (h *harness) advance(d time.Duration) {
 // timeout expires (the runner dispatches via goroutines).
 func (h *harness) waitForDeliveries(t *testing.T, n int) {
 	t.Helper()
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		if int(h.sender.delivers.Load()) >= n {
-			return
-		}
-		time.Sleep(5 * time.Millisecond)
-	}
-	t.Fatalf("expected %d deliveries, got %d", n, h.sender.delivers.Load())
+	require.Eventually(t, func() bool {
+		return int(h.sender.delivers.Load()) >= n
+	}, 2*time.Second, 5*time.Millisecond, "expected %d deliveries within timeout", n)
 }
 
 // --- shared fixtures ---
@@ -774,9 +769,12 @@ func TestRunner_DeliveryDuplicateIdempotence(t *testing.T) {
 
 	h.advance(61 * time.Second)
 	require.NoError(t, h.runner.EvaluateCycle(context.Background()))
-	// No new delivery dispatched — duplicate caught silently.
-	time.Sleep(50 * time.Millisecond)
-	assert.Equal(t, int32(0), h.sender.delivers.Load())
+	// Negative check: the duplicate insert is caught synchronously before any
+	// goroutine is spawned (see dispatchToChannel), so no delivery is ever
+	// dispatched — held over a window rather than sampled once.
+	assert.Never(t, func() bool {
+		return h.sender.delivers.Load() != 0
+	}, 300*time.Millisecond, 10*time.Millisecond, "duplicate delivery must not be dispatched")
 	// Run still advances (level is considered done).
 	runs := h.store.listRuns()
 	require.Len(t, runs, 1)
@@ -803,26 +801,18 @@ func TestRunner_OneChannelFailureDoesNotBlockOthers(t *testing.T) {
 
 	deliveries := h.store.listDeliveries()
 	require.Len(t, deliveries, 2)
-	statuses := map[string]string{}
-	for _, d := range deliveries {
-		require.NotNil(t, d.ChannelID)
-		statuses[*d.ChannelID] = d.Status
-	}
+
 	// Wait for async UpdateDelivery to land.
-	deadline := time.Now().Add(time.Second)
-	for time.Now().Before(deadline) {
-		ok := true
+	require.Eventually(t, func() bool {
 		for _, d := range h.store.listDeliveries() {
 			if d.Status == DeliveryStatusPending {
-				ok = false
-				break
+				return false
 			}
 		}
-		if ok {
-			break
-		}
-		time.Sleep(5 * time.Millisecond)
-	}
+		return true
+	}, time.Second, 5*time.Millisecond, "both deliveries must leave pending status")
+
+	statuses := map[string]string{}
 	for _, d := range h.store.listDeliveries() {
 		require.NotNil(t, d.ChannelID)
 		statuses[*d.ChannelID] = d.Status
@@ -842,9 +832,12 @@ func TestRunner_DisabledChannelMarksDeliveryFailed(t *testing.T) {
 	h.advance(61 * time.Second)
 	require.NoError(t, h.runner.EvaluateCycle(context.Background()))
 
-	// No network call (channel disabled).
-	time.Sleep(50 * time.Millisecond)
-	assert.Equal(t, int32(0), h.sender.delivers.Load())
+	// Negative check: a disabled channel is marked failed synchronously and
+	// never reaches the sender (see dispatchToChannel) — held over a window
+	// rather than sampled once.
+	assert.Never(t, func() bool {
+		return h.sender.delivers.Load() != 0
+	}, 300*time.Millisecond, 10*time.Millisecond, "disabled channel must not receive a network call")
 
 	deliveries := h.store.listDeliveries()
 	require.Len(t, deliveries, 1)
@@ -877,11 +870,11 @@ func TestRunner_OrphanRecoveryRetries(t *testing.T) {
 
 	deliveries := h.store.listDeliveries()
 	require.Len(t, deliveries, 1)
-	deadline := time.Now().Add(500 * time.Millisecond)
-	for time.Now().Before(deadline) && deliveries[0].Status == DeliveryStatusPending {
-		time.Sleep(5 * time.Millisecond)
+
+	require.Eventually(t, func() bool {
 		deliveries = h.store.listDeliveries()
-	}
+		return len(deliveries) == 1 && deliveries[0].Status != DeliveryStatusPending
+	}, 500*time.Millisecond, 5*time.Millisecond, "orphan delivery must leave pending status")
 	assert.Equal(t, DeliveryStatusSent, deliveries[0].Status)
 }
 

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -69,17 +69,18 @@ func TestStart_DegradedMode(t *testing.T) {
 	}()
 
 	// Wait until the HTTP server is reachable.
-	deadline := time.Now().Add(5 * time.Second)
-	for time.Now().Before(deadline) {
-		resp, err := http.Get("http://" + addr + "/api/v1/health")
-		if err == nil {
-			_ = resp.Body.Close()
-			assert.Equal(t, http.StatusOK, resp.StatusCode, "health endpoint must return 200 in degraded mode")
-			cancel() // trigger graceful shutdown
-			break
+	var resp *http.Response
+	require.Eventually(t, func() bool {
+		r, err := http.Get("http://" + addr + "/api/v1/health")
+		if err != nil {
+			return false
 		}
-		time.Sleep(50 * time.Millisecond)
-	}
+		resp = r
+		return true
+	}, 5*time.Second, 50*time.Millisecond, "the HTTP server must become reachable")
+	_ = resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode, "health endpoint must return 200 in degraded mode")
+	cancel() // trigger graceful shutdown
 
 	// Start() should return (shutdown) within the context.
 	select {

--- a/internal/license/manager_test.go
+++ b/internal/license/manager_test.go
@@ -216,9 +216,9 @@ func TestManager_InvalidSignature(t *testing.T) {
 	// Set an existing state to verify it's preserved
 	m.state.Store(&State{
 		Edition:    extension.Pro,
-		Status:       "active",
-		Plan:         "pro",
-		VerifiedAt:   time.Now(),
+		Status:     "active",
+		Plan:       "pro",
+		VerifiedAt: time.Now(),
 	})
 
 	m.check(context.Background())
@@ -404,12 +404,14 @@ func TestLicenseManagerEditionChangeCallback(t *testing.T) {
 			mu.Unlock()
 		})
 
-		// First check: sets baseline (Pro), no dispatch
+		// First check: sets baseline (Pro), no dispatch. Negative check: held
+		// over a window since the dispatch (if it fired) would be async.
 		m.check(context.Background())
-		time.Sleep(10 * time.Millisecond)
-		mu.Lock()
-		assert.Equal(t, 0, callCount, "baseline should not trigger callback")
-		mu.Unlock()
+		assert.Never(t, func() bool {
+			mu.Lock()
+			defer mu.Unlock()
+			return callCount != 0
+		}, 300*time.Millisecond, 10*time.Millisecond, "baseline should not trigger callback")
 
 		// Simulate Pro→CE: override server to return expired
 		origOverride := licenseServerOverride
@@ -423,7 +425,11 @@ func TestLicenseManagerEditionChangeCallback(t *testing.T) {
 		defer func() { licenseServerOverride = origOverride }()
 
 		m.check(context.Background())
-		time.Sleep(50 * time.Millisecond)
+		require.Eventually(t, func() bool {
+			mu.Lock()
+			defer mu.Unlock()
+			return callCount == 1
+		}, 2*time.Second, 10*time.Millisecond, "Pro→CE should trigger callback")
 
 		mu.Lock()
 		assert.Equal(t, 1, callCount, "Pro→CE should trigger callback")
@@ -462,16 +468,22 @@ func TestLicenseManagerEditionChangeCallback(t *testing.T) {
 			mu.Unlock()
 		})
 
-		// First check: sets baseline (expired → CE)
+		// First check: sets baseline (expired → CE). Negative check: held over
+		// a window since the dispatch (if it fired) would be async.
 		m.check(context.Background())
-		time.Sleep(10 * time.Millisecond)
-		mu.Lock()
-		assert.Equal(t, 0, callCount, "baseline should not trigger")
-		mu.Unlock()
+		assert.Never(t, func() bool {
+			mu.Lock()
+			defer mu.Unlock()
+			return callCount != 0
+		}, 300*time.Millisecond, 10*time.Millisecond, "baseline should not trigger")
 
 		// Second check: CE→Pro
 		m.check(context.Background())
-		time.Sleep(50 * time.Millisecond)
+		require.Eventually(t, func() bool {
+			mu.Lock()
+			defer mu.Unlock()
+			return callCount == 1
+		}, 2*time.Second, 10*time.Millisecond, "CE→Pro should trigger callback")
 
 		mu.Lock()
 		assert.Equal(t, 1, callCount, "CE→Pro should trigger callback")
@@ -499,13 +511,14 @@ func TestLicenseManagerEditionChangeCallback(t *testing.T) {
 			mu.Unlock()
 		})
 
-		// Single applyPayload — sets baseline, no dispatch
+		// Single applyPayload — sets baseline, no dispatch. Negative check:
+		// held over a window since a dispatch (if it fired) would be async.
 		m.check(context.Background())
-		time.Sleep(50 * time.Millisecond)
-
-		mu.Lock()
-		assert.Equal(t, 0, callCount, "initial state must not trigger callback")
-		mu.Unlock()
+		assert.Never(t, func() bool {
+			mu.Lock()
+			defer mu.Unlock()
+			return callCount != 0
+		}, 300*time.Millisecond, 10*time.Millisecond, "initial state must not trigger callback")
 	})
 
 	t.Run("pro_to_pro_no_dispatch", func(t *testing.T) {
@@ -525,14 +538,15 @@ func TestLicenseManagerEditionChangeCallback(t *testing.T) {
 			mu.Unlock()
 		})
 
-		// Both checks return Pro — no transition, no dispatch
+		// Both checks return Pro — no transition, no dispatch. Negative check:
+		// held over a window since a dispatch (if it fired) would be async.
 		m.check(context.Background())
 		m.check(context.Background())
-		time.Sleep(50 * time.Millisecond)
-
-		mu.Lock()
-		assert.Equal(t, 0, callCount, "Pro→Pro must not trigger callback")
-		mu.Unlock()
+		assert.Never(t, func() bool {
+			mu.Lock()
+			defer mu.Unlock()
+			return callCount != 0
+		}, 300*time.Millisecond, 10*time.Millisecond, "Pro→Pro must not trigger callback")
 	})
 
 	t.Run("two_callbacks_both_invoked", func(t *testing.T) {
@@ -570,7 +584,11 @@ func TestLicenseManagerEditionChangeCallback(t *testing.T) {
 
 		m.check(context.Background()) // baseline Pro
 		m.check(context.Background()) // transition → expired (CE)
-		time.Sleep(50 * time.Millisecond)
+		require.Eventually(t, func() bool {
+			mu.Lock()
+			defer mu.Unlock()
+			return callCount == 2
+		}, 2*time.Second, 10*time.Millisecond, "both callbacks should be invoked")
 
 		mu.Lock()
 		assert.Equal(t, 2, callCount, "both callbacks should be invoked")
@@ -607,7 +625,11 @@ func TestLicenseManagerEditionChangeCallback(t *testing.T) {
 
 		m.check(context.Background()) // baseline
 		m.check(context.Background()) // transition
-		time.Sleep(100 * time.Millisecond)
+		require.Eventually(t, func() bool {
+			mu.Lock()
+			defer mu.Unlock()
+			return secondCalled
+		}, 2*time.Second, 10*time.Millisecond, "second callback must run even after first panicked")
 
 		mu.Lock()
 		assert.True(t, secondCalled, "second callback must run even after first panicked")
@@ -671,7 +693,9 @@ func TestManager_HTTP401NotifiesTheTransition(t *testing.T) {
 
 	unauthorized = true
 	m.check(context.Background())
-	time.Sleep(50 * time.Millisecond)
+	require.Eventually(t, func() bool {
+		return len(seen()) == 1
+	}, 2*time.Second, 10*time.Millisecond, "an HTTP 401 must dispatch the transition, not just store the state")
 
 	assert.Equal(t, extension.Community, m.Edition())
 	assert.Equal(t, []extension.Edition{extension.Community}, seen(),
@@ -700,7 +724,9 @@ func TestManager_HTTP403NotifiesTheTransition(t *testing.T) {
 
 	forbidden = true
 	m.check(context.Background())
-	time.Sleep(50 * time.Millisecond)
+	require.Eventually(t, func() bool {
+		return len(seen()) == 1
+	}, 2*time.Second, 10*time.Millisecond, "an HTTP 403 revocation must dispatch the transition")
 
 	assert.Equal(t, extension.Community, m.Edition())
 	assert.Equal(t, []extension.Edition{extension.Community}, seen(),
@@ -731,7 +757,9 @@ func TestManager_NetworkDegradationBeyondSixtyDaysNotifies(t *testing.T) {
 
 	down = true
 	m.check(context.Background())
-	time.Sleep(50 * time.Millisecond)
+	require.Eventually(t, func() bool {
+		return len(seen()) == 1
+	}, 2*time.Second, 10*time.Millisecond, "crossing the 60-day offline window must dispatch the transition")
 
 	assert.Equal(t, extension.Community, m.Edition())
 	assert.Equal(t, []extension.Edition{extension.Community}, seen(),

--- a/internal/store/outage_test.go
+++ b/internal/store/outage_test.go
@@ -135,16 +135,9 @@ func TestStorageSurvivesOutage(t *testing.T) {
 	relay.Restore()
 
 	// No restart, no re-open: the pool renews its connections by itself.
-	var recovered bool
-	deadline := time.Now().Add(20 * time.Second)
-	for time.Now().Before(deadline) {
-		if err := db.PingContext(ctx); err == nil {
-			recovered = true
-			break
-		}
-		time.Sleep(200 * time.Millisecond)
-	}
-	require.True(t, recovered, "FR-019: the instance recovers on its own, without a restart")
+	require.Eventually(t, func() bool {
+		return db.PingContext(ctx) == nil
+	}, 20*time.Second, 200*time.Millisecond, "FR-019: the instance recovers on its own, without a restart")
 
 	peers, err := s.Peers(ctx, "someone-else", time.Now().Add(-time.Hour))
 	require.NoError(t, err, "queries work again with the same handle")


### PR DESCRIPTION
The alert engine drains its event channel in a goroutine, and the tests waited
for it with a fixed sleep. On a loaded CI runner under the race detector that is
not long enough: a dedup-collision test read the first event's message where it
expected the second, and failed on PR #107 — a run that had nothing to do with
the alert package. Nineteen sites across the package waited that way, so any of
them could have been next.

They now poll the outcome the assertions actually depend on — the alert row, the
delivery count, the captured webhook body — with a deadline, and the negative
checks hold over a window instead of sampling once after a nap. The same pattern
existed in five other packages and gets the same treatment.

One subtlety worth naming: a predicate passed to `Eventually` runs on testify's
own goroutine, where `require` may not be called. The delivery-count helper is
split so predicates use a plain error-returning core, and only the assertions
that follow keep the `require`-based one. Without that split the suite failed
under repetition with `sql: database is closed`.

No assertion is weakened and the package is no slower: every positive wait now
returns as soon as its condition holds instead of always paying the full delay.
`go test -race ./internal/alert/... -count=20` is green across three separate
runs.
